### PR TITLE
new arguments, and direct alsa access for hardware mixer

### DIFF
--- a/examples/basic_client/main.cpp
+++ b/examples/basic_client/main.cpp
@@ -37,6 +37,7 @@
 #include "sendspin/player_role.h"
 #ifdef SENDSPIN_HAS_PORTAUDIO
 #include "portaudio_sink.h"
+#include <portaudio.h>
 #endif
 
 #include <dns_sd.h>
@@ -233,45 +234,35 @@ int main(int argc, char* argv[]) {
     PlayerRole::Config player_config;
     
     // Dynamically determine supported audio formats based on device capabilities
-    if (audio_device_index >= 0) {
-        fprintf(stderr, "Checking supported formats for device %d...\n", audio_device_index);
-        
-        // Test common sample rates
-        std::vector<uint32_t> sample_rates = {44100, 48000, 96000, 192000};
-        std::vector<uint8_t> bit_depths = {16, 24, 32};
-        
-        for (uint32_t sample_rate : sample_rates) {
-            for (uint8_t bit_depth : bit_depths) {
-                if (PortAudioSink::is_format_supported(audio_device_index, sample_rate, 2, bit_depth)) {
-                    fprintf(stderr, "  Device supports: %uHz 2ch %ubit\n", sample_rate, bit_depth);
-                    
-                    // Add FLAC format if supported
-                    player_config.audio_formats.push_back({SendspinCodecFormat::FLAC, 2, sample_rate, bit_depth});
-                    
-                    // Add PCM format if supported
-                    player_config.audio_formats.push_back({SendspinCodecFormat::PCM, 2, sample_rate, bit_depth});
-                    
-                    // Add OPUS format for common sample rates (OPUS typically uses 48kHz)
-                    if (sample_rate == 48000) {
-                        player_config.audio_formats.push_back({SendspinCodecFormat::OPUS, 2, sample_rate, 16});
-                    }
+    int device_to_check = audio_device_index >= 0 ? audio_device_index : Pa_GetDefaultOutputDevice();
+    
+    fprintf(stderr, "Checking supported formats for device %d...\n", device_to_check);
+    
+    // Test common sample rates
+    std::vector<uint32_t> sample_rates = {44100, 48000, 96000, 192000};
+    std::vector<uint8_t> bit_depths = {16, 24, 32};
+    
+    for (uint32_t sample_rate : sample_rates) {
+        for (uint8_t bit_depth : bit_depths) {
+            if (PortAudioSink::is_format_supported(device_to_check, sample_rate, 2, bit_depth)) {
+                fprintf(stderr, "  Device supports: %uHz 2ch %ubit\n", sample_rate, bit_depth);
+                
+                // Add FLAC format if supported
+                player_config.audio_formats.push_back({SendspinCodecFormat::FLAC, 2, sample_rate, bit_depth});
+                
+                // Add PCM format if supported
+                player_config.audio_formats.push_back({SendspinCodecFormat::PCM, 2, sample_rate, bit_depth});
+                
+                // Add OPUS format for common sample rates (OPUS typically uses 48kHz)
+                if (sample_rate == 48000) {
+                    player_config.audio_formats.push_back({SendspinCodecFormat::OPUS, 2, sample_rate, 16});
                 }
             }
         }
-        
-        if (player_config.audio_formats.empty()) {
-            fprintf(stderr, "Warning: No supported formats found for device %d, using defaults\n", audio_device_index);
-            player_config.audio_formats = {
-                {SendspinCodecFormat::FLAC, 2, 44100, 16},
-                {SendspinCodecFormat::FLAC, 2, 48000, 16},
-                {SendspinCodecFormat::OPUS, 2, 48000, 16},
-                {SendspinCodecFormat::PCM, 2, 44100, 16},
-                {SendspinCodecFormat::PCM, 2, 48000, 16},
-            };
-        }
-    } else {
-        // Use default formats when no specific device is selected
-        fprintf(stderr, "Using default audio formats (no specific device selected)\n");
+    }
+    
+    if (player_config.audio_formats.empty()) {
+        fprintf(stderr, "Warning: No supported formats found for device %d, using defaults\n", device_to_check);
         player_config.audio_formats = {
             {SendspinCodecFormat::FLAC, 2, 44100, 16},
             {SendspinCodecFormat::FLAC, 2, 48000, 16},

--- a/examples/basic_client/main.cpp
+++ b/examples/basic_client/main.cpp
@@ -28,7 +28,7 @@
 ///   -q        Quiet logging (same as -l error)
 ///   -L        List available audio devices and exit
 ///   -d DEVICE Select audio device by index (use -L to list devices)
-///   -m MIXER  Use ALSA hardware mixer for volume control (e.g., "PCM")
+///   -m MIXER  Use ALSA hardware mixer for volume control (format: card:control, e.g., "1:Digital")
 ///   -h        Show usage
 
 #include "sendspin/client.h"
@@ -130,7 +130,7 @@ static void print_usage(const char* prog) {
     fprintf(stderr, "  -q            Quiet logging (same as -l error)\n");
     fprintf(stderr, "  -L            List available audio devices and exit\n");
     fprintf(stderr, "  -d DEVICE     Select audio device by index (use -L to list devices)\n");
-    fprintf(stderr, "  -m MIXER      Use ALSA hardware mixer for volume control (e.g., \"PCM\")\n");
+    fprintf(stderr, "  -m MIXER      Use ALSA hardware mixer for volume control (format: card:control, e.g., \"1:Digital\")\n");
     fprintf(stderr, "  -h            Show this help\n");
 }
 
@@ -154,7 +154,7 @@ int main(int argc, char* argv[]) {
     std::string connect_url;
     int audio_device_index = -1;
     bool list_devices = false;
-    std::string alsa_mixer_name;
+    std::string alsa_mixer_spec;
     int opt;
     while ((opt = getopt(argc, argv, "u:l:vqhd:m:L")) != -1) {
         switch (opt) {
@@ -178,7 +178,7 @@ int main(int argc, char* argv[]) {
                 audio_device_index = std::atoi(optarg);
                 break;
             case 'm':
-                alsa_mixer_name = optarg;
+                alsa_mixer_spec = optarg;
                 break;
             case 'L':
                 list_devices = true;
@@ -223,8 +223,16 @@ int main(int argc, char* argv[]) {
     // Create audio output and client
 #ifdef SENDSPIN_HAS_PORTAUDIO
     PortAudioSink audio_sink;
-    if (!alsa_mixer_name.empty()) {
-        audio_sink.set_alsa_mixer_name(alsa_mixer_name);
+    if (!alsa_mixer_spec.empty()) {
+        audio_sink.set_alsa_mixer_spec(alsa_mixer_spec);
+        
+        // Try to read and display current hardware volume
+        int current_volume = PortAudioSink::get_alsa_volume(alsa_mixer_spec);
+        if (current_volume >= 0) {
+            fprintf(stderr, "ALSA mixer '%s' current volume: %d%%\n", alsa_mixer_spec.c_str(), current_volume);
+        } else {
+            fprintf(stderr, "Warning: Could not read current volume from ALSA mixer '%s'\n", alsa_mixer_spec.c_str());
+        }
     }
 #endif
 
@@ -272,6 +280,16 @@ int main(int argc, char* argv[]) {
         };
     }
     auto& player = client.add_player(std::move(player_config));
+    
+    // Set initial volume to match hardware mixer if using ALSA volume control
+    if (!alsa_mixer_spec.empty()) {
+        int current_volume = PortAudioSink::get_alsa_volume(alsa_mixer_spec);
+        if (current_volume >= 0) {
+            player.update_volume(static_cast<uint8_t>(current_volume));
+            player.update_muted(false);
+        }
+    }
+    
     auto& controller = client.add_controller();
     auto& metadata = client.add_metadata();
 
@@ -396,13 +414,25 @@ int main(int argc, char* argv[]) {
 
     // Main loop
     int tick = 0;
+    uint8_t last_volume = player.get_volume();
+    bool last_muted = player.get_muted();
     while (running.load()) {
         client.loop();
 #ifdef SENDSPIN_HAS_PORTAUDIO
         // Sync audio sink volume periodically (catches all volume change sources)
         if (++tick % 25 == 0) {
-            audio_sink.set_volume(player.get_volume());
-            audio_sink.set_muted(player.get_muted());
+            uint8_t current_volume = player.get_volume();
+            bool current_muted = player.get_muted();
+            
+            // Only update if values have changed
+            if (current_volume != last_volume) {
+                audio_sink.set_volume(current_volume);
+                last_volume = current_volume;
+            }
+            if (current_muted != last_muted) {
+                audio_sink.set_muted(current_muted);
+                last_muted = current_muted;
+            }
         }
 #else
         ++tick;

--- a/examples/basic_client/main.cpp
+++ b/examples/basic_client/main.cpp
@@ -26,6 +26,9 @@
 ///   -l LEVEL  Set log level: none, error, warn, info (default), debug, verbose
 ///   -v        Verbose logging (same as -l verbose)
 ///   -q        Quiet logging (same as -l error)
+///   -L        List available audio devices and exit
+///   -d DEVICE Select audio device by index (use -L to list devices)
+///   -m MIXER  Use ALSA hardware mixer for volume control (e.g., "PCM")
 ///   -h        Show usage
 
 #include "sendspin/client.h"
@@ -124,6 +127,9 @@ static void print_usage(const char* prog) {
     fprintf(stderr, "  -l LEVEL      Log level: none, error, warn, info (default), debug, verbose\n");
     fprintf(stderr, "  -v            Verbose logging (same as -l verbose)\n");
     fprintf(stderr, "  -q            Quiet logging (same as -l error)\n");
+    fprintf(stderr, "  -L            List available audio devices and exit\n");
+    fprintf(stderr, "  -d DEVICE     Select audio device by index (use -L to list devices)\n");
+    fprintf(stderr, "  -m MIXER      Use ALSA hardware mixer for volume control (e.g., \"PCM\")\n");
     fprintf(stderr, "  -h            Show this help\n");
 }
 
@@ -145,8 +151,11 @@ int main(int argc, char* argv[]) {
     // Parse command line options
     LogLevel log_level = LogLevel::INFO;
     std::string connect_url;
+    int audio_device_index = -1;
+    bool list_devices = false;
+    std::string alsa_mixer_name;
     int opt;
-    while ((opt = getopt(argc, argv, "u:l:vqh")) != -1) {
+    while ((opt = getopt(argc, argv, "u:l:vqhd:m:L")) != -1) {
         switch (opt) {
             case 'u':
                 connect_url = optarg;
@@ -164,6 +173,15 @@ int main(int argc, char* argv[]) {
             case 'q':
                 log_level = LogLevel::ERROR;
                 break;
+            case 'd':
+                audio_device_index = std::atoi(optarg);
+                break;
+            case 'm':
+                alsa_mixer_name = optarg;
+                break;
+            case 'L':
+                list_devices = true;
+                break;
             case 'h':
                 print_usage(argv[0]);
                 return 0;
@@ -174,6 +192,21 @@ int main(int argc, char* argv[]) {
     }
 
     SendspinClient::set_log_level(log_level);
+
+    // Handle device listing request
+#ifdef SENDSPIN_HAS_PORTAUDIO
+    if (list_devices) {
+        // Initialize PortAudio just to list devices
+        PaError err = Pa_Initialize();
+        if (err == paNoError) {
+            PortAudioSink::list_devices();
+            Pa_Terminate();
+        } else {
+            fprintf(stderr, "PortAudio init failed: %s\n", Pa_GetErrorText(err));
+        }
+        return 0;
+    }
+#endif
 
     // Optional name from remaining arguments
     std::string friendly_name = (optind < argc) ? argv[optind] : "Basic Client";
@@ -189,19 +222,64 @@ int main(int argc, char* argv[]) {
     // Create audio output and client
 #ifdef SENDSPIN_HAS_PORTAUDIO
     PortAudioSink audio_sink;
+    if (!alsa_mixer_name.empty()) {
+        audio_sink.set_alsa_mixer_name(alsa_mixer_name);
+    }
 #endif
 
     SendspinClient client(std::move(config));
 
     // Add roles
     PlayerRole::Config player_config;
-    player_config.audio_formats = {
-        {SendspinCodecFormat::FLAC, 2, 44100, 16},
-        {SendspinCodecFormat::FLAC, 2, 48000, 16},
-        {SendspinCodecFormat::OPUS, 2, 48000, 16},
-        {SendspinCodecFormat::PCM, 2, 44100, 16},
-        {SendspinCodecFormat::PCM, 2, 48000, 16},
-    };
+    
+    // Dynamically determine supported audio formats based on device capabilities
+    if (audio_device_index >= 0) {
+        fprintf(stderr, "Checking supported formats for device %d...\n", audio_device_index);
+        
+        // Test common sample rates
+        std::vector<uint32_t> sample_rates = {44100, 48000, 96000, 192000};
+        std::vector<uint8_t> bit_depths = {16, 24, 32};
+        
+        for (uint32_t sample_rate : sample_rates) {
+            for (uint8_t bit_depth : bit_depths) {
+                if (PortAudioSink::is_format_supported(audio_device_index, sample_rate, 2, bit_depth)) {
+                    fprintf(stderr, "  Device supports: %uHz 2ch %ubit\n", sample_rate, bit_depth);
+                    
+                    // Add FLAC format if supported
+                    player_config.audio_formats.push_back({SendspinCodecFormat::FLAC, 2, sample_rate, bit_depth});
+                    
+                    // Add PCM format if supported
+                    player_config.audio_formats.push_back({SendspinCodecFormat::PCM, 2, sample_rate, bit_depth});
+                    
+                    // Add OPUS format for common sample rates (OPUS typically uses 48kHz)
+                    if (sample_rate == 48000) {
+                        player_config.audio_formats.push_back({SendspinCodecFormat::OPUS, 2, sample_rate, 16});
+                    }
+                }
+            }
+        }
+        
+        if (player_config.audio_formats.empty()) {
+            fprintf(stderr, "Warning: No supported formats found for device %d, using defaults\n", audio_device_index);
+            player_config.audio_formats = {
+                {SendspinCodecFormat::FLAC, 2, 44100, 16},
+                {SendspinCodecFormat::FLAC, 2, 48000, 16},
+                {SendspinCodecFormat::OPUS, 2, 48000, 16},
+                {SendspinCodecFormat::PCM, 2, 44100, 16},
+                {SendspinCodecFormat::PCM, 2, 48000, 16},
+            };
+        }
+    } else {
+        // Use default formats when no specific device is selected
+        fprintf(stderr, "Using default audio formats (no specific device selected)\n");
+        player_config.audio_formats = {
+            {SendspinCodecFormat::FLAC, 2, 44100, 16},
+            {SendspinCodecFormat::FLAC, 2, 48000, 16},
+            {SendspinCodecFormat::OPUS, 2, 48000, 16},
+            {SendspinCodecFormat::PCM, 2, 44100, 16},
+            {SendspinCodecFormat::PCM, 2, 48000, 16},
+        };
+    }
     auto& player = client.add_player(std::move(player_config));
     auto& controller = client.add_controller();
     auto& metadata = client.add_metadata();
@@ -215,7 +293,8 @@ int main(int argc, char* argv[]) {
 #ifdef SENDSPIN_HAS_PORTAUDIO
         PortAudioSink& sink;
         PlayerRole& player;
-        BasicPlayerListener(PortAudioSink& s, PlayerRole& p) : sink(s), player(p) {}
+        int audio_device_index;
+        BasicPlayerListener(PortAudioSink& s, PlayerRole& p, int device_index) : sink(s), player(p), audio_device_index(device_index) {}
 #endif
 
         size_t on_audio_write(uint8_t* data, size_t length, uint32_t timeout_ms) override {
@@ -235,7 +314,7 @@ int main(int argc, char* argv[]) {
             auto& params = player.get_current_stream_params();
             if (params.sample_rate.has_value() && params.channels.has_value() &&
                 params.bit_depth.has_value()) {
-                sink.configure(*params.sample_rate, *params.channels, *params.bit_depth);
+                sink.configure(*params.sample_rate, *params.channels, *params.bit_depth, audio_device_index);
             } else {
                 fprintf(stderr, ">>> Stream params not yet available for PortAudio\n");
             }
@@ -284,7 +363,7 @@ int main(int argc, char* argv[]) {
     };
 
 #ifdef SENDSPIN_HAS_PORTAUDIO
-    BasicPlayerListener player_listener(audio_sink, player);
+    BasicPlayerListener player_listener(audio_sink, player, audio_device_index);
     audio_sink.on_frames_played = [&player](uint32_t frames, int64_t timestamp) {
         player.notify_audio_played(frames, timestamp);
     };

--- a/examples/basic_client/main.cpp
+++ b/examples/basic_client/main.cpp
@@ -281,13 +281,15 @@ int main(int argc, char* argv[]) {
     }
     auto& player = client.add_player(std::move(player_config));
     
-    // Set initial volume to match hardware mixer if using ALSA volume control
+    // Set initial volume and mute to match hardware mixer if using ALSA control
     if (!alsa_mixer_spec.empty()) {
         int current_volume = PortAudioSink::get_alsa_volume(alsa_mixer_spec);
         if (current_volume >= 0) {
             player.update_volume(static_cast<uint8_t>(current_volume));
-            player.update_muted(false);
         }
+        
+        bool current_mute = PortAudioSink::get_alsa_mute(alsa_mixer_spec);
+        player.update_muted(current_mute);
     }
     
     auto& controller = client.add_controller();

--- a/examples/common/portaudio_sink.cpp
+++ b/examples/common/portaudio_sink.cpp
@@ -20,6 +20,12 @@
 #include <cstring>
 #include <thread>
 
+// ALSA includes for mixer control (Linux only)
+#ifdef __linux__
+#include <alsa/asoundlib.h>
+#include <alsa/mixer.h>
+#endif
+
 namespace sendspin {
 
 // Ring buffer capacity. With condition-variable-based blocking in write(),
@@ -162,7 +168,7 @@ size_t PortAudioSink::write(uint8_t* data, size_t length, uint32_t timeout_ms) {
     return total_written;
 }
 
-bool PortAudioSink::configure(uint32_t sample_rate, uint8_t channels, uint8_t bits_per_sample) {
+bool PortAudioSink::configure(uint32_t sample_rate, uint8_t channels, uint8_t bits_per_sample, int device_index) {
     stop();
     abort_write_.store(false, std::memory_order_release);
 
@@ -170,6 +176,7 @@ bool PortAudioSink::configure(uint32_t sample_rate, uint8_t channels, uint8_t bi
     channels_ = channels;
     bits_per_sample_ = bits_per_sample;
     bytes_per_frame_ = channels * (bits_per_sample / 8);
+    device_index_ = device_index;
 
     PaSampleFormat sample_format;
     switch (bits_per_sample) {
@@ -187,8 +194,62 @@ bool PortAudioSink::configure(uint32_t sample_rate, uint8_t channels, uint8_t bi
             return false;
     }
 
-    PaError err = Pa_OpenDefaultStream(&stream_, 0, channels, sample_format, sample_rate,
-                                       paFramesPerBufferUnspecified, pa_callback, this);
+    PaError err;
+    uint32_t actual_sample_rate = sample_rate;
+    
+    if (device_index >= 0) {
+        // Use specific device
+        PaDeviceIndex device = static_cast<PaDeviceIndex>(device_index);
+        const PaDeviceInfo* device_info = Pa_GetDeviceInfo(device);
+        if (device_info == nullptr) {
+            fprintf(stderr, "PortAudio: invalid device index %d\n", device_index);
+            return false;
+        }
+        
+        // Check if the device supports the requested format
+        PaStreamParameters test_params = {};
+        test_params.device = device;
+        test_params.channelCount = channels;
+        test_params.sampleFormat = sample_format;
+        test_params.suggestedLatency = device_info->defaultLowOutputLatency;
+        
+        if (Pa_IsFormatSupported(nullptr, &test_params, static_cast<double>(sample_rate)) != paFormatIsSupported) {
+            // Try using the device's default sample rate instead
+            fprintf(stderr, "PortAudio: device %d does not support %uHz, trying default rate %.0fHz\n", 
+                    device_index, sample_rate, device_info->defaultSampleRate);
+            actual_sample_rate = static_cast<uint32_t>(device_info->defaultSampleRate);
+            
+            if (Pa_IsFormatSupported(nullptr, &test_params, static_cast<double>(actual_sample_rate)) != paFormatIsSupported) {
+                fprintf(stderr, "PortAudio: device %d does not support %uch %ubit format at any sample rate\n", 
+                        device_index, channels, bits_per_sample);
+                return false;
+            }
+        }
+        
+        PaStreamParameters output_parameters = {};
+        output_parameters.device = device;
+        output_parameters.channelCount = channels;
+        output_parameters.sampleFormat = sample_format;
+        output_parameters.suggestedLatency = device_info->defaultLowOutputLatency;
+        output_parameters.hostApiSpecificStreamInfo = nullptr;
+        
+        err = Pa_OpenStream(&stream_, nullptr, &output_parameters, actual_sample_rate,
+                           paFramesPerBufferUnspecified, paFramesPerBufferUnspecified,
+                           pa_callback, this);
+    } else {
+        // Use default device
+        err = Pa_OpenDefaultStream(&stream_, 0, channels, sample_format, sample_rate,
+                                   paFramesPerBufferUnspecified, pa_callback, this);
+    }
+    
+    if (err != paNoError) {
+        fprintf(stderr, "PortAudio: failed to open stream: %s\n", Pa_GetErrorText(err));
+        stream_ = nullptr;
+        return false;
+    }
+    
+    // Update the actual sample rate used (might be different from requested)
+    sample_rate_ = actual_sample_rate;
     if (err != paNoError) {
         fprintf(stderr, "PortAudio: failed to open stream: %s\n", Pa_GetErrorText(err));
         stream_ = nullptr;
@@ -203,7 +264,7 @@ bool PortAudioSink::configure(uint32_t sample_rate, uint8_t channels, uint8_t bi
         return false;
     }
 
-    fprintf(stderr, "PortAudio: playing %uHz %uch %ubit\n", sample_rate, channels, bits_per_sample);
+    fprintf(stderr, "PortAudio: playing %uHz %uch %ubit\n", sample_rate_, channels_, bits_per_sample_);
     return true;
 }
 
@@ -239,6 +300,29 @@ bool PortAudioSink::is_format_supported(uint32_t sample_rate, uint8_t channels,
            paFormatIsSupported;
 }
 
+void PortAudioSink::list_devices() {
+    int device_count = Pa_GetDeviceCount();
+    if (device_count < 0) {
+        fprintf(stderr, "Error getting device count: %s\n", Pa_GetErrorText(device_count));
+        return;
+    }
+
+    fprintf(stderr, "Available audio devices [%d]:\n", device_count);
+    for (int i = 0; i < device_count; i++) {
+        const PaDeviceInfo* info = Pa_GetDeviceInfo(i);
+        if (info == nullptr) continue;
+
+        fprintf(stderr, "  %d: %s\n", i, info->name);
+        fprintf(stderr, "     Input channels: %d, Output channels: %d\n", 
+                info->maxInputChannels, info->maxOutputChannels);
+        fprintf(stderr, "     Default sample rate: %.1f Hz\n", info->defaultSampleRate);
+        
+        if (i == Pa_GetDefaultOutputDevice()) {
+            fprintf(stderr, "     [DEFAULT OUTPUT]\n");
+        }
+    }
+}
+
 uint8_t PortAudioSink::max_output_channels() {
     PaDeviceIndex device = Pa_GetDefaultOutputDevice();
     if (device == paNoDevice) {
@@ -249,6 +333,37 @@ uint8_t PortAudioSink::max_output_channels() {
         return 0;
     }
     return static_cast<uint8_t>(std::min(info->maxOutputChannels, 255));
+}
+
+bool PortAudioSink::is_format_supported(int device_index, uint32_t sample_rate, uint8_t channels,
+                                        uint8_t bits_per_sample) {
+    if (device_index < 0 || device_index >= Pa_GetDeviceCount()) {
+        return false;
+    }
+
+    PaSampleFormat sample_format;
+    switch (bits_per_sample) {
+        case 16:
+            sample_format = paInt16;
+            break;
+        case 24:
+            sample_format = paInt24;
+            break;
+        case 32:
+            sample_format = paInt32;
+            break;
+        default:
+            return false;
+    }
+
+    PaStreamParameters params = {};
+    params.device = device_index;
+    params.channelCount = channels;
+    params.sampleFormat = sample_format;
+    params.suggestedLatency = Pa_GetDeviceInfo(device_index)->defaultLowOutputLatency;
+
+    return Pa_IsFormatSupported(nullptr, &params, static_cast<double>(sample_rate)) ==
+           paFormatIsSupported;
 }
 
 void PortAudioSink::stop() {
@@ -316,12 +431,27 @@ int PortAudioSink::pa_callback(const void* /*input*/, void* output, unsigned lon
 
 void PortAudioSink::set_volume(uint8_t volume) {
     volume_ = volume > 100 ? 100 : volume;
+    
+    // Try hardware volume control first if ALSA mixer is specified
+    if (!alsa_mixer_name_.empty() && device_index_ >= 0) {
+        if (set_alsa_volume(alsa_mixer_name_, device_index_, volume_)) {
+            // Hardware volume control succeeded, use full software volume
+            update_volume_multiplier_();
+            return;
+        }
+    }
+    
+    // Fall back to software volume control
     update_volume_multiplier_();
 }
 
 void PortAudioSink::set_muted(bool muted) {
     muted_ = muted;
     update_volume_multiplier_();
+}
+
+void PortAudioSink::set_alsa_mixer_name(const std::string& mixer_name) {
+    alsa_mixer_name_ = mixer_name;
 }
 
 void PortAudioSink::update_volume_multiplier_() {
@@ -394,5 +524,122 @@ void PortAudioSink::apply_volume_(uint8_t* data, size_t len, uint8_t bytes_per_s
             break;
     }
 }
+
+// ALSA hardware volume control implementations
+#ifdef __linux__
+bool PortAudioSink::set_alsa_volume(const std::string& mixer_name, int device_index, uint8_t volume) {
+    snd_mixer_t* handle;
+    snd_mixer_selem_id_t* sid;
+    
+    // Open mixer
+    if (snd_mixer_open(&handle, 0) < 0) {
+        return false;
+    }
+    
+    // Attach to default card
+    if (snd_mixer_attach(handle, "default") < 0) {
+        snd_mixer_close(handle);
+        return false;
+    }
+    
+    // Register mixer
+    if (snd_mixer_selem_register(handle, nullptr, nullptr) < 0) {
+        snd_mixer_close(handle);
+        return false;
+    }
+    
+    // Load mixer elements
+    if (snd_mixer_load(handle) < 0) {
+        snd_mixer_close(handle);
+        return false;
+    }
+    
+    // Allocate memory for mixer element ID
+    snd_mixer_selem_id_alloca(&sid);
+    snd_mixer_selem_id_set_index(sid, 0);
+    snd_mixer_selem_id_set_name(sid, mixer_name.c_str());
+    
+    // Find the mixer element
+    snd_mixer_elem_t* elem = snd_mixer_find_selem(handle, sid);
+    if (!elem) {
+        snd_mixer_close(handle);
+        return false;
+    }
+    
+    // Set volume (convert 0-100 to ALSA range)
+    long alsa_min, alsa_max;
+    snd_mixer_selem_get_playback_volume_range(elem, &alsa_min, &alsa_max);
+    long alsa_volume = alsa_min + (alsa_max - alsa_min) * volume / 100;
+    
+    if (snd_mixer_selem_set_playback_volume_all(elem, alsa_volume) < 0) {
+        snd_mixer_close(handle);
+        return false;
+    }
+    
+    snd_mixer_close(handle);
+    return true;
+}
+
+int PortAudioSink::get_alsa_volume(const std::string& mixer_name, int device_index) {
+    snd_mixer_t* handle;
+    snd_mixer_selem_id_t* sid;
+    
+    // Open mixer
+    if (snd_mixer_open(&handle, 0) < 0) {
+        return -1;
+    }
+    
+    // Attach to default card
+    if (snd_mixer_attach(handle, "default") < 0) {
+        snd_mixer_close(handle);
+        return -1;
+    }
+    
+    // Register mixer
+    if (snd_mixer_selem_register(handle, nullptr, nullptr) < 0) {
+        snd_mixer_close(handle);
+        return -1;
+    }
+    
+    // Load mixer elements
+    if (snd_mixer_load(handle) < 0) {
+        snd_mixer_close(handle);
+        return -1;
+    }
+    
+    // Allocate memory for mixer element ID
+    snd_mixer_selem_id_alloca(&sid);
+    snd_mixer_selem_id_set_index(sid, 0);
+    snd_mixer_selem_id_set_name(sid, mixer_name.c_str());
+    
+    // Find the mixer element
+    snd_mixer_elem_t* elem = snd_mixer_find_selem(handle, sid);
+    if (!elem) {
+        snd_mixer_close(handle);
+        return -1;
+    }
+    
+    // Get volume
+    long alsa_min, alsa_max, alsa_volume;
+    snd_mixer_selem_get_playback_volume_range(elem, &alsa_min, &alsa_max);
+    snd_mixer_selem_get_playback_volume(elem, SND_MIXER_SCHN_FRONT_LEFT, &alsa_volume);
+    
+    // Convert ALSA volume to 0-100 range
+    int volume = static_cast<int>((alsa_volume - alsa_min) * 100 / (alsa_max - alsa_min));
+    
+    snd_mixer_close(handle);
+    return volume;
+}
+#else
+bool PortAudioSink::set_alsa_volume(const std::string& mixer_name, int device_index, uint8_t volume) {
+    (void)mixer_name; (void)device_index; (void)volume;
+    return false;
+}
+
+int PortAudioSink::get_alsa_volume(const std::string& mixer_name, int device_index) {
+    (void)mixer_name; (void)device_index;
+    return -1;
+}
+#endif
 
 }  // namespace sendspin

--- a/examples/common/portaudio_sink.cpp
+++ b/examples/common/portaudio_sink.cpp
@@ -19,6 +19,7 @@
 #include <cstdio>
 #include <cstring>
 #include <thread>
+#include <cmath>
 
 // ALSA includes for mixer control (Linux only)
 #ifdef __linux__
@@ -433,10 +434,10 @@ void PortAudioSink::set_volume(uint8_t volume) {
     volume_ = volume > 100 ? 100 : volume;
     
     // Try hardware volume control first if ALSA mixer is specified
-    if (!alsa_mixer_name_.empty() && device_index_ >= 0) {
-        if (set_alsa_volume(alsa_mixer_name_, device_index_, volume_)) {
-            // Hardware volume control succeeded, use full software volume
-            update_volume_multiplier_();
+    if (!alsa_mixer_spec_.empty()) {
+        if (set_alsa_volume(alsa_mixer_spec_, volume_)) {
+            // Hardware volume control succeeded, set software volume to full (no scaling)
+            volume_multiplier_.store(UINT64_C(1) << 32, std::memory_order_relaxed);
             return;
         }
     }
@@ -450,8 +451,8 @@ void PortAudioSink::set_muted(bool muted) {
     update_volume_multiplier_();
 }
 
-void PortAudioSink::set_alsa_mixer_name(const std::string& mixer_name) {
-    alsa_mixer_name_ = mixer_name;
+void PortAudioSink::set_alsa_mixer_spec(const std::string& mixer_spec) {
+    alsa_mixer_spec_ = mixer_spec;
 }
 
 void PortAudioSink::update_volume_multiplier_() {
@@ -527,7 +528,18 @@ void PortAudioSink::apply_volume_(uint8_t* data, size_t len, uint8_t bytes_per_s
 
 // ALSA hardware volume control implementations
 #ifdef __linux__
-bool PortAudioSink::set_alsa_volume(const std::string& mixer_name, int device_index, uint8_t volume) {
+bool PortAudioSink::set_alsa_volume(const std::string& mixer_spec, uint8_t volume) {
+    fprintf(stderr, "[ALSA DEBUG] Setting volume to %d%% for mixer: %s\n", volume, mixer_spec.c_str());
+    
+    // Parse mixer specification in format "card:control"
+    size_t colon_pos = mixer_spec.find(':');
+    if (colon_pos == std::string::npos) {
+        fprintf(stderr, "[ALSA DEBUG] Invalid mixer specification format. Expected 'card:control'\n");
+        return false;
+    }
+    
+    std::string card_str = mixer_spec.substr(0, colon_pos);
+    std::string control_name = mixer_spec.substr(colon_pos + 1);
     snd_mixer_t* handle;
     snd_mixer_selem_id_t* sid;
     
@@ -536,8 +548,9 @@ bool PortAudioSink::set_alsa_volume(const std::string& mixer_name, int device_in
         return false;
     }
     
-    // Attach to default card
-    if (snd_mixer_attach(handle, "default") < 0) {
+    // Attach to the specified card
+    std::string card_name = "hw:" + card_str;
+    if (snd_mixer_attach(handle, card_name.c_str()) < 0) {
         snd_mixer_close(handle);
         return false;
     }
@@ -557,7 +570,7 @@ bool PortAudioSink::set_alsa_volume(const std::string& mixer_name, int device_in
     // Allocate memory for mixer element ID
     snd_mixer_selem_id_alloca(&sid);
     snd_mixer_selem_id_set_index(sid, 0);
-    snd_mixer_selem_id_set_name(sid, mixer_name.c_str());
+    snd_mixer_selem_id_set_name(sid, control_name.c_str());
     
     // Find the mixer element
     snd_mixer_elem_t* elem = snd_mixer_find_selem(handle, sid);
@@ -568,19 +581,34 @@ bool PortAudioSink::set_alsa_volume(const std::string& mixer_name, int device_in
     
     // Set volume (convert 0-100 to ALSA range)
     long alsa_min, alsa_max;
-    snd_mixer_selem_get_playback_volume_range(elem, &alsa_min, &alsa_max);
-    long alsa_volume = alsa_min + (alsa_max - alsa_min) * volume / 100;
+    snd_mixer_selem_get_playback_dB_range(elem, &alsa_min, &alsa_max);
     
-    if (snd_mixer_selem_set_playback_volume_all(elem, alsa_volume) < 0) {
+    // ALSA uses a logarithmic scale for perceived volume
+    double min_norm = exp10((alsa_min - alsa_max) / 6000.0);
+    double vol = (volume / 100 ) * (1 - min_norm) + min_norm;
+    double alsa_volume = 6000.0 * log10(vol) + alsa_max;
+    if (snd_mixer_selem_set_playback_dB_all(elem, alsa_volume, 0) < 0) {
         snd_mixer_close(handle);
         return false;
     }
     
+    fprintf(stderr, "[ALSA DEBUG] Successfully set volume to %d%%\n", volume);
     snd_mixer_close(handle);
     return true;
 }
 
-int PortAudioSink::get_alsa_volume(const std::string& mixer_name, int device_index) {
+int PortAudioSink::get_alsa_volume(const std::string& mixer_spec) {
+    fprintf(stderr, "[ALSA DEBUG] Getting volume for mixer: %s\n", mixer_spec.c_str());
+    
+    // Parse mixer specification in format "card:control"
+    size_t colon_pos = mixer_spec.find(':');
+    if (colon_pos == std::string::npos) {
+        fprintf(stderr, "[ALSA DEBUG] Invalid mixer specification format. Expected 'card:control'\n");
+        return -1;
+    }
+    
+    std::string card_str = mixer_spec.substr(0, colon_pos);
+    std::string control_name = mixer_spec.substr(colon_pos + 1);
     snd_mixer_t* handle;
     snd_mixer_selem_id_t* sid;
     
@@ -589,8 +617,9 @@ int PortAudioSink::get_alsa_volume(const std::string& mixer_name, int device_ind
         return -1;
     }
     
-    // Attach to default card
-    if (snd_mixer_attach(handle, "default") < 0) {
+    // Attach to the specified card
+    std::string card_name = "hw:" + card_str;
+    if (snd_mixer_attach(handle, card_name.c_str()) < 0) {
         snd_mixer_close(handle);
         return -1;
     }
@@ -610,7 +639,7 @@ int PortAudioSink::get_alsa_volume(const std::string& mixer_name, int device_ind
     // Allocate memory for mixer element ID
     snd_mixer_selem_id_alloca(&sid);
     snd_mixer_selem_id_set_index(sid, 0);
-    snd_mixer_selem_id_set_name(sid, mixer_name.c_str());
+    snd_mixer_selem_id_set_name(sid, control_name.c_str());
     
     // Find the mixer element
     snd_mixer_elem_t* elem = snd_mixer_find_selem(handle, sid);
@@ -621,11 +650,18 @@ int PortAudioSink::get_alsa_volume(const std::string& mixer_name, int device_ind
     
     // Get volume
     long alsa_min, alsa_max, alsa_volume;
-    snd_mixer_selem_get_playback_volume_range(elem, &alsa_min, &alsa_max);
-    snd_mixer_selem_get_playback_volume(elem, SND_MIXER_SCHN_FRONT_LEFT, &alsa_volume);
+    snd_mixer_selem_get_playback_dB_range(elem, &alsa_min, &alsa_max);
+    snd_mixer_selem_get_playback_dB(elem, SND_MIXER_SCHN_MONO, &alsa_volume);
     
-    // Convert ALSA volume to 0-100 range
-    int volume = static_cast<int>((alsa_volume - alsa_min) * 100 / (alsa_max - alsa_min));
+    double _vol = pow(10, (alsa_volume - alsa_max) / 6000.0);
+    if (alsa_min != SND_CTL_TLV_DB_GAIN_MUTE)
+    {
+        double min_norm = pow(10, (alsa_min - alsa_max) / 6000.0);
+        _vol = (_vol - min_norm) / (1 - min_norm);
+    }
+    int volume = static_cast<int>(_vol * 100);
+    
+    fprintf(stderr, "[ALSA DEBUG] ALSA volume: %.3f -> volume: %d%%\n", _vol, volume);
     
     snd_mixer_close(handle);
     return volume;

--- a/examples/common/portaudio_sink.cpp
+++ b/examples/common/portaudio_sink.cpp
@@ -448,6 +448,16 @@ void PortAudioSink::set_volume(uint8_t volume) {
 
 void PortAudioSink::set_muted(bool muted) {
     muted_ = muted;
+    
+    // Try hardware mute control first if ALSA mixer is specified
+    if (!alsa_mixer_spec_.empty()) {
+        if (set_alsa_mute(alsa_mixer_spec_, muted_)) {
+            // Hardware mute control succeeded
+            return;
+        }
+    }
+    
+    // Fall back to software mute control
     update_volume_multiplier_();
 }
 
@@ -528,43 +538,39 @@ void PortAudioSink::apply_volume_(uint8_t* data, size_t len, uint8_t bytes_per_s
 
 // ALSA hardware volume control implementations
 #ifdef __linux__
-bool PortAudioSink::set_alsa_volume(const std::string& mixer_spec, uint8_t volume) {
-    fprintf(stderr, "[ALSA DEBUG] Setting volume to %d%% for mixer: %s\n", volume, mixer_spec.c_str());
-    
+snd_mixer_elem_t* PortAudioSink::get_alsa_mixer_elem(const std::string& mixer_spec, snd_mixer_t** handle) {
     // Parse mixer specification in format "card:control"
     size_t colon_pos = mixer_spec.find(':');
     if (colon_pos == std::string::npos) {
-        fprintf(stderr, "[ALSA DEBUG] Invalid mixer specification format. Expected 'card:control'\n");
-        return false;
+        return nullptr;
     }
     
     std::string card_str = mixer_spec.substr(0, colon_pos);
     std::string control_name = mixer_spec.substr(colon_pos + 1);
-    snd_mixer_t* handle;
     snd_mixer_selem_id_t* sid;
     
     // Open mixer
-    if (snd_mixer_open(&handle, 0) < 0) {
-        return false;
+    if (snd_mixer_open(handle, 0) < 0) {
+        return nullptr;
     }
     
     // Attach to the specified card
     std::string card_name = "hw:" + card_str;
-    if (snd_mixer_attach(handle, card_name.c_str()) < 0) {
-        snd_mixer_close(handle);
-        return false;
+    if (snd_mixer_attach(*handle, card_name.c_str()) < 0) {
+        snd_mixer_close(*handle);
+        return nullptr;
     }
     
     // Register mixer
-    if (snd_mixer_selem_register(handle, nullptr, nullptr) < 0) {
-        snd_mixer_close(handle);
-        return false;
+    if (snd_mixer_selem_register(*handle, nullptr, nullptr) < 0) {
+        snd_mixer_close(*handle);
+        return nullptr;
     }
     
     // Load mixer elements
-    if (snd_mixer_load(handle) < 0) {
-        snd_mixer_close(handle);
-        return false;
+    if (snd_mixer_load(*handle) < 0) {
+        snd_mixer_close(*handle);
+        return nullptr;
     }
     
     // Allocate memory for mixer element ID
@@ -573,26 +579,51 @@ bool PortAudioSink::set_alsa_volume(const std::string& mixer_spec, uint8_t volum
     snd_mixer_selem_id_set_name(sid, control_name.c_str());
     
     // Find the mixer element
-    snd_mixer_elem_t* elem = snd_mixer_find_selem(handle, sid);
+    snd_mixer_elem_t* elem = snd_mixer_find_selem(*handle, sid);
     if (!elem) {
-        snd_mixer_close(handle);
+        snd_mixer_close(*handle);
+        return nullptr;
+    }
+    
+    return elem;
+}
+
+bool PortAudioSink::set_alsa_volume(const std::string& mixer_spec, uint8_t volume) {
+    fprintf(stderr, "[ALSA DEBUG] Setting volume to %d%% for mixer: %s\n", volume, mixer_spec.c_str());
+    
+    // Use helper function to get mixer element
+    snd_mixer_t* handle;
+    snd_mixer_elem_t* elem = get_alsa_mixer_elem(mixer_spec, &handle);
+    if (!elem) {
+        fprintf(stderr, "[ALSA DEBUG] Failed to get mixer element\n");
         return false;
     }
     
-    // Set volume (convert 0-100 to ALSA range)
+    // Set volume (convert 0-100 to ALSA dB range)
     long alsa_min, alsa_max;
     snd_mixer_selem_get_playback_dB_range(elem, &alsa_min, &alsa_max);
+    fprintf(stderr, "[ALSA DEBUG] dB range: %ld to %ld\n", alsa_min, alsa_max);
     
-    // ALSA uses a logarithmic scale for perceived volume
-    double min_norm = exp10((alsa_min - alsa_max) / 6000.0);
-    double vol = (volume / 100 ) * (1 - min_norm) + min_norm;
-    double alsa_volume = 6000.0 * log10(vol) + alsa_max;
-    if (snd_mixer_selem_set_playback_dB_all(elem, alsa_volume, 0) < 0) {
+    // Use the same formula as get_alsa_volume but in reverse
+    double _vol = static_cast<double>(volume) / 100.0;
+    if (alsa_min != SND_CTL_TLV_DB_GAIN_MUTE)
+    {
+        double min_norm = pow(10, (alsa_min - alsa_max) / 6000.0);
+        _vol = _vol * (1 - min_norm) + min_norm;
+    }
+    double alsa_volume = 6000.0 * log10(_vol) + alsa_max;
+    
+    fprintf(stderr, "[ALSA DEBUG] Target volume %.2f -> dB value: %.1f\n", _vol, alsa_volume);
+    
+    if (snd_mixer_selem_set_playback_dB_all(elem, static_cast<long>(alsa_volume), 0) < 0) {
+        fprintf(stderr, "[ALSA DEBUG] Failed to set dB volume: %s\n", snd_strerror(errno));
         snd_mixer_close(handle);
         return false;
     }
     
-    fprintf(stderr, "[ALSA DEBUG] Successfully set volume to %d%%\n", volume);
+    int current_vol = get_alsa_volume(mixer_spec);
+    fprintf(stderr, "[ALSA DEBUG] Successfully set volume to %d%% (current: %d)\n", volume, current_vol);
+
     snd_mixer_close(handle);
     return true;
 }
@@ -600,52 +631,12 @@ bool PortAudioSink::set_alsa_volume(const std::string& mixer_spec, uint8_t volum
 int PortAudioSink::get_alsa_volume(const std::string& mixer_spec) {
     fprintf(stderr, "[ALSA DEBUG] Getting volume for mixer: %s\n", mixer_spec.c_str());
     
-    // Parse mixer specification in format "card:control"
-    size_t colon_pos = mixer_spec.find(':');
-    if (colon_pos == std::string::npos) {
-        fprintf(stderr, "[ALSA DEBUG] Invalid mixer specification format. Expected 'card:control'\n");
-        return -1;
-    }
-    
-    std::string card_str = mixer_spec.substr(0, colon_pos);
-    std::string control_name = mixer_spec.substr(colon_pos + 1);
+    // Use helper function to get mixer element
     snd_mixer_t* handle;
-    snd_mixer_selem_id_t* sid;
-    
-    // Open mixer
-    if (snd_mixer_open(&handle, 0) < 0) {
-        return -1;
-    }
-    
-    // Attach to the specified card
-    std::string card_name = "hw:" + card_str;
-    if (snd_mixer_attach(handle, card_name.c_str()) < 0) {
-        snd_mixer_close(handle);
-        return -1;
-    }
-    
-    // Register mixer
-    if (snd_mixer_selem_register(handle, nullptr, nullptr) < 0) {
-        snd_mixer_close(handle);
-        return -1;
-    }
-    
-    // Load mixer elements
-    if (snd_mixer_load(handle) < 0) {
-        snd_mixer_close(handle);
-        return -1;
-    }
-    
-    // Allocate memory for mixer element ID
-    snd_mixer_selem_id_alloca(&sid);
-    snd_mixer_selem_id_set_index(sid, 0);
-    snd_mixer_selem_id_set_name(sid, control_name.c_str());
-    
-    // Find the mixer element
-    snd_mixer_elem_t* elem = snd_mixer_find_selem(handle, sid);
+    snd_mixer_elem_t* elem = get_alsa_mixer_elem(mixer_spec, &handle);
     if (!elem) {
-        snd_mixer_close(handle);
-        return -1;
+        fprintf(stderr, "[ALSA DEBUG] Failed to get mixer element\n");
+        return false;
     }
     
     // Get volume
@@ -660,11 +651,57 @@ int PortAudioSink::get_alsa_volume(const std::string& mixer_spec) {
         _vol = (_vol - min_norm) / (1 - min_norm);
     }
     int volume = static_cast<int>(_vol * 100);
-    
-    fprintf(stderr, "[ALSA DEBUG] ALSA volume: %.3f -> volume: %d%%\n", _vol, volume);
-    
     snd_mixer_close(handle);
     return volume;
+}
+
+bool PortAudioSink::set_alsa_mute(const std::string& mixer_spec, bool muted) {
+    // Use helper function to get mixer element
+    snd_mixer_t* handle;
+    snd_mixer_elem_t* elem = get_alsa_mixer_elem(mixer_spec, &handle);
+    if (!elem) {
+        return false;
+    }
+    
+    // Check if this control supports playback switch (mute)
+    if (!snd_mixer_selem_has_playback_switch(elem)) {
+        snd_mixer_close(handle);
+        return false;
+    }
+    
+    // Set mute state
+    if (snd_mixer_selem_set_playback_switch_all(elem, !muted) < 0) {
+        snd_mixer_close(handle);
+        return false;
+    }
+    
+    snd_mixer_close(handle);
+    return true;
+}
+
+bool PortAudioSink::get_alsa_mute(const std::string& mixer_spec) {
+    // Use helper function to get mixer element
+    snd_mixer_t* handle;
+    snd_mixer_elem_t* elem = get_alsa_mixer_elem(mixer_spec, &handle);
+    if (!elem) {
+        return false;
+    }
+    
+    // Check if this control supports playback switch (mute)
+    if (!snd_mixer_selem_has_playback_switch(elem)) {
+        snd_mixer_close(handle);
+        return false;
+    }
+    
+    // Get mute state
+    int mute_state;
+    if (snd_mixer_selem_get_playback_switch(elem, SND_MIXER_SCHN_MONO, &mute_state) < 0) {
+        snd_mixer_close(handle);
+        return false;
+    }
+    
+    snd_mixer_close(handle);
+    return !mute_state;  // Return true if muted (switch is off)
 }
 #else
 bool PortAudioSink::set_alsa_volume(const std::string& mixer_name, int device_index, uint8_t volume) {
@@ -672,9 +709,19 @@ bool PortAudioSink::set_alsa_volume(const std::string& mixer_name, int device_in
     return false;
 }
 
-int PortAudioSink::get_alsa_volume(const std::string& mixer_name, int device_index) {
-    (void)mixer_name; (void)device_index;
+int PortAudioSink::get_alsa_volume(const std::string& mixer_spec) {
+    (void)mixer_spec;
     return -1;
+}
+
+bool PortAudioSink::set_alsa_mute(const std::string& mixer_spec, bool muted) {
+    (void)mixer_spec; (void)muted;
+    return false;
+}
+
+bool PortAudioSink::get_alsa_mute(const std::string& mixer_spec) {
+    (void)mixer_spec;
+    return false;
 }
 #endif
 

--- a/examples/common/portaudio_sink.h
+++ b/examples/common/portaudio_sink.h
@@ -97,8 +97,9 @@ public:
     /// @brief Set the mute state. When muted, output is silenced regardless of volume.
     void set_muted(bool muted);
 
-    /// @brief Set the ALSA mixer name for hardware volume control.
-    void set_alsa_mixer_name(const std::string& mixer_name);
+    /// @brief Set the ALSA mixer specification for hardware volume control.
+    /// @param mixer_spec Mixer specification in format "card:control" (e.g., "1:Digital")
+    void set_alsa_mixer_spec(const std::string& mixer_spec);
 
     /// @brief Check if the default output device supports a given format.
     /// PortAudio must be initialized before calling (i.e., a PortAudioSink must exist).
@@ -116,12 +117,14 @@ public:
     static bool list_alsa_mixers(int device_index);
 
     /// @brief Set hardware volume using ALSA mixer (Linux only).
+    /// @param mixer_spec Mixer specification in format "card:control" (e.g., "1:Digital")
     /// @return true if successful, false otherwise.
-    static bool set_alsa_volume(const std::string& mixer_name, int device_index, uint8_t volume);
+    static bool set_alsa_volume(const std::string& mixer_spec, uint8_t volume);
 
     /// @brief Get hardware volume using ALSA mixer (Linux only).
+    /// @param mixer_spec Mixer specification in format "card:control" (e.g., "1:Digital")
     /// @return volume in 0-100 range, or -1 if failed.
-    static int get_alsa_volume(const std::string& mixer_name, int device_index);
+    static int get_alsa_volume(const std::string& mixer_spec);
 
     /// @brief Check if a specific device supports a given format.
     static bool is_format_supported(int device_index, uint32_t sample_rate, uint8_t channels, uint8_t bits_per_sample);
@@ -155,7 +158,7 @@ private:
     uint8_t volume_{100};
     bool muted_{false};
     int device_index_{-1};
-    std::string alsa_mixer_name_;
+    std::string alsa_mixer_spec_;
     void update_volume_multiplier_();
     static void apply_volume_(uint8_t* data, size_t len, uint8_t bytes_per_sample, uint64_t scale);
 };

--- a/examples/common/portaudio_sink.h
+++ b/examples/common/portaudio_sink.h
@@ -25,6 +25,12 @@
 #include <vector>
 #include <string>
 
+// ALSA includes for mixer control (Linux only)
+#ifdef __linux__
+#include <alsa/asoundlib.h>
+#include <alsa/mixer.h>
+#endif
+
 namespace sendspin {
 
 /// @brief Lock-free single-producer single-consumer ring buffer for bridging
@@ -126,6 +132,16 @@ public:
     /// @return volume in 0-100 range, or -1 if failed.
     static int get_alsa_volume(const std::string& mixer_spec);
 
+    /// @brief Set hardware mute state using ALSA mixer (Linux only).
+    /// @param mixer_spec Mixer specification in format "card:control" (e.g., "1:Digital")
+    /// @return true if successful, false otherwise.
+    static bool set_alsa_mute(const std::string& mixer_spec, bool muted);
+
+    /// @brief Get hardware mute state using ALSA mixer (Linux only).
+    /// @param mixer_spec Mixer specification in format "card:control" (e.g., "1:Digital")
+    /// @return true if muted, false if unmuted, error will return false (assume unmuted)
+    static bool get_alsa_mute(const std::string& mixer_spec);
+
     /// @brief Check if a specific device supports a given format.
     static bool is_format_supported(int device_index, uint32_t sample_rate, uint8_t channels, uint8_t bits_per_sample);
 
@@ -133,6 +149,12 @@ public:
     std::function<void(uint32_t frames, int64_t timestamp)> on_frames_played;
 
 private:
+#ifdef __linux__
+    /// @brief Helper function to get ALSA mixer element
+    /// @return snd_mixer_elem_t* on success, nullptr on failure
+    static snd_mixer_elem_t* get_alsa_mixer_elem(const std::string& mixer_spec, snd_mixer_t** handle);
+#endif
+
     static int pa_callback(const void* input, void* output, unsigned long frame_count,
                            const PaStreamCallbackTimeInfo* time_info,
                            PaStreamCallbackFlags status_flags, void* user_data);

--- a/examples/common/portaudio_sink.h
+++ b/examples/common/portaudio_sink.h
@@ -23,6 +23,7 @@
 #include <functional>
 #include <mutex>
 #include <vector>
+#include <string>
 
 namespace sendspin {
 
@@ -81,7 +82,8 @@ public:
     size_t write(uint8_t* data, size_t length, uint32_t timeout_ms);
 
     /// @brief Configure audio format and (re)open the PortAudio stream.
-    bool configure(uint32_t sample_rate, uint8_t channels, uint8_t bits_per_sample);
+    /// @param device_index Optional device index, uses default if -1
+    bool configure(uint32_t sample_rate, uint8_t channels, uint8_t bits_per_sample, int device_index = -1);
 
     /// @brief Stop playback and clear the ring buffer.
     void stop();
@@ -95,6 +97,9 @@ public:
     /// @brief Set the mute state. When muted, output is silenced regardless of volume.
     void set_muted(bool muted);
 
+    /// @brief Set the ALSA mixer name for hardware volume control.
+    void set_alsa_mixer_name(const std::string& mixer_name);
+
     /// @brief Check if the default output device supports a given format.
     /// PortAudio must be initialized before calling (i.e., a PortAudioSink must exist).
     static bool is_format_supported(uint32_t sample_rate, uint8_t channels, uint8_t bits_per_sample);
@@ -102,6 +107,24 @@ public:
     /// @brief Return the maximum output channel count of the default output device.
     /// Returns 0 if no output device is available.
     static uint8_t max_output_channels();
+
+    /// @brief List all available audio devices.
+    static void list_devices();
+
+    /// @brief List ALSA mixer controls for a specific device (Linux only).
+    /// @return true if ALSA is available and listing was successful, false otherwise.
+    static bool list_alsa_mixers(int device_index);
+
+    /// @brief Set hardware volume using ALSA mixer (Linux only).
+    /// @return true if successful, false otherwise.
+    static bool set_alsa_volume(const std::string& mixer_name, int device_index, uint8_t volume);
+
+    /// @brief Get hardware volume using ALSA mixer (Linux only).
+    /// @return volume in 0-100 range, or -1 if failed.
+    static int get_alsa_volume(const std::string& mixer_name, int device_index);
+
+    /// @brief Check if a specific device supports a given format.
+    static bool is_format_supported(int device_index, uint32_t sample_rate, uint8_t channels, uint8_t bits_per_sample);
 
     /// @brief Callback for timing feedback. Wire to client.notify_audio_played().
     std::function<void(uint32_t frames, int64_t timestamp)> on_frames_played;
@@ -131,6 +154,8 @@ private:
     std::atomic<uint64_t> volume_multiplier_{UINT64_C(1) << 32};
     uint8_t volume_{100};
     bool muted_{false};
+    int device_index_{-1};
+    std::string alsa_mixer_name_;
     void update_volume_multiplier_();
     static void apply_volume_(uint8_t* data, size_t len, uint8_t bytes_per_sample, uint64_t scale);
 };


### PR DESCRIPTION
I have extended the basic_client with some new arguments  and features:

- List and choose specific device to use.
- Option to use a hardware mixer instead of software volume
- Find sample formats for the chosen device

I chose the lazy path of using vibe coding for this, as I just wanted to get on with testing sendspin on my RPI4 with bullseye debian. For this old debian release it is rather tricky to get uv sendspin-cli installed. This however I could compile fairly fast, so thanks you for this :)

