### PR TITLE
Expose static delay setting to sendspin server for the example clients

### DIFF
--- a/examples/basic_client/main.cpp
+++ b/examples/basic_client/main.cpp
@@ -203,6 +203,7 @@ int main(int argc, char* argv[]) {
         {SendspinCodecFormat::PCM, 2, 48000, 16},
     };
     auto& player = client.add_player(std::move(player_config));
+    player.set_static_delay_adjustable(true);
     auto& controller = client.add_controller();
     auto& metadata = client.add_metadata();
 

--- a/examples/tui_client/main.cpp
+++ b/examples/tui_client/main.cpp
@@ -495,6 +495,7 @@ int main(int argc, char* argv[]) {
     PlayerRole::Config player_config;
     player_config.audio_formats = std::move(audio_formats);
     auto& player = client.add_player(std::move(player_config));
+    player.set_static_delay_adjustable(true);
     auto& controller = client.add_controller();
     auto& metadata = client.add_metadata();
 


### PR DESCRIPTION
Support for this was added to the spec in https://github.com/Sendspin/spec/pull/67 and is now in Music Assistant [2.9.0 NIGHTLY 2026041504](https://github.com/music-assistant/server/releases/tag/2.9.0.dev2026041504)