### PR TITLE
Refactor publish and release GitHub workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Resolve component version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Publish package
         uses: espressif/upload-components-ci-action@2ce17d73e35473317c1419dbd4f007aacb593040 # v2.2.1
         with:
-          version: ${{ github.event.release.tag_name }}
+          version: ${{ steps.version.outputs.version }}
           components: |
             sendspin-cpp: .
           namespace: esphome

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,27 +16,8 @@ permissions:
 jobs:
   release-drafter:
     name: Release Drafter
-    environment: release-drafter
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0
-        id: drafter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
-
-      - name: Update version files
-        run: |
-          sed -i "s/version: .*/version: \"${{ steps.drafter.outputs.resolved_version }}\"/g" idf_component.yml
-
-      - name: Commit changes
-        run: |
-          if ! git diff --quiet; then
-            git config --global user.name "esphomebot"
-            git config --global user.email "68923041+esphomebot@users.noreply.github.com"
-            git commit -am "Bump version to ${{ steps.drafter.outputs.resolved_version }}"
-            git push
-          fi

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -12,7 +12,7 @@ description: "Sendspin synchronized audio streaming client for ESP32"
 license: "Apache-2.0"
 maintainers:
   - Kevin Ahrendt <kevin.ahrendt@openhomefoundation.org>
-version: "0.1.0"
+version: "0.0.0"
 url: https://github.com/sendspin/sendspin-cpp
 repository: https://github.com/sendspin/sendspin-cpp.git
 files:


### PR DESCRIPTION
Always use v0.0.0 in idf_component.yml but replace the version when we publish on the Espressif component registry