### PR TITLE
Use >= versioning requirements for IDF components

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -3,11 +3,11 @@ name: "sendspin-cpp"
 dependencies:
   idf: ">=5.1"
   espressif/esp_websocket_client: ">=1.0.0"
-  bblanchon/arduinojson: "==7.4.1"
+  bblanchon/arduinojson: ">=7.4.2"
   esphome/micro-flac:
-    version: "0.1.1"
+    version: ">=0.1.1"
   esphome/micro-opus:
-    version: "0.3.5"
+    version: ">=0.3.5"
 description: "Sendspin synchronized audio streaming client for ESP32"
 license: "Apache-2.0"
 maintainers:


### PR DESCRIPTION
This makes it easier to stay compatible with future changes in ESPHome.