### PR TITLE
Use a shadow slot instead of queue for playback progress

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -73,7 +73,6 @@ Fixed-depth FIFO queue with timed send/receive. Used to defer events from networ
 |-------|-------|------|----------|----------|
 | `PlayerRole::stream_queue` | 8 | `StreamCallbackType` | Network thread | Main loop (`drain_events`) |
 | `PlayerRole::state_queue` | 4 | `SendspinClientState` | Sync task thread | Main loop (`drain_events`) |
-| `SyncTask::playback_progress_queue_` | 50 | `PlaybackProgress` | Audio output callback | Sync task thread |
 | `Client::time_queue` | 16 | `TimeResponseEvent` | Network thread | Main loop (`loop`) |
 | `ArtworkRole::notify_queue` | 8 | `ArtworkNotification` | Network thread | Artwork drain thread |
 | `ArtworkRole::queue` | 8 | `EventType` | Network thread | Main loop (`drain_events`) |
@@ -92,6 +91,7 @@ Single-slot state container with "latest wins" or custom merge semantics. The ne
 | `MetadataRole::shadow` | `ServerMetadataStateObject` | Field-by-field delta merge |
 | `ArtworkRole::shadow_config` | `ServerArtworkStreamObject` | Latest wins |
 | `VisualizerRole::shadow_config` | `ServerVisualizerStreamObject` | Latest wins |
+| `SyncTask::playback_progress_slot_` | `PlaybackProgress` | Sum `frames_played`, keep latest `finish_timestamp` |
 
 The merge strategy for `shadow_command` is important: if a volume change and a mute change arrive between two drain ticks, both are preserved because the merge function only overwrites fields that have values in the delta.
 
@@ -316,7 +316,7 @@ Hard sync sets a flag that switches to a tighter 500 us settle threshold until t
 
 ### Playback Progress Tracking
 
-The audio output hardware reports consumed frames via `notify_audio_played()` → `playback_progress_queue_`. The sync task drains this queue on every inner loop iteration to maintain an accurate `new_audio_client_playtime` estimate:
+The audio output hardware reports consumed frames via `notify_audio_played()` → `playback_progress_slot_` (a `ShadowSlot` whose merge strategy sums `frames_played` across unread updates and keeps the latest `finish_timestamp`). The sync task takes the accumulated value on every inner loop iteration to maintain an accurate `new_audio_client_playtime` estimate:
 
 ```cpp
 new_audio_client_playtime = last_finish_timestamp + remaining_buffered_frames_as_microseconds
@@ -416,7 +416,7 @@ This prevents the sync task from starting a new stream before the main loop has 
 
 ### Playback Progress
 
-Audio output callbacks run on a platform audio thread. They report consumed frames via `notify_audio_played()` → `playback_progress_queue_`. The sync task drains this queue non-blockingly on each iteration of its inner loop, keeping the playtime estimate accurate without blocking the audio thread.
+Audio output callbacks run on a platform audio thread. They report consumed frames via `notify_audio_played()` → `playback_progress_slot_` (merging sums frames and keeps the latest timestamp). The sync task takes the accumulated value non-blockingly on each iteration of its inner loop, keeping the playtime estimate accurate without blocking the audio thread.
 
 ### Cleanup Atomicity
 

--- a/src/sync_task.cpp
+++ b/src/sync_task.cpp
@@ -41,9 +41,6 @@ static constexpr uint32_t INITIAL_SYNC_ZEROS_DURATION_MS = 25;
 
 static constexpr size_t SYNC_TASK_STACK_SIZE = 6192;  // Opus uses more stack than FLAC
 
-/// @brief Capacity of the playback progress queue (number of progress events)
-static constexpr size_t PLAYBACK_PROGRESS_QUEUE_SIZE = 50U;
-
 /// @brief Wait time (ms) between retries when time sync is not yet available
 static constexpr uint32_t WAIT_FOR_TIME_SYNC_MS = 15U;
 
@@ -66,11 +63,6 @@ bool SyncTask::init(PlayerRole* player, SendspinClient* client, size_t buffer_si
 
     if (!this->event_flags_.create()) {
         SS_LOGE(TAG, "Couldn't create event flags.");
-        return false;
-    }
-
-    if (!this->playback_progress_queue_.create(PLAYBACK_PROGRESS_QUEUE_SIZE)) {
-        SS_LOGE(TAG, "Couldn't create playback progress queue.");
         return false;
     }
 
@@ -137,10 +129,15 @@ bool SyncTask::write_audio_chunk(const uint8_t* data, size_t data_size, int64_t 
 }
 
 void SyncTask::notify_audio_played(uint32_t frames, int64_t timestamp) {
-    PlaybackProgress playback_progress{frames, timestamp};
-    if (!this->playback_progress_queue_.send(playback_progress, 0)) {
-        SS_LOGE(TAG, "Playback info queue was full");
-    }
+    // Merge into the shadow slot: sum frames across unread updates and keep
+    // the most recent finish_timestamp. The sync thread drains on each inner
+    // loop iteration.
+    this->playback_progress_slot_.merge(
+        [](PlaybackProgress& current, PlaybackProgress&& delta) {
+            current.frames_played += delta.frames_played;
+            current.finish_timestamp = delta.finish_timestamp;
+        },
+        PlaybackProgress{frames, timestamp});
 }
 
 // ============================================================================
@@ -575,9 +572,7 @@ void SyncTask::reset_context(SyncContext& sync_context) {
 
 void SyncTask::process_playback_progress(SyncContext& sync_context) {
     PlaybackProgress playback_progress{};
-    bool received = false;
-    while (this->playback_progress_queue_.receive(playback_progress, 0)) {
-        received = true;
+    if (this->playback_progress_slot_.take(playback_progress)) {
         uint32_t frames_played = playback_progress.frames_played;
 
         if (sync_context.initial_decode && frames_played) {
@@ -592,8 +587,7 @@ void SyncTask::process_playback_progress(SyncContext& sync_context) {
         } else {
             sync_context.buffered_frames -= frames_played;
         }
-    }
-    if (received) {
+
         uint32_t unplayed_frames = sync_context.buffered_frames;
         int64_t unplayed_ms =
             sync_context.current_stream_info.frames_to_milliseconds_with_remainder(
@@ -652,7 +646,7 @@ void SyncTask::thread_entry(void* params) {
         this_task->event_flags_.set(EventGroupBits::TASK_IDLE);
 
         this_task->reset_context(sync_context);
-        this_task->playback_progress_queue_.reset();
+        this_task->playback_progress_slot_.reset();
 
         // Wait for a codec header to arrive in the ring buffer (yields CPU with long timeout)
         bool got_header = this_task->wait_for_codec_header(sync_context);
@@ -705,7 +699,7 @@ void SyncTask::thread_entry(void* params) {
         // before setting TASK_RUNNING. The I2S hardware may still be draining its DMA
         // buffer from the old stream, and those callbacks would corrupt the new stream's
         // buffered_frames tracking.
-        this_task->playback_progress_queue_.reset();
+        this_task->playback_progress_slot_.reset();
 
         this_task->event_flags_.set(EventGroupBits::TASK_RUNNING);
 

--- a/src/sync_task.h
+++ b/src/sync_task.h
@@ -22,7 +22,7 @@
 #include "audio_stream_info.h"
 #include "decoder.h"
 #include "platform/event_flags.h"
-#include "platform/thread_safe_queue.h"
+#include "platform/shadow_slot.h"
 #include "transfer_buffer.h"
 
 #include <atomic>
@@ -230,7 +230,9 @@ protected:
 
     // Struct fields
     EventFlags event_flags_;
-    ThreadSafeQueue<PlaybackProgress> playback_progress_queue_;
+    // Latest-wins slot that merges (sum frames, keep latest finish_timestamp)
+    // updates from the audio callback and is drained by the sync thread.
+    ShadowSlot<PlaybackProgress> playback_progress_slot_;
     std::thread sync_thread_;
 
     // Pointer fields


### PR DESCRIPTION
Uses a shadow slow to store playback progress notifications instead of a queue. This avoids a large memory allocation. Additionally, the queue's length implicitly depended on the notification frequencies, so if a platform sent them more often it could overfill. Using the shadow slot avoids that altogether.