### PR TITLE
Simplify time message handling

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -518,8 +518,7 @@ void SendspinClient::process_json_message(SendspinConnection* conn, const std::s
 
             int64_t offset{0};
             int64_t max_error{0};
-            if (process_server_time_message(root, timestamp, conn->peek_time_replacement(), &offset,
-                                            &max_error)) {
+            if (process_server_time_message(root, timestamp, &offset, &max_error)) {
                 this->event_state_->time_queue.send({offset, max_error, timestamp}, 0);
             }
             break;

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -15,9 +15,7 @@
 #include "connection.h"
 
 #include "platform/logging.h"
-#include "platform/time.h"
 #include "time_filter.h"
-#include <ArduinoJson.h>
 
 #include <memory>
 
@@ -40,47 +38,11 @@ void SendspinConnection::init_time_filter() {
         TIME_FILTER_PROCESS_STD_DEV, TIME_FILTER_DRIFT_PROCESS_STD_DEV, TIME_FILTER_FORGET_FACTOR,
         TIME_FILTER_ADAPTIVE_CUTOFF, TIME_FILTER_MIN_SAMPLES,
         TIME_FILTER_DRIFT_SIGNIFICANCE_THRESHOLD);
-    if (!this->time_replacement_queue_.is_created()) {
-        this->time_replacement_queue_.create(1);
-    }
-}
-
-TimeTransmittedReplacement SendspinConnection::peek_time_replacement() const {
-    TimeTransmittedReplacement replacement{};
-    this->time_replacement_queue_.peek(replacement);
-    return replacement;
 }
 
 // ============================================================================
 // Message sending
 // ============================================================================
-
-bool SendspinConnection::send_time_message(SendCompleteCallback cb) {
-    int64_t now = platform_time_us();
-
-    // Build the time message using ArduinoJson directly
-    JsonDocument doc = make_json_document();
-    doc["type"] = "client/time";
-    doc["payload"]["client_transmitted"] = now;
-    std::string serialized_text;
-    serializeJson(doc, serialized_text);
-
-    // Wrap the caller's callback to push the time replacement into the queue
-    // after the message is actually sent. This is thread-safe: the queue handles
-    // synchronization between the send thread and the receive thread.
-    auto* queue = &this->time_replacement_queue_;
-    auto wrapped_cb = [now, queue, cb = std::move(cb)](bool success, int64_t actual_send_time) {
-        if (success && queue->is_created()) {
-            TimeTransmittedReplacement replacement{now, actual_send_time};
-            queue->overwrite(replacement);
-        }
-        if (cb) {
-            cb(success, actual_send_time);
-        }
-    };
-
-    return this->send_text_message(serialized_text, std::move(wrapped_cb)) == SsErr::OK;
-}
 
 SsErr SendspinConnection::send_goodbye_reason(SendspinGoodbyeReason reason,
                                               SendCompleteCallback on_complete) {

--- a/src/connection.h
+++ b/src/connection.h
@@ -117,7 +117,7 @@ public:
 
     /// @brief Sends a text message to the server with a completion callback
     /// @param msg The message string to send.
-    /// @param cb Callback invoked after send completes (success, actual_send_time).
+    /// @param cb Callback invoked after send completes.
     /// @return SsErr::OK if queued successfully, error code otherwise.
     virtual SsErr send_text_message(const std::string& message, SendCompleteCallback cb) = 0;
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "platform/memory.h"
-#include "platform/thread_safe_queue.h"
 #include "platform/types.h"
 #include "protocol_messages.h"
 #include "time_filter.h"
@@ -123,10 +122,15 @@ public:
     /// @return SsErr::OK if queued successfully, error code otherwise.
     virtual SsErr send_text_message(const std::string& message, SendCompleteCallback cb) = 0;
 
-    /// @brief Sends a time synchronization message with a completion callback
-    /// @param cb Callback invoked after send completes, providing actual send timestamp.
-    /// @return true if message was queued successfully, false otherwise.
-    bool send_time_message(SendCompleteCallback cb);
+    /// @brief Sends a client/time synchronization message
+    ///
+    /// The transport implementation captures `client_transmitted` as close to the actual wire
+    /// send as possible (e.g., inside the httpd worker on ESP server, just before
+    /// `httpd_ws_send_frame_async`) and serializes the JSON inline. This eliminates the queue
+    /// latency variance that a hub-thread timestamp would introduce.
+    ///
+    /// @return true if the message was queued/sent successfully, false otherwise.
+    virtual bool send_time_message() = 0;
 
     /// @brief Sends a goodbye message with completion callback
     /// @param reason The reason for disconnecting.
@@ -216,6 +220,25 @@ public:
     /// @brief Initializes the time filter with Kalman parameters
     void init_time_filter();
 
+    /// @brief Returns the EMA (microseconds) of how long format_client_time_message() takes
+    ///
+    /// Updated by `send_time_message()` on each call. The serialization happens between when
+    /// `client_transmitted` is captured and when the bytes hit the wire, so this EMA estimates
+    /// the constant bias subtracted from the embedded timestamp. Reported alongside per-burst
+    /// stats for diagnostics. Atomic so the httpd worker (ESP server) can update it while the
+    /// hub thread reads it.
+    int64_t get_serialize_ema_us() const {
+        return this->serialize_ema_us_.load(std::memory_order_relaxed);
+    }
+
+    /// @brief Folds a new serialization-duration sample into the EMA (1/16 weight)
+    /// @param sample_us Measured duration in microseconds.
+    void update_serialize_ema(int64_t sample_us) {
+        int64_t prev = this->serialize_ema_us_.load(std::memory_order_relaxed);
+        const int64_t next = (prev == 0) ? sample_us : ((prev * 15 + sample_us) / 16);
+        this->serialize_ema_us_.store(next, std::memory_order_relaxed);
+    }
+
     // ========================================
     // Configuration setters (called by hub after receiving server/hello message)
     // ========================================
@@ -270,12 +293,6 @@ public:
         this->pending_time_message_ = pending;
     }
 
-    /// @brief Thread-safe peek at the last time replacement data
-    /// Uses a FreeRTOS queue (depth 1) so the send callback can write from any thread
-    /// while the receive handler reads from any thread without data races.
-    /// @return Copy of the last time replacement, or default-constructed if none available.
-    TimeTransmittedReplacement peek_time_replacement() const;
-
 protected:
     /// @brief Deallocates the websocket payload buffer if allocated
     void deallocate_websocket_payload();
@@ -310,11 +327,6 @@ protected:
 
     // Struct fields
 
-    /// Thread-safe single-slot buffer for time replacement data.
-    /// Written by the send callback (which may run on httpd/websocket thread),
-    /// read by the receive handler (which may run on a different thread).
-    ThreadSafeQueue<TimeTransmittedReplacement> time_replacement_queue_;
-
     /// Message buffering (for websocket frame assembly).
     PlatformBuffer websocket_payload_;
 
@@ -327,6 +339,10 @@ protected:
     std::unique_ptr<SendspinTimeFilter> time_filter_;
 
     // 64-bit fields
+
+    /// EMA (microseconds) of format_client_time_message() duration. Atomic because the ESP
+    /// server worker thread updates it while the hub thread reads it for logging.
+    std::atomic<int64_t> serialize_ema_us_{0};
 
     /// Time message state.
     int64_t last_sent_time_message_{0};

--- a/src/connection.h
+++ b/src/connection.h
@@ -32,8 +32,7 @@ namespace sendspin {
 
 /// @brief Callback type for message send completion
 /// @param success True if the message was sent successfully, false otherwise.
-/// @param timestamp The actual timestamp when the message was sent (in microseconds).
-using SendCompleteCallback = std::function<void(bool, int64_t)>;
+using SendCompleteCallback = std::function<void(bool)>;
 
 /**
  * @brief Abstract base class for Sendspin connections (server-initiated or client-initiated)
@@ -275,12 +274,6 @@ public:
     // Time message state accessors
     // ========================================
 
-    /// @brief Sets the timestamp of the last sent time message
-    /// @param timestamp The timestamp of the last sent time message
-    void set_last_sent_time_message(int64_t timestamp) {
-        this->last_sent_time_message_ = timestamp;
-    }
-
     /// @brief Checks if a time message is pending (waiting for response)
     /// @return True if a time message has been sent and a response is expected, false otherwise.
     bool is_pending_time_message() const {
@@ -343,9 +336,6 @@ protected:
     /// EMA (microseconds) of format_client_time_message() duration. Atomic because the ESP
     /// server worker thread updates it while the hub thread reads it for logging.
     std::atomic<int64_t> serialize_ema_us_{0};
-
-    /// Time message state.
-    int64_t last_sent_time_message_{0};
 
     // size_t fields
     size_t websocket_write_offset_{0};

--- a/src/connection_manager.cpp
+++ b/src/connection_manager.cpp
@@ -373,15 +373,13 @@ bool ConnectionManager::send_hello_message(uint8_t remaining_attempts, SendspinC
 
     std::string hello_message = this->client_->build_hello_message();
 
-    SsErr err =
-        conn->send_text_message(hello_message, [conn](bool success, int64_t actual_send_time) {
-            if (success) {
-                conn->set_client_hello_sent(true);
-                conn->set_last_sent_time_message(actual_send_time);
-            } else {
-                SS_LOGW(TAG, "Hello message send failed");
-            }
-        });
+    SsErr err = conn->send_text_message(hello_message, [conn](bool success) {
+        if (success) {
+            conn->set_client_hello_sent(true);
+        } else {
+            SS_LOGW(TAG, "Hello message send failed");
+        }
+    });
 
     if (err == SsErr::OK) {
         return true;  // Successfully queued

--- a/src/esp/client_connection.cpp
+++ b/src/esp/client_connection.cpp
@@ -15,6 +15,7 @@
 #include "client_connection.h"
 
 #include "platform/logging.h"
+#include "protocol_messages.h"
 #include <esp_timer.h>
 
 #include <cstring>
@@ -158,6 +159,31 @@ SsErr SendspinClientConnection::send_text_message(const std::string& message,
     }
 
     return SsErr::OK;
+}
+
+bool SendspinClientConnection::send_time_message() {
+    if (!this->is_connected()) {
+        return false;
+    }
+
+    // Capture client_transmitted as close to the actual send call as possible. Track the
+    // serialization duration as the bias subtracted from the embedded timestamp. Stack buffer
+    // keeps the path heap-free.
+    char buf[96];
+    const int64_t client_transmitted = esp_timer_get_time();
+    const size_t len = format_client_time_message(buf, sizeof(buf), client_transmitted);
+    this->update_serialize_ema(esp_timer_get_time() - client_transmitted);
+    if (len == 0) {
+        return false;
+    }
+
+    int sent = esp_websocket_client_send_text(this->client_, buf, len,
+                                              pdMS_TO_TICKS(WEBSOCKET_SEND_TIMEOUT_MS));
+    if (sent < 0) {
+        SS_LOGE(TAG, "Failed to send time message: %d", sent);
+        return false;
+    }
+    return true;
 }
 
 // ============================================================================

--- a/src/esp/client_connection.cpp
+++ b/src/esp/client_connection.cpp
@@ -164,7 +164,7 @@ bool SendspinClientConnection::send_time_message() {
     // Capture client_transmitted as close to the actual send call as possible. Track the
     // serialization duration as the bias subtracted from the embedded timestamp. Stack buffer
     // keeps the path heap-free.
-    char buf[96];
+    char buf[TIME_MESSAGE_BUF_SIZE];
     const int64_t client_transmitted = esp_timer_get_time();
     const size_t len = format_client_time_message(buf, sizeof(buf), client_transmitted);
     if (len == 0) {

--- a/src/esp/client_connection.cpp
+++ b/src/esp/client_connection.cpp
@@ -167,10 +167,10 @@ bool SendspinClientConnection::send_time_message() {
     char buf[96];
     const int64_t client_transmitted = esp_timer_get_time();
     const size_t len = format_client_time_message(buf, sizeof(buf), client_transmitted);
-    this->update_serialize_ema(esp_timer_get_time() - client_transmitted);
     if (len == 0) {
         return false;
     }
+    this->update_serialize_ema(esp_timer_get_time() - client_transmitted);
 
     int sent = esp_websocket_client_send_text(this->client_, buf, len,
                                               pdMS_TO_TICKS(WEBSOCKET_SEND_TIMEOUT_MS));

--- a/src/esp/client_connection.cpp
+++ b/src/esp/client_connection.cpp
@@ -112,7 +112,7 @@ void SendspinClientConnection::disconnect(SendspinGoodbyeReason reason,
 
     // Send goodbye message and then stop client
     // For client connections, send_text_message is synchronous, so callback fires immediately
-    this->send_goodbye_reason(reason, [this, on_complete](bool success, int64_t) {
+    this->send_goodbye_reason(reason, [this, on_complete](bool success) {
         // Stop the client regardless of send success
         if (this->client_ != nullptr) {
             esp_websocket_client_stop(this->client_);
@@ -132,9 +132,8 @@ bool SendspinClientConnection::is_connected() const {
 SsErr SendspinClientConnection::send_text_message(const std::string& message,
                                                   SendCompleteCallback cb) {
     if (!this->is_connected()) {
-        // No connection - invoke callback with failure if provided
         if (cb) {
-            cb(false, 0);
+            cb(false);
         }
         return SsErr::INVALID_STATE;
     }
@@ -143,14 +142,10 @@ SsErr SendspinClientConnection::send_text_message(const std::string& message,
     int sent = esp_websocket_client_send_text(this->client_, message.c_str(), message.length(),
                                               pdMS_TO_TICKS(WEBSOCKET_SEND_TIMEOUT_MS));
 
-    // Capture timestamp after send
-    int64_t after_send_time = esp_timer_get_time();
-
     bool success = (sent >= 0);
 
-    // Invoke callback if provided
     if (cb) {
-        cb(success, after_send_time);
+        cb(success);
     }
 
     if (!success) {

--- a/src/esp/client_connection.h
+++ b/src/esp/client_connection.h
@@ -88,6 +88,10 @@ public:
     /// @return SsErr::OK if sent successfully, error code otherwise.
     SsErr send_text_message(const std::string& message, SendCompleteCallback cb) override;
 
+    /// @brief Sends a client/time message, capturing the timestamp just before send
+    /// @return true if the message was sent successfully, false otherwise.
+    bool send_time_message() override;
+
     // ========================================
     // Client connection-specific configuration
     // ========================================

--- a/src/esp/server_connection.cpp
+++ b/src/esp/server_connection.cpp
@@ -230,22 +230,25 @@ void SendspinServerConnection::async_send_time_text(void* arg) {
         return;
     }
 
+    httpd_ws_frame_t ws_pkt;
+    memset(&ws_pkt, 0, sizeof(httpd_ws_frame_t));
+    ws_pkt.type = HTTPD_WS_TYPE_TEXT;
+
     // Capture client_transmitted as close as possible to the actual send. The serialization
     // happens between this capture and the wire send; track its duration so the bias is
     // visible in the time_burst log. Stack buffer keeps the path heap-free.
     char buf[96];
     const int64_t client_transmitted = esp_timer_get_time();
     const size_t len = format_client_time_message(buf, sizeof(buf), client_transmitted);
-    this_conn->update_serialize_ema(esp_timer_get_time() - client_transmitted);
+
     if (len == 0) {
         return;
     }
 
-    httpd_ws_frame_t ws_pkt;
-    memset(&ws_pkt, 0, sizeof(httpd_ws_frame_t));
     ws_pkt.payload = reinterpret_cast<uint8_t*>(buf);
     ws_pkt.len = len;
-    ws_pkt.type = HTTPD_WS_TYPE_TEXT;
+
+    this_conn->update_serialize_ema(esp_timer_get_time() - client_transmitted);
 
     httpd_ws_send_frame_async(this_conn->server_, this_conn->sockfd_, &ws_pkt);
 }

--- a/src/esp/server_connection.cpp
+++ b/src/esp/server_connection.cpp
@@ -237,7 +237,7 @@ void SendspinServerConnection::async_send_time_text(void* arg) {
     // Capture client_transmitted as close as possible to the actual send. The serialization
     // happens between this capture and the wire send; track its duration so the bias is
     // visible in the time_burst log. Stack buffer keeps the path heap-free.
-    char buf[96];
+    char buf[TIME_MESSAGE_BUF_SIZE];
     const int64_t client_transmitted = esp_timer_get_time();
     const size_t len = format_client_time_message(buf, sizeof(buf), client_transmitted);
 

--- a/src/esp/server_connection.cpp
+++ b/src/esp/server_connection.cpp
@@ -72,7 +72,7 @@ void SendspinServerConnection::disconnect(SendspinGoodbyeReason reason,
 
     // Send goodbye message, then trigger close, then invoke user callback
     // Capture on_complete by value to keep it alive until async callback fires
-    this->send_goodbye_reason(reason, [this, on_complete](bool success, int64_t) {
+    this->send_goodbye_reason(reason, [this, on_complete](bool success) {
         // Trigger close regardless of send success
         this->trigger_close();
 
@@ -94,7 +94,7 @@ SsErr SendspinServerConnection::send_text_message(const std::string& message,
     if (!this->is_connected()) {
         // No client connected - invoke callback with failure if provided
         if (on_complete) {
-            on_complete(false, 0);
+            on_complete(false);
         }
         return SsErr::INVALID_STATE;
     }
@@ -104,7 +104,7 @@ SsErr SendspinServerConnection::send_text_message(const std::string& message,
     if (resp_arg == nullptr) {
         SS_LOGE(TAG, "Failed to allocate AsyncRespArg for message send");
         if (on_complete) {
-            on_complete(false, 0);
+            on_complete(false);
         }
         return SsErr::NO_MEM;
     }
@@ -119,7 +119,7 @@ SsErr SendspinServerConnection::send_text_message(const std::string& message,
         resp_arg->~AsyncRespArg();
         platform_free(resp_arg);
         if (on_complete) {
-            on_complete(false, 0);
+            on_complete(false);
         }
         return SsErr::NO_MEM;
     }
@@ -138,7 +138,7 @@ SsErr SendspinServerConnection::send_text_message(const std::string& message,
         platform_free(resp_arg->payload);
         // Need to invoke callback with failure before destroying it
         if (resp_arg->has_callback) {
-            resp_arg->on_complete(false, 0);
+            resp_arg->on_complete(false);
         }
         resp_arg->~AsyncRespArg();
         platform_free(resp_arg);
@@ -262,8 +262,6 @@ void SendspinServerConnection::async_send_text(void* arg) {
     ws_pkt.type = HTTPD_WS_TYPE_TEXT;
 
     bool send_success = false;
-    const int64_t after_send_time = esp_timer_get_time();
-
     if (this_conn->is_connected()) {
         esp_err_t err = httpd_ws_send_frame_async(this_conn->server_, this_conn->sockfd_, &ws_pkt);
         send_success = (err == ESP_OK);
@@ -271,7 +269,7 @@ void SendspinServerConnection::async_send_text(void* arg) {
 
     // Call the completion callback if provided
     if (resp_arg->has_callback) {
-        resp_arg->on_complete(send_success, after_send_time);
+        resp_arg->on_complete(send_success);
     }
 
     platform_free(ws_pkt.payload);

--- a/src/esp/server_connection.cpp
+++ b/src/esp/server_connection.cpp
@@ -17,6 +17,7 @@
 #include "lwip/sockets.h"  // for setsockopt, IPPROTO_TCP, NODELAY
 #include "platform/logging.h"
 #include "platform/memory.h"
+#include "protocol_messages.h"
 #include <esp_timer.h>
 
 #include <cstring>
@@ -207,6 +208,48 @@ esp_err_t SendspinServerConnection::handle_data(httpd_req_t* req, int64_t receiv
     return ESP_OK;
 }
 
+bool SendspinServerConnection::send_time_message() {
+    if (!this->is_connected()) {
+        return false;
+    }
+
+    // The worker job only needs the connection pointer (no buffer to free), so pass `this`
+    // directly. The JSON is built inside the worker so client_transmitted is captured as
+    // close to the wire send as possible.
+    if (httpd_queue_work(this->server_, async_send_time_text, this) != ESP_OK) {
+        SS_LOGE(TAG, "httpd_queue_work failed for time message");
+        return false;
+    }
+    return true;
+}
+
+void SendspinServerConnection::async_send_time_text(void* arg) {
+    auto* this_conn = static_cast<SendspinServerConnection*>(arg);
+
+    if (!this_conn->is_connected()) {
+        return;
+    }
+
+    // Capture client_transmitted as close as possible to the actual send. The serialization
+    // happens between this capture and the wire send; track its duration so the bias is
+    // visible in the time_burst log. Stack buffer keeps the path heap-free.
+    char buf[96];
+    const int64_t client_transmitted = esp_timer_get_time();
+    const size_t len = format_client_time_message(buf, sizeof(buf), client_transmitted);
+    this_conn->update_serialize_ema(esp_timer_get_time() - client_transmitted);
+    if (len == 0) {
+        return;
+    }
+
+    httpd_ws_frame_t ws_pkt;
+    memset(&ws_pkt, 0, sizeof(httpd_ws_frame_t));
+    ws_pkt.payload = reinterpret_cast<uint8_t*>(buf);
+    ws_pkt.len = len;
+    ws_pkt.type = HTTPD_WS_TYPE_TEXT;
+
+    httpd_ws_send_frame_async(this_conn->server_, this_conn->sockfd_, &ws_pkt);
+}
+
 void SendspinServerConnection::async_send_text(void* arg) {
     struct AsyncRespArg* resp_arg = (AsyncRespArg*)arg;
     httpd_ws_frame_t ws_pkt;
@@ -219,12 +262,12 @@ void SendspinServerConnection::async_send_text(void* arg) {
     ws_pkt.type = HTTPD_WS_TYPE_TEXT;
 
     bool send_success = false;
+    const int64_t after_send_time = esp_timer_get_time();
+
     if (this_conn->is_connected()) {
         esp_err_t err = httpd_ws_send_frame_async(this_conn->server_, this_conn->sockfd_, &ws_pkt);
         send_success = (err == ESP_OK);
     }
-
-    const int64_t after_send_time = esp_timer_get_time();
 
     // Call the completion callback if provided
     if (resp_arg->has_callback) {

--- a/src/esp/server_connection.h
+++ b/src/esp/server_connection.h
@@ -91,6 +91,14 @@ public:
     /// @return SsErr::OK if queued successfully, error code otherwise.
     SsErr send_text_message(const std::string& message, SendCompleteCallback on_complete) override;
 
+    /// @brief Sends a client/time message, stamping the timestamp inside the httpd worker
+    ///
+    /// Schedules a worker job that captures `client_transmitted` and serializes the JSON
+    /// just before calling `httpd_ws_send_frame_async`, eliminating hub→worker queue latency
+    /// from the measured client timestamp.
+    /// @return true if the worker job was queued successfully, false otherwise.
+    bool send_time_message() override;
+
     /// @brief Triggers the underlying socket to close
     ///
     /// This is a low-level method that directly triggers the httpd session to close.
@@ -121,6 +129,13 @@ protected:
     /// @brief httpd_queue_work callback that sends a queued text frame over the WebSocket
     /// @param arg Pointer to the AsyncRespArg context allocated by send_text_message().
     static void async_send_text(void* arg);
+
+    /// @brief httpd_queue_work callback that builds and sends a client/time frame
+    ///
+    /// Captures the client_transmitted timestamp inside the worker (just before
+    /// `httpd_ws_send_frame_async`), serializes the JSON, then sends.
+    /// @param arg The owning `SendspinServerConnection*` (passed directly, not heap-allocated).
+    static void async_send_time_text(void* arg);
 
     // Pointer fields
 

--- a/src/host/client_connection.cpp
+++ b/src/host/client_connection.cpp
@@ -85,7 +85,7 @@ void SendspinClientConnection::disconnect(SendspinGoodbyeReason reason,
     }
 
     // Send goodbye message then stop
-    this->send_goodbye_reason(reason, [this, on_complete](bool /*success*/, int64_t) {
+    this->send_goodbye_reason(reason, [this, on_complete](bool /*success*/) {
         if (this->ws_) {
             this->ws_->stop();
         }
@@ -99,17 +99,16 @@ SsErr SendspinClientConnection::send_text_message(const std::string& message,
                                                   SendCompleteCallback cb) {
     if (!this->is_connected()) {
         if (cb) {
-            cb(false, 0);
+            cb(false);
         }
         return SsErr::INVALID_STATE;
     }
 
-    int64_t send_time = platform_time_us();
     auto info = this->ws_->send(message);
     bool success = info.success;
 
     if (cb) {
-        cb(success, send_time);
+        cb(success);
     }
 
     if (!success) {

--- a/src/host/client_connection.cpp
+++ b/src/host/client_connection.cpp
@@ -127,10 +127,10 @@ bool SendspinClientConnection::send_time_message() {
     char buf[96];
     const int64_t client_transmitted = platform_time_us();
     const size_t len = format_client_time_message(buf, sizeof(buf), client_transmitted);
-    this->update_serialize_ema(platform_time_us() - client_transmitted);
     if (len == 0) {
         return false;
     }
+    this->update_serialize_ema(platform_time_us() - client_transmitted);
     return this->ws_->send(std::string(buf, len)).success;
 }
 

--- a/src/host/client_connection.cpp
+++ b/src/host/client_connection.cpp
@@ -16,6 +16,7 @@
 
 #include "platform/logging.h"
 #include "platform/time.h"
+#include "protocol_messages.h"
 
 #include <algorithm>
 #include <chrono>
@@ -103,12 +104,12 @@ SsErr SendspinClientConnection::send_text_message(const std::string& message,
         return SsErr::INVALID_STATE;
     }
 
+    int64_t send_time = platform_time_us();
     auto info = this->ws_->send(message);
-    int64_t after_send_time = platform_time_us();
     bool success = info.success;
 
     if (cb) {
-        cb(success, after_send_time);
+        cb(success, send_time);
     }
 
     if (!success) {
@@ -117,6 +118,21 @@ SsErr SendspinClientConnection::send_text_message(const std::string& message,
     }
 
     return SsErr::OK;
+}
+
+bool SendspinClientConnection::send_time_message() {
+    if (!this->is_connected()) {
+        return false;
+    }
+
+    char buf[96];
+    const int64_t client_transmitted = platform_time_us();
+    const size_t len = format_client_time_message(buf, sizeof(buf), client_transmitted);
+    this->update_serialize_ema(platform_time_us() - client_transmitted);
+    if (len == 0) {
+        return false;
+    }
+    return this->ws_->send(std::string(buf, len)).success;
 }
 
 // ============================================================================

--- a/src/host/client_connection.cpp
+++ b/src/host/client_connection.cpp
@@ -124,7 +124,7 @@ bool SendspinClientConnection::send_time_message() {
         return false;
     }
 
-    char buf[96];
+    char buf[TIME_MESSAGE_BUF_SIZE];
     const int64_t client_transmitted = platform_time_us();
     const size_t len = format_client_time_message(buf, sizeof(buf), client_transmitted);
     if (len == 0) {

--- a/src/host/client_connection.h
+++ b/src/host/client_connection.h
@@ -74,6 +74,10 @@ public:
     /// @return SsErr::OK if queued successfully, error code otherwise.
     SsErr send_text_message(const std::string& message, SendCompleteCallback cb) override;
 
+    /// @brief Sends a client/time message, capturing the timestamp synchronously before send
+    /// @return true if the message was sent successfully, false otherwise.
+    bool send_time_message() override;
+
     /// @brief Enables or disables automatic reconnection after connection loss
     /// @param enabled True to reconnect automatically, false to stay disconnected.
     void set_auto_reconnect(bool enabled) {

--- a/src/host/client_connection.h
+++ b/src/host/client_connection.h
@@ -70,7 +70,7 @@ public:
 
     /// @brief Sends a text message to the server
     /// @param message The message string to send.
-    /// @param cb Callback invoked after send completes (success, actual_send_time).
+    /// @param cb Callback invoked after send completes.
     /// @return SsErr::OK if queued successfully, error code otherwise.
     SsErr send_text_message(const std::string& message, SendCompleteCallback cb) override;
 

--- a/src/host/server_connection.cpp
+++ b/src/host/server_connection.cpp
@@ -86,10 +86,10 @@ bool SendspinServerConnection::send_time_message() {
     char buf[96];
     const int64_t client_transmitted = platform_time_us();
     const size_t len = format_client_time_message(buf, sizeof(buf), client_transmitted);
-    this->update_serialize_ema(platform_time_us() - client_transmitted);
     if (len == 0) {
         return false;
     }
+    this->update_serialize_ema(platform_time_us() - client_transmitted);
     return this->ws_->send(std::string(buf, len)).success;
 }
 

--- a/src/host/server_connection.cpp
+++ b/src/host/server_connection.cpp
@@ -47,7 +47,7 @@ void SendspinServerConnection::disconnect(SendspinGoodbyeReason reason,
     }
 
     // Send goodbye message, then close
-    this->send_goodbye_reason(reason, [this, on_complete](bool /*success*/, int64_t) {
+    this->send_goodbye_reason(reason, [this, on_complete](bool /*success*/) {
         this->trigger_close();
         if (on_complete) {
             on_complete();
@@ -63,17 +63,16 @@ SsErr SendspinServerConnection::send_text_message(const std::string& message,
                                                   SendCompleteCallback on_complete) {
     if (!this->is_connected()) {
         if (on_complete) {
-            on_complete(false, 0);
+            on_complete(false);
         }
         return SsErr::INVALID_STATE;
     }
 
-    int64_t send_time = platform_time_us();
     auto info = this->ws_->send(message);
     bool success = info.success;
 
     if (on_complete) {
-        on_complete(success, send_time);
+        on_complete(success);
     }
 
     return success ? SsErr::OK : SsErr::FAIL;

--- a/src/host/server_connection.cpp
+++ b/src/host/server_connection.cpp
@@ -16,6 +16,7 @@
 
 #include "platform/logging.h"
 #include "platform/time.h"
+#include "protocol_messages.h"
 
 #include <algorithm>
 
@@ -67,15 +68,30 @@ SsErr SendspinServerConnection::send_text_message(const std::string& message,
         return SsErr::INVALID_STATE;
     }
 
+    int64_t send_time = platform_time_us();
     auto info = this->ws_->send(message);
-    int64_t after_send_time = platform_time_us();
     bool success = info.success;
 
     if (on_complete) {
-        on_complete(success, after_send_time);
+        on_complete(success, send_time);
     }
 
     return success ? SsErr::OK : SsErr::FAIL;
+}
+
+bool SendspinServerConnection::send_time_message() {
+    if (!this->is_connected()) {
+        return false;
+    }
+
+    char buf[96];
+    const int64_t client_transmitted = platform_time_us();
+    const size_t len = format_client_time_message(buf, sizeof(buf), client_transmitted);
+    this->update_serialize_ema(platform_time_us() - client_transmitted);
+    if (len == 0) {
+        return false;
+    }
+    return this->ws_->send(std::string(buf, len)).success;
 }
 
 void SendspinServerConnection::trigger_close() {

--- a/src/host/server_connection.cpp
+++ b/src/host/server_connection.cpp
@@ -83,7 +83,7 @@ bool SendspinServerConnection::send_time_message() {
         return false;
     }
 
-    char buf[96];
+    char buf[TIME_MESSAGE_BUF_SIZE];
     const int64_t client_transmitted = platform_time_us();
     const size_t len = format_client_time_message(buf, sizeof(buf), client_transmitted);
     if (len == 0) {

--- a/src/host/server_connection.h
+++ b/src/host/server_connection.h
@@ -72,7 +72,7 @@ public:
 
     /// @brief Sends a text message to the connected client
     /// @param message The message string to send.
-    /// @param on_complete Callback invoked after send completes (success, actual_send_time).
+    /// @param on_complete Callback invoked after send completes.
     /// @return SsErr::OK if sent successfully, error code otherwise.
     SsErr send_text_message(const std::string& message, SendCompleteCallback on_complete) override;
 

--- a/src/host/server_connection.h
+++ b/src/host/server_connection.h
@@ -76,6 +76,10 @@ public:
     /// @return SsErr::OK if sent successfully, error code otherwise.
     SsErr send_text_message(const std::string& message, SendCompleteCallback on_complete) override;
 
+    /// @brief Sends a client/time message, capturing the timestamp synchronously before send
+    /// @return true if the message was sent successfully, false otherwise.
+    bool send_time_message() override;
+
     /// @brief Requests the WebSocket connection to close
     void trigger_close();
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -819,6 +819,15 @@ std::string format_client_goodbye_message(SendspinGoodbyeReason reason) {
 
 namespace {
 
+/// Maximum decimal digits in a uint64_t value.
+static constexpr int MAX_UINT64_DIGITS = 19;
+
+/// Radix used for two-digit-at-a-time integer formatting.
+static constexpr uint64_t RADIX_100 = 100U;
+
+/// Threshold for single vs. two-digit final write.
+static constexpr uint64_t RADIX_10 = 10U;
+
 // Two-digit ASCII lookup. Index 2*N..2*N+1 holds the decimal digits of N for N in [0, 99].
 // Lets us emit two characters per 64-bit division instead of one, halving the libgcc
 // __udivdi3 calls, which are the expensive part on a 32-bit MCU.
@@ -863,7 +872,7 @@ inline int decimal_digits(uint64_t v) {
                                            100000000000000000ULL,
                                            1000000000000000000ULL,
                                            10000000000000000000ULL};
-    return approx + 1 + (v >= POW10[approx + 1]);
+    return approx + 1 + static_cast<int>(v >= POW10[approx + 1]);
 }
 
 }  // namespace
@@ -879,8 +888,8 @@ size_t format_client_time_message(char* buf, size_t cap, int64_t client_transmit
     static constexpr char SUFFIX[] = "}}";
     static constexpr size_t SUFFIX_LEN = sizeof(SUFFIX) - 1;
 
-    // Worst case: prefix + '-' + 19 digits + suffix.
-    if (cap < PREFIX_LEN + 1 + 19 + SUFFIX_LEN) {
+    // Worst case: prefix + '-' + MAX_UINT64_DIGITS digits + suffix.
+    if (cap < PREFIX_LEN + 1 + MAX_UINT64_DIGITS + SUFFIX_LEN) {
         return 0;
     }
 
@@ -888,7 +897,7 @@ size_t format_client_time_message(char* buf, size_t cap, int64_t client_transmit
     std::memcpy(p, PREFIX, PREFIX_LEN);
     p += PREFIX_LEN;
 
-    uint64_t v;
+    uint64_t v = 0;
     if (client_transmitted < 0) {
         *p++ = '-';
         // Cast through uint64_t to handle INT64_MIN without UB
@@ -902,16 +911,16 @@ size_t format_client_time_message(char* buf, size_t cap, int64_t client_transmit
     const int n = decimal_digits(v);
     char* end = p + n;
     char* w = end;
-    while (v >= 100U) {
-        const uint64_t q = v / 100U;
-        const uint32_t r = static_cast<uint32_t>(v - q * 100U);
+    while (v >= RADIX_100) {
+        const uint64_t q = v / RADIX_100;
+        const auto r = static_cast<size_t>(v - q * RADIX_100);
         w -= 2;
         std::memcpy(w, &TWO_DIGIT_TABLE[r * 2U], 2);
         v = q;
     }
-    if (v >= 10U) {
+    if (v >= RADIX_10) {
         w -= 2;
-        std::memcpy(w, &TWO_DIGIT_TABLE[v * 2U], 2);
+        std::memcpy(w, &TWO_DIGIT_TABLE[static_cast<size_t>(v) * 2U], 2);
     } else {
         w -= 1;
         *w = static_cast<char>('0' + v);

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -821,7 +821,7 @@ namespace {
 
 // Two-digit ASCII lookup. Index 2*N..2*N+1 holds the decimal digits of N for N in [0, 99].
 // Lets us emit two characters per 64-bit division instead of one, halving the libgcc
-// __udivdi3 calls — those are the expensive part on a 32-bit MCU.
+// __udivdi3 calls, which are the expensive part on a 32-bit MCU.
 constexpr char TWO_DIGIT_TABLE[201] = "00010203040506070809"
                                       "10111213141516171819"
                                       "20212223242526272829"

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -17,6 +17,10 @@
 #include "protocol_messages.h"
 #include <ArduinoJson.h>
 
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
 namespace sendspin {
 
 static const char* const TAG = "sendspin.protocol";
@@ -312,8 +316,7 @@ bool process_server_hello_message(JsonObject root, ServerHelloMessage* hello_msg
     return true;
 }
 
-bool process_server_time_message(JsonObject root, int64_t timestamp,
-                                 TimeTransmittedReplacement time_replacement, int64_t* offset,
+bool process_server_time_message(JsonObject root, int64_t timestamp, int64_t* offset,
                                  int64_t* max_error) {
     if (!root["payload"]["client_transmitted"].is<JsonVariant>() ||
         !root["payload"]["server_received"].is<JsonVariant>() ||
@@ -322,14 +325,7 @@ bool process_server_time_message(JsonObject root, int64_t timestamp,
         return false;
     }
 
-    int64_t client_transmitted = root["payload"]["client_transmitted"];
-
-    if (client_transmitted != time_replacement.transmitted_time) {
-        SS_LOGW(TAG, "Mismatched time message history, discarding measurement");
-        return false;
-    }
-    client_transmitted = time_replacement.actual_transmit_time;
-
+    const int64_t client_transmitted = root["payload"]["client_transmitted"];
     const int64_t server_received = root["payload"]["server_received"];
     const int64_t server_transmitted = root["payload"]["server_transmitted"];
     const int64_t client_received = timestamp;
@@ -819,6 +815,113 @@ std::string format_client_goodbye_message(SendspinGoodbyeReason reason) {
     std::string output;
     serializeJson(doc, output);
     return output;
+}
+
+namespace {
+
+// Two-digit ASCII lookup. Index 2*N..2*N+1 holds the decimal digits of N for N in [0, 99].
+// Lets us emit two characters per 64-bit division instead of one, halving the libgcc
+// __udivdi3 calls — those are the expensive part on a 32-bit MCU.
+constexpr char TWO_DIGIT_TABLE[201] = "00010203040506070809"
+                                      "10111213141516171819"
+                                      "20212223242526272829"
+                                      "30313233343536373839"
+                                      "40414243444546474849"
+                                      "50515253545556575859"
+                                      "60616263646566676869"
+                                      "70717273747576777879"
+                                      "80818283848586878889"
+                                      "90919293949596979899";
+
+// log10(v) + 1, computed without any division. Uses clz to get an approximate base-10 length
+// from the base-2 length, then a single table comparison to round to the exact value.
+inline int decimal_digits(uint64_t v) {
+    if (v == 0U) {
+        return 1;
+    }
+    // floor(log2(v)) for v != 0
+    const int log2 = 63 - __builtin_clzll(v);
+    // floor(log10(v)) ≈ floor(log2(v) * log10(2)). 1233 / 4096 ≈ 0.30108, accurate to within 1.
+    const int approx = (log2 * 1233) >> 12;
+    static constexpr uint64_t POW10[20] = {1ULL,
+                                           10ULL,
+                                           100ULL,
+                                           1000ULL,
+                                           10000ULL,
+                                           100000ULL,
+                                           1000000ULL,
+                                           10000000ULL,
+                                           100000000ULL,
+                                           1000000000ULL,
+                                           10000000000ULL,
+                                           100000000000ULL,
+                                           1000000000000ULL,
+                                           10000000000000ULL,
+                                           100000000000000ULL,
+                                           1000000000000000ULL,
+                                           10000000000000000ULL,
+                                           100000000000000000ULL,
+                                           1000000000000000000ULL,
+                                           10000000000000000000ULL};
+    return approx + 1 + (v >= POW10[approx + 1]);
+}
+
+}  // namespace
+
+size_t format_client_time_message(char* buf, size_t cap, int64_t client_transmitted) {
+    // Hot path on the time-sync send side. ESP-IDF newlib's snprintf("%lld", ...) costs ~50us
+    // for a single int64 because it instantiates a full printf state machine and does 64-bit
+    // division through generic code. We bypass it entirely: memcpy the two constant chunks
+    // around a hand-rolled int64-to-decimal conversion that uses clz for digit count and a
+    // two-digit-at-a-time write to halve the 64-bit division count.
+    static constexpr char PREFIX[] = R"({"type":"client/time","payload":{"client_transmitted":)";
+    static constexpr size_t PREFIX_LEN = sizeof(PREFIX) - 1;
+    static constexpr char SUFFIX[] = "}}";
+    static constexpr size_t SUFFIX_LEN = sizeof(SUFFIX) - 1;
+
+    // Worst case: prefix + '-' + 19 digits + suffix.
+    if (cap < PREFIX_LEN + 1 + 19 + SUFFIX_LEN) {
+        return 0;
+    }
+
+    char* p = buf;
+    std::memcpy(p, PREFIX, PREFIX_LEN);
+    p += PREFIX_LEN;
+
+    uint64_t v;
+    if (client_transmitted < 0) {
+        *p++ = '-';
+        // Cast through uint64_t to handle INT64_MIN without UB
+        v = static_cast<uint64_t>(-(client_transmitted + 1)) + 1U;
+    } else {
+        v = static_cast<uint64_t>(client_transmitted);
+    }
+
+    // Place the digit cursor at the end of the integer field and write backwards, two digits
+    // per loop iteration. The clz-based digit count means we know exactly where to start.
+    const int n = decimal_digits(v);
+    char* end = p + n;
+    char* w = end;
+    while (v >= 100U) {
+        const uint64_t q = v / 100U;
+        const uint32_t r = static_cast<uint32_t>(v - q * 100U);
+        w -= 2;
+        std::memcpy(w, &TWO_DIGIT_TABLE[r * 2U], 2);
+        v = q;
+    }
+    if (v >= 10U) {
+        w -= 2;
+        std::memcpy(w, &TWO_DIGIT_TABLE[v * 2U], 2);
+    } else {
+        w -= 1;
+        *w = static_cast<char>('0' + v);
+    }
+    p = end;
+
+    std::memcpy(p, SUFFIX, SUFFIX_LEN);
+    p += SUFFIX_LEN;
+
+    return static_cast<size_t>(p - buf);
 }
 
 std::string format_client_command_message(SendspinControllerCommand command,

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -820,13 +820,13 @@ std::string format_client_goodbye_message(SendspinGoodbyeReason reason) {
 namespace {
 
 /// Maximum decimal digits in a uint64_t value.
-static constexpr int MAX_UINT64_DIGITS = 19;
+constexpr int MAX_UINT64_DIGITS = 19;
 
 /// Radix used for two-digit-at-a-time integer formatting.
-static constexpr uint64_t RADIX_100 = 100U;
+constexpr uint64_t RADIX_100 = 100U;
 
 /// Threshold for single vs. two-digit final write.
-static constexpr uint64_t RADIX_10 = 10U;
+constexpr uint64_t RADIX_10 = 10U;
 
 // Two-digit ASCII lookup. Index 2*N..2*N+1 holds the decimal digits of N for N in [0, 99].
 // Lets us emit two characters per 64-bit division instead of one, halving the libgcc

--- a/src/protocol_messages.h
+++ b/src/protocol_messages.h
@@ -304,6 +304,10 @@ std::string format_stream_request_format_message(const StreamRequestFormatMessag
 /// @return Goodbye message serialized into JSON format.
 std::string format_client_goodbye_message(SendspinGoodbyeReason reason);
 
+/// Buffer size for format_client_time_message(). Fits the longest possible message:
+/// prefix (52) + '-' (1) + 19 digits + suffix (2) + padding = 75 bytes, rounded up.
+static constexpr size_t TIME_MESSAGE_BUF_SIZE = 96;
+
 /// @brief Formats a client/time JSON message into a caller-supplied buffer
 ///
 /// Hot path on the time-sync send side: avoids any heap allocation by writing the fixed-shape

--- a/src/protocol_messages.h
+++ b/src/protocol_messages.h
@@ -144,16 +144,6 @@ inline std::optional<SendspinConnectionReason> connection_reason_from_string(
     return std::nullopt;
 }
 
-/// @brief Holds the planned and actual transmit timestamps for a client/time message
-///
-/// When a client/time message is queued, the intended transmit time is stored. After the
-/// WebSocket layer sends it, the actual send time replaces the placeholder so the server
-/// can compute round-trip latency more accurately.
-struct TimeTransmittedReplacement {
-    int64_t transmitted_time = 0;
-    int64_t actual_transmit_time = 0;
-};
-
 // ============================================================================
 // Message envelope structs
 // ============================================================================
@@ -241,12 +231,10 @@ bool process_server_hello_message(JsonObject root, ServerHelloMessage* hello_msg
 /// @brief Parses a server/time JSON message and computes time offset and max error
 /// @param root Parsed JSON object from the message.
 /// @param timestamp Client timestamp when the message was received (microseconds).
-/// @param time_replacement Actual send time replacement from the outgoing time message.
 /// @param offset [out] Computed time offset between server and client clocks (microseconds).
 /// @param max_error [out] Upper bound on clock error from the round-trip (microseconds).
 /// @return true if parsing and computation succeeded, false otherwise.
-bool process_server_time_message(JsonObject root, int64_t timestamp,
-                                 TimeTransmittedReplacement time_replacement, int64_t* offset,
+bool process_server_time_message(JsonObject root, int64_t timestamp, int64_t* offset,
                                  int64_t* max_error);
 
 /// @brief Parses a group/update JSON message into the provided struct
@@ -315,6 +303,17 @@ std::string format_stream_request_format_message(const StreamRequestFormatMessag
 /// @param reason The reason for disconnecting.
 /// @return Goodbye message serialized into JSON format.
 std::string format_client_goodbye_message(SendspinGoodbyeReason reason);
+
+/// @brief Formats a client/time JSON message into a caller-supplied buffer
+///
+/// Hot path on the time-sync send side: avoids any heap allocation by writing the fixed-shape
+/// message directly into the caller's stack buffer. A 96-byte buffer is always large enough.
+/// @param buf Destination buffer.
+/// @param cap Capacity of `buf` in bytes (recommend >= 96).
+/// @param client_transmitted The client transmit timestamp (microseconds) — should be captured
+///                           as close as possible to the actual wire send.
+/// @return Number of bytes written (excluding any null terminator), or 0 on error.
+size_t format_client_time_message(char* buf, size_t cap, int64_t client_transmitted);
 
 /// @brief Formats a client/command message as a JSON string for sending to the server
 /// @param command The playback command to send.

--- a/src/protocol_messages.h
+++ b/src/protocol_messages.h
@@ -310,7 +310,7 @@ std::string format_client_goodbye_message(SendspinGoodbyeReason reason);
 /// message directly into the caller's stack buffer. A 96-byte buffer is always large enough.
 /// @param buf Destination buffer.
 /// @param cap Capacity of `buf` in bytes (recommend >= 96).
-/// @param client_transmitted The client transmit timestamp (microseconds) — should be captured
+/// @param client_transmitted The client transmit timestamp (microseconds). Should be captured
 ///                           as close as possible to the actual wire send.
 /// @return Number of bytes written (excluding any null terminator), or 0 on error.
 size_t format_client_time_message(char* buf, size_t cap, int64_t client_transmitted);

--- a/src/time_burst.cpp
+++ b/src/time_burst.cpp
@@ -76,10 +76,10 @@ TimeBurstResult SendspinTimeBurst::loop(SendspinConnection* conn) {
         return {.sent = false, .burst_completed = burst_completed_by_response};
     }
 
-    // State 3: Ready to send next message in burst
-    // The time replacement (transmitted_time + actual_transmit_time) is pushed to the
-    // connection's thread-safe queue internally by send_time_message's send callback.
-    bool queued = conn->send_time_message(nullptr);
+    // State 3: Ready to send next message in burst.
+    // The transport stamps client_transmitted at the actual send point (e.g., inside the
+    // httpd worker on ESP server), so no post-send replacement is needed.
+    bool queued = conn->send_time_message();
 
     if (queued) {
         conn->set_pending_time_message(true);


### PR DESCRIPTION
Currently, we capture the timestamp immediately after a time message is sent. When we get the response from the Sendspin server, we would replace the client sent timestamp with this other timestamp. This was a huge headache from a thread-safety standpoint! Even worse, on a host platform this, after sent timestamp could be nonsensical; e.g., it's captured after we got the response from the server. On an ESP32, this timestamp may be slightly better, but my recent tests show it's not particularly helpful for the overall time sync, so it is not worth the headache and diverged code paths.

- Adds a new serialization routine just for time messages that is as fast as possible to avoid biasing the filter. On an ESP32-S3, it takes 9 microseconds. On a host, it takes at most 1 microsecond. The duration is captured in an exponential moving average, so a future PR could use that to remove the minimal bias it introduces.
- Removes time message replacement code altogether, instead it just relies on the content of the time message alone
- Removes timestamps from the sent message callback as it is no longer used in any capacity