### PR TITLE
Publish under sendspin namespace, not esphome

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,4 +24,4 @@ jobs:
           version: ${{ steps.version.outputs.version }}
           components: |
             sendspin-cpp: .
-          namespace: esphome
+          namespace: sendspin


### PR DESCRIPTION
Bad copypaste here from esphome library workflows!