### PR TITLE
Readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/Sendspin/sendspin-cpp/actions/workflows/ci.yml/badge.svg)](https://github.com/Sendspin/sendspin-cpp/actions/workflows/ci.yml)
 [![Component Registry](https://components.espressif.com/components/sendspin/sendspin-cpp/badge.svg)](https://components.espressif.com/components/sendspin/sendspin-cpp)
 
-Standalone C++ library implementing the Sendspin synchronized audio streaming protocol. Builds on both ESP-IDF (ESP32) and host platforms (macOS/Linux). Designed to be consumed by ESPHome but has no ESPHome dependencies.
+Standalone C++ library implementing the [Sendspin synchronized audio streaming protocol](https://www.sendspin-audio.com/). Builds on both ESP-IDF (ESP32) and host platforms (macOS/Linux). Designed to be consumed by ESPHome but has no ESPHome dependencies.
 
 [![A project from the Open Home Foundation](https://www.openhomefoundation.org/badges/ohf-project.png)](https://www.openhomefoundation.org/)
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # sendspin-cpp
 
-Standalone C++ library implementing the Sendspin synchronized audio streaming protocol. Builds on both ESP-IDF (ESP32) and host platforms (macOS/Linux). Designed to be consumed by ESPHome but has no ESPHome dependencies.
-
 [![CI](https://github.com/Sendspin/sendspin-cpp/actions/workflows/ci.yml/badge.svg)](https://github.com/Sendspin/sendspin-cpp/actions/workflows/ci.yml)
 [![Component Registry](https://components.espressif.com/components/sendspin/sendspin-cpp/badge.svg)](https://components.espressif.com/components/sendspin/sendspin-cpp)
+
+Standalone C++ library implementing the Sendspin synchronized audio streaming protocol. Builds on both ESP-IDF (ESP32) and host platforms (macOS/Linux). Designed to be consumed by ESPHome but has no ESPHome dependencies.
 
 [![A project from the Open Home Foundation](https://www.openhomefoundation.org/badges/ohf-project.png)](https://www.openhomefoundation.org/)
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,14 @@ Dependencies (fetched automatically via CMake FetchContent): ArduinoJson, micro-
 
 ### ESP-IDF
 
-Used as an IDF component. Add to your project's `idf_component.yml`.
+Available on the [ESP-IDF Component Registry](https://components.espressif.com/components/sendspin/sendspin-cpp). Add to your project's `idf_component.yml`:
+
+```yaml
+dependencies:
+  sendspin/sendspin-cpp: ">=0.1.2"
+```
+
+Requires ESP-IDF v5.1 or later.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Standalone C++ library implementing the [Sendspin synchronized audio streaming p
 
 ## Features
 
-- WebSocket-based audio streaming with server time synchronization
-- FLAC, Opus, and PCM audio decoding
+- Modular Sendspin role composition: artwork, controller, metadata, player, and visualizer
+- WebSocket client and server support
+- Decodes FLAC, Opus, and PCM
 - Cross-platform: ESP-IDF (ESP32) and host (macOS/Linux)
 
 ## Documentation


### PR DESCRIPTION
- Fixes the order of the new badges
- Adds a link to sendspin-audio.com
- Makes the features list more specific to this implementation
- Adds more details to the esp-idf section now that the library is available on the registry