### PR TITLE
Refactor to minimize public API using PIMPL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ The platform (e.g., ESPHome) provides:
 ## Project layout
 
 ```text
-include/sendspin/     - Public API headers (client.h, types.h, *_role.h)
+include/sendspin/     - Public API headers (client.h, config.h, types.h, *_role.h)
 src/                        - Cross-platform source files (.cpp) and private headers (.h)
 src/platform/               - Platform abstraction headers and host-only source files
 src/esp/                    - ESP-IDF networking implementations and headers
@@ -84,7 +84,7 @@ examples/tui_client/        - Terminal UI host example with PortAudio audio outp
 
 ### Header visibility
 
-- **Public** (`include/sendspin/`): `client.h`, `types.h`, and role headers (`player_role.h`, `controller_role.h`, `metadata_role.h`, `artwork_role.h`, `visualizer_role.h`). These are the consumer-facing API. Each role header defines its own protocol types (enums, structs, conversion functions). `types.h` contains shared types used across the client and roles.
+- **Public** (`include/sendspin/`): `client.h`, `config.h`, `types.h`, and role headers (`player_role.h`, `controller_role.h`, `metadata_role.h`, `artwork_role.h`, `visualizer_role.h`). These are the consumer-facing API. `config.h` contains all configuration structs (`SendspinClientConfig` and role configs). Each role header defines its own protocol types (enums, structs, conversion functions). `types.h` contains shared types used across the client and roles.
 - **Private** (`src/`): All internal headers (decoder, sync_task, time_filter, ring buffers, protocol_messages, etc.). Not exposed to consumers. `protocol_messages.h` contains message envelope structs, internal protocol enums, and protocol function declarations.
 - **Platform-specific** (`src/esp/`, `src/host/`): Networking headers with the same names (`client_connection.h`, `server_connection.h`, `ws_server.h`) but different implementations per platform.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,9 @@ The library provides `SendspinClient` as the main public API. It handles the ful
 
 ### Role composition
 
-Roles are added to the client at runtime via `add_player()`, `add_metadata()`, etc. Each role receives a `SendspinClient*` at construction time and uses it to access shared services (time sync, state publishing, message sending). The consumer provides behavior by implementing listener interfaces (`PlayerRoleListener`, `MetadataRoleListener`, etc.) and setting them via `set_listener()`. Required callbacks are pure virtual; optional callbacks have default no-op implementations. The client dispatches messages to roles via null-pointer checks on role pointers; no preprocessor guards.
+Roles are added to the client at runtime via `add_player()`, `add_metadata()`, etc. Each role receives a `SendspinClient*` at construction time and uses it to access shared services (time sync, state publishing, message sending). The consumer provides behavior by implementing listener interfaces (`PlayerRoleListener`, `MetadataRoleListener`, etc.) and setting them via `set_listener()`. Required callbacks are pure virtual; optional callbacks have default no-op implementations. The client dispatches messages to roles via null-pointer checks on role pointers.
+
+Roles can be disabled at compile time via `SENDSPIN_ENABLE_*` cmake options (host build) or Kconfig entries (ESP-IDF build). When a role is disabled, its source files are not compiled and its `add_*()` declaration, accessor, and `unique_ptr` member are removed from `client.h`. `#ifdef` guards live in exactly two places: `cmake/sources.cmake` (source lists) and `include/sendspin/client.h` / `src/client.cpp` (dispatch points).
 
 ```cpp
 // Implement listener interfaces
@@ -117,7 +119,7 @@ Core source files in `src/` have no `#ifdef ESP_PLATFORM` guards; all platform d
 - Logging: Platform macros `SS_LOGE`, `SS_LOGW`, `SS_LOGI`, `SS_LOGD`, `SS_LOGV` (not raw `ESP_LOG*`)
 - Memory: `platform_malloc`/`platform_realloc`/`platform_free` from `platform/memory.h` (not raw `heap_caps_malloc`)
 - Threading: `std::mutex`, `std::thread` (via pthreads on both platforms). ESP build also uses FreeRTOS primitives (`xRingbuffer`, queues, event groups) for performance via the platform abstraction layer.
-- Role composition: Roles are added at runtime via `add_player()`, `add_metadata()`, etc. No compile-time feature flags in library code. Audio codec dependencies (micro-flac, micro-opus) are always linked.
+- Role composition: Roles are added at runtime via `add_player()`, `add_metadata()`, etc. Roles can be disabled at compile time via `SENDSPIN_ENABLE_*` cmake options / Kconfig entries. Audio codec dependencies (micro-flac, micro-opus) are only linked when the player role is enabled.
 - Apache 2.0 license headers on all files
 
 ## Pre-commit hooks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,16 +41,51 @@ if(ESP_IDF_BUILD)
     # Collect sources
     sendspin_get_sources(${SENDSPIN_COMPONENT_DIR})
 
-    set(SENDSPIN_REQUIRES esp_http_server esp_timer esp_ringbuf pthread mbedtls bblanchon__arduinojson esphome__micro-flac esphome__micro-opus)
+    # Assemble source list from core + enabled roles (driven by Kconfig)
+    set(SENDSPIN_ALL_SOURCES ${SENDSPIN_CORE_SOURCES} ${SENDSPIN_ESP_SOURCES})
 
-    # Register the component — uses both common and ESP-specific sources
+    set(SENDSPIN_REQUIRES esp_http_server esp_timer esp_ringbuf pthread mbedtls bblanchon__arduinojson)
+    set(SENDSPIN_COMPILE_DEFS "")
+
+    if(CONFIG_SENDSPIN_ENABLE_PLAYER)
+        list(APPEND SENDSPIN_ALL_SOURCES ${SENDSPIN_PLAYER_SOURCES})
+        list(APPEND SENDSPIN_REQUIRES esphome__micro-flac esphome__micro-opus)
+        list(APPEND SENDSPIN_COMPILE_DEFS SENDSPIN_ENABLE_PLAYER)
+    endif()
+
+    if(CONFIG_SENDSPIN_ENABLE_CONTROLLER)
+        list(APPEND SENDSPIN_ALL_SOURCES ${SENDSPIN_CONTROLLER_SOURCES})
+        list(APPEND SENDSPIN_COMPILE_DEFS SENDSPIN_ENABLE_CONTROLLER)
+    endif()
+
+    if(CONFIG_SENDSPIN_ENABLE_METADATA)
+        list(APPEND SENDSPIN_ALL_SOURCES ${SENDSPIN_METADATA_SOURCES})
+        list(APPEND SENDSPIN_COMPILE_DEFS SENDSPIN_ENABLE_METADATA)
+    endif()
+
+    if(CONFIG_SENDSPIN_ENABLE_ARTWORK)
+        list(APPEND SENDSPIN_ALL_SOURCES ${SENDSPIN_ARTWORK_SOURCES})
+        list(APPEND SENDSPIN_COMPILE_DEFS SENDSPIN_ENABLE_ARTWORK)
+    endif()
+
+    if(CONFIG_SENDSPIN_ENABLE_VISUALIZER)
+        list(APPEND SENDSPIN_ALL_SOURCES ${SENDSPIN_VISUALIZER_SOURCES})
+        list(APPEND SENDSPIN_COMPILE_DEFS SENDSPIN_ENABLE_VISUALIZER)
+    endif()
+
+    # Register the component — uses assembled source list
     idf_component_register(
-        SRCS ${SENDSPIN_COMMON_SOURCES} ${SENDSPIN_ESP_SOURCES}
+        SRCS ${SENDSPIN_ALL_SOURCES}
         INCLUDE_DIRS "include"
         PRIV_INCLUDE_DIRS "src" "src/esp"
         REQUIRES ${SENDSPIN_REQUIRES}
         PRIV_REQUIRES espressif__esp_websocket_client
     )
+
+    # Apply compile definitions for enabled roles
+    foreach(DEF ${SENDSPIN_COMPILE_DEFS})
+        target_compile_definitions(${COMPONENT_LIB} PUBLIC ${DEF})
+    endforeach()
 
     # Apply ESP-IDF configuration
     sendspin_configure_esp_idf(${COMPONENT_LIB} ${COMPONENT_DIR})
@@ -62,13 +97,56 @@ if(ESP_IDF_BUILD)
 else()
     project(sendspin VERSION 0.1.0 LANGUAGES CXX)
 
+    # Role selection options
+    option(SENDSPIN_ENABLE_PLAYER "Enable player role (audio decoding)" ON)
+    option(SENDSPIN_ENABLE_CONTROLLER "Enable controller role" ON)
+    option(SENDSPIN_ENABLE_METADATA "Enable metadata role" ON)
+    option(SENDSPIN_ENABLE_ARTWORK "Enable artwork role" ON)
+    option(SENDSPIN_ENABLE_VISUALIZER "Enable visualizer role" ON)
+
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/host.cmake)
 
     # Get sources
     sendspin_get_sources(${CMAKE_CURRENT_SOURCE_DIR})
 
-    # Create the library — common sources + host networking (added via host.cmake)
-    add_library(sendspin STATIC ${SENDSPIN_COMMON_SOURCES})
+    # Assemble source list from core + enabled roles
+    set(SENDSPIN_ALL_SOURCES ${SENDSPIN_CORE_SOURCES})
+
+    if(SENDSPIN_ENABLE_PLAYER)
+        list(APPEND SENDSPIN_ALL_SOURCES ${SENDSPIN_PLAYER_SOURCES})
+    endif()
+    if(SENDSPIN_ENABLE_CONTROLLER)
+        list(APPEND SENDSPIN_ALL_SOURCES ${SENDSPIN_CONTROLLER_SOURCES})
+    endif()
+    if(SENDSPIN_ENABLE_METADATA)
+        list(APPEND SENDSPIN_ALL_SOURCES ${SENDSPIN_METADATA_SOURCES})
+    endif()
+    if(SENDSPIN_ENABLE_ARTWORK)
+        list(APPEND SENDSPIN_ALL_SOURCES ${SENDSPIN_ARTWORK_SOURCES})
+    endif()
+    if(SENDSPIN_ENABLE_VISUALIZER)
+        list(APPEND SENDSPIN_ALL_SOURCES ${SENDSPIN_VISUALIZER_SOURCES})
+    endif()
+
+    # Create the library — core sources + enabled role sources + host networking (added via host.cmake)
+    add_library(sendspin STATIC ${SENDSPIN_ALL_SOURCES})
+
+    # Add compile definitions for enabled roles
+    if(SENDSPIN_ENABLE_PLAYER)
+        target_compile_definitions(sendspin PUBLIC SENDSPIN_ENABLE_PLAYER)
+    endif()
+    if(SENDSPIN_ENABLE_CONTROLLER)
+        target_compile_definitions(sendspin PUBLIC SENDSPIN_ENABLE_CONTROLLER)
+    endif()
+    if(SENDSPIN_ENABLE_METADATA)
+        target_compile_definitions(sendspin PUBLIC SENDSPIN_ENABLE_METADATA)
+    endif()
+    if(SENDSPIN_ENABLE_ARTWORK)
+        target_compile_definitions(sendspin PUBLIC SENDSPIN_ENABLE_ARTWORK)
+    endif()
+    if(SENDSPIN_ENABLE_VISUALIZER)
+        target_compile_definitions(sendspin PUBLIC SENDSPIN_ENABLE_VISUALIZER)
+    endif()
 
     # Host build options
     option(ENABLE_WERROR "Treat warnings as errors" OFF)

--- a/Kconfig
+++ b/Kconfig
@@ -5,4 +5,24 @@ menu "sendspin-cpp"
         default y
         select HTTPD_WS_SUPPORT
 
+    config SENDSPIN_ENABLE_PLAYER
+        bool "Enable player role (audio decode/playback)"
+        default y
+
+    config SENDSPIN_ENABLE_CONTROLLER
+        bool "Enable controller role"
+        default y
+
+    config SENDSPIN_ENABLE_METADATA
+        bool "Enable metadata role"
+        default y
+
+    config SENDSPIN_ENABLE_ARTWORK
+        bool "Enable artwork role"
+        default y
+
+    config SENDSPIN_ENABLE_VISUALIZER
+        bool "Enable visualizer role"
+        default y
+
 endmenu

--- a/cmake/host.cmake
+++ b/cmake/host.cmake
@@ -58,24 +58,27 @@ function(sendspin_configure_host TARGET_LIB SOURCE_DIR)
         ARDUINOJSON_USE_LONG_LONG=1
     )
 
-    # micro-flac and micro-opus (audio codec libraries, required by decoder)
-    FetchContent_Declare(
-        micro_flac
-        GIT_REPOSITORY https://github.com/esphome-libs/micro-flac.git
-        GIT_TAG        v0.1.1
-        GIT_SUBMODULES "lib/micro-ogg-demuxer"
-    )
-    FetchContent_MakeAvailable(micro_flac)
-    target_link_libraries(${TARGET_LIB} PUBLIC micro_flac)
+    # micro-flac and micro-opus (audio codec libraries, required by player/decoder)
+    # Only fetched and linked when the player role is enabled.
+    if(SENDSPIN_ENABLE_PLAYER)
+        FetchContent_Declare(
+            micro_flac
+            GIT_REPOSITORY https://github.com/esphome-libs/micro-flac.git
+            GIT_TAG        v0.1.1
+            GIT_SUBMODULES "lib/micro-ogg-demuxer"
+        )
+        FetchContent_MakeAvailable(micro_flac)
+        target_link_libraries(${TARGET_LIB} PUBLIC micro_flac)
 
-    FetchContent_Declare(
-        micro_opus
-        GIT_REPOSITORY https://github.com/esphome-libs/micro-opus.git
-        GIT_TAG        v0.3.5
-        GIT_SUBMODULES "lib/opus" "lib/micro-ogg-demuxer"
-    )
-    FetchContent_MakeAvailable(micro_opus)
-    target_link_libraries(${TARGET_LIB} PUBLIC micro_opus)
+        FetchContent_Declare(
+            micro_opus
+            GIT_REPOSITORY https://github.com/esphome-libs/micro-opus.git
+            GIT_TAG        v0.3.5
+            GIT_SUBMODULES "lib/opus" "lib/micro-ogg-demuxer"
+        )
+        FetchContent_MakeAvailable(micro_opus)
+        target_link_libraries(${TARGET_LIB} PUBLIC micro_opus)
+    endif()
 
     # IXWebSocket (WebSocket server/client for host networking)
     set(USE_TLS OFF CACHE BOOL "" FORCE)

--- a/cmake/sources.cmake
+++ b/cmake/sources.cmake
@@ -1,8 +1,8 @@
 # Source file definitions for sendspin-cpp
 
 function(sendspin_get_sources BASE_DIR)
-    # Common sources — build on both ESP-IDF and host
-    set(SENDSPIN_COMMON_SOURCES
+    # Core sources — always compiled on both ESP-IDF and host
+    set(SENDSPIN_CORE_SOURCES
         # Audio utilities
         ${BASE_DIR}/src/audio_stream_info.cpp
         ${BASE_DIR}/src/transfer_buffer.cpp
@@ -17,23 +17,45 @@ function(sendspin_get_sources BASE_DIR)
         # Connection base class
         ${BASE_DIR}/src/connection.cpp
 
-        # Audio pipeline
+        # Connection management
+        ${BASE_DIR}/src/connection_manager.cpp
+
+        # Client orchestration
+        ${BASE_DIR}/src/client.cpp
+
+        PARENT_SCOPE
+    )
+
+    # Per-role source sets — conditionally compiled based on SENDSPIN_ENABLE_* options
+    set(SENDSPIN_PLAYER_SOURCES
+        ${BASE_DIR}/src/player_role.cpp
         ${BASE_DIR}/src/audio_ring_buffer.cpp
         ${BASE_DIR}/src/decoder.cpp
         ${BASE_DIR}/src/sync_task.cpp
 
-        # Connection management
-        ${BASE_DIR}/src/connection_manager.cpp
+        PARENT_SCOPE
+    )
 
-        # Role classes
-        ${BASE_DIR}/src/player_role.cpp
+    set(SENDSPIN_CONTROLLER_SOURCES
         ${BASE_DIR}/src/controller_role.cpp
-        ${BASE_DIR}/src/metadata_role.cpp
-        ${BASE_DIR}/src/artwork_role.cpp
-        ${BASE_DIR}/src/visualizer_role.cpp
 
-        # Client orchestration
-        ${BASE_DIR}/src/client.cpp
+        PARENT_SCOPE
+    )
+
+    set(SENDSPIN_METADATA_SOURCES
+        ${BASE_DIR}/src/metadata_role.cpp
+
+        PARENT_SCOPE
+    )
+
+    set(SENDSPIN_ARTWORK_SOURCES
+        ${BASE_DIR}/src/artwork_role.cpp
+
+        PARENT_SCOPE
+    )
+
+    set(SENDSPIN_VISUALIZER_SOURCES
+        ${BASE_DIR}/src/visualizer_role.cpp
 
         PARENT_SCOPE
     )

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -50,7 +50,7 @@ Add only the roles your application needs. All roles must be added before callin
 The player role handles audio decoding and synchronized playback. It requires a configuration struct that declares which audio formats your hardware supports.
 
 ```cpp
-PlayerRole::Config player_config;
+PlayerRoleConfig player_config;
 player_config.audio_formats = {
     {SendspinCodecFormat::FLAC, 2, 44100, 16},
     {SendspinCodecFormat::FLAC, 2, 48000, 16},
@@ -100,7 +100,7 @@ auto& metadata = client.add_metadata();
 Receives album artwork images from the server. Requires a configuration struct declaring preferred image formats per slot.
 
 ```cpp
-ArtworkRole::Config artwork_config;
+ArtworkRoleConfig artwork_config;
 artwork_config.preferred_formats = {
     {0, SendspinImageSource::ALBUM, SendspinImageFormat::JPEG, 300, 300},
 };
@@ -566,7 +566,7 @@ int main() {
 
     SendspinClient client(std::move(config));
 
-    PlayerRole::Config player_config;
+    PlayerRoleConfig player_config;
     player_config.audio_formats = {{SendspinCodecFormat::PCM, 2, 44100, 16}};
     auto& player = client.add_player(std::move(player_config));
 
@@ -608,7 +608,7 @@ Main client configuration passed to the `SendspinClient` constructor.
 
 ---
 
-### PlayerRole::Config
+### PlayerRoleConfig
 
 Configuration passed to `client.add_player()`.
 
@@ -632,7 +632,7 @@ Each entry in `audio_formats` is an `AudioSupportedFormatObject`:
 
 ---
 
-### ArtworkRole::Config
+### ArtworkRoleConfig
 
 Configuration passed to `client.add_artwork()`.
 
@@ -654,7 +654,7 @@ Each entry in `preferred_formats` is an `ImageSlotPreference`:
 
 ---
 
-### VisualizerRole::Config
+### VisualizerRoleConfig
 
 Configuration passed to `client.add_visualizer()`.
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -197,7 +197,7 @@ player.notify_audio_played(frames_played, current_timestamp_us);
 ```
 
 - `frames_played`: Number of audio frames (not bytes) just played
-- `timestamp`: Server timestamp corresponding to the played position
+- `timestamp`: Client timestamp in microseconds when the audio will finish playing (e.g., from `std::chrono::steady_clock`)
 
 This method is thread-safe and is expected to be called from an audio callback thread.
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -17,11 +17,18 @@ The only role with a required callback is the player role (`on_audio_write`). Al
 
 ## Headers
 
-Include `sendspin/client.h` to get the full public API. It pulls in all role headers and `types.h` transitively.
+Include `sendspin/client.h` for the client class, config types, and shared types. Role headers must be included explicitly for any roles you use:
 
 ```cpp
-#include "sendspin/client.h"
+#include "sendspin/client.h"          // SendspinClient, config types, types.h
+#include "sendspin/player_role.h"     // PlayerRole, PlayerRoleListener
+#include "sendspin/controller_role.h" // ControllerRole, ControllerRoleListener
+#include "sendspin/metadata_role.h"   // MetadataRole, MetadataRoleListener
+#include "sendspin/artwork_role.h"    // ArtworkRole, ArtworkRoleListener
+#include "sendspin/visualizer_role.h" // VisualizerRole, VisualizerRoleListener
 ```
+
+Only include the role headers you need. `client.h` includes `sendspin/config.h` and `sendspin/types.h` transitively.
 
 ## Step 1: Configure and Create the Client
 
@@ -165,7 +172,7 @@ struct MyPlayerListener : PlayerRoleListener {
         my_audio_output.clear();
     }
 
-    // Optional: Called when the server changes the volume (0-100).
+    // Optional: Called when the server changes the volume.
     void on_volume_changed(uint8_t volume) override {
         my_audio_output.set_volume(volume);
     }
@@ -190,7 +197,7 @@ player.notify_audio_played(frames_played, current_timestamp_us);
 ```
 
 - `frames_played`: Number of audio frames (not bytes) just played
-- `current_timestamp_us`: Current monotonic timestamp in microseconds (e.g., from `std::chrono::steady_clock`)
+- `timestamp`: Server timestamp corresponding to the played position
 
 This method is thread-safe and is expected to be called from an audio callback thread.
 
@@ -472,6 +479,8 @@ if (auto* v = client.visualizer()) { /* ... */ }
 
 Use these accessors when the role reference from `add_*()` is out of scope.
 
+> **Note:** Role registration methods (`add_player()`, etc.), accessor methods (`player()`, etc.), and their backing members are conditionally compiled based on `SENDSPIN_ENABLE_*` flags. When a role is disabled at build time, calling `add_player()` or `client.player()` is a compile error, not a runtime nullptr. See [Compile-Time Role Selection](#compile-time-role-selection) below.
+
 ## Updating Player State
 
 Report local state changes back to the server:
@@ -504,14 +513,12 @@ The client and roles expose query methods for polling state in your main loop or
 bool connected = client.is_connected();       // Active connection with completed handshake
 bool synced = client.is_time_synced();         // Time filter has received at least one measurement
 std::string group = client.get_group_name();   // Current group name (empty if none)
-std::string gid = client.get_group_id();       // Current group ID (empty if none)
 
 // Player state
 uint8_t vol = player.get_volume();
 bool muted = player.get_muted();
 uint16_t delay = player.get_static_delay_ms();
 int32_t fixed = player.get_fixed_delay_us();
-size_t buf_size = player.get_buffer_size();
 auto& stream = player.get_current_stream_params();
 
 // Controller state
@@ -546,6 +553,7 @@ A minimal integration that receives and discards audio:
 
 ```cpp
 #include "sendspin/client.h"
+#include "sendspin/player_role.h"
 
 using namespace sendspin;
 
@@ -583,6 +591,55 @@ int main() {
     }
 }
 ```
+
+## Compile-Time Role Selection
+
+By default all roles are enabled. You can disable roles at build time to exclude their code (and dependencies like audio decoders) from the binary. This is useful on constrained targets where flash space matters.
+
+### CMake (Host Builds)
+
+Pass `-D` options to cmake:
+
+```bash
+# Disable the player role (excludes decoder, sync task, audio ring buffer)
+cmake -B build -DSENDSPIN_ENABLE_PLAYER=OFF
+
+# Disable all optional roles, keep only the player
+cmake -B build -DSENDSPIN_ENABLE_CONTROLLER=OFF \
+               -DSENDSPIN_ENABLE_METADATA=OFF \
+               -DSENDSPIN_ENABLE_ARTWORK=OFF \
+               -DSENDSPIN_ENABLE_VISUALIZER=OFF
+```
+
+Available options (all `ON` by default):
+
+| Option | Controls |
+|---|---|
+| `SENDSPIN_ENABLE_PLAYER` | Player role, audio decoders (micro-flac, micro-opus), sync task |
+| `SENDSPIN_ENABLE_CONTROLLER` | Controller role |
+| `SENDSPIN_ENABLE_METADATA` | Metadata role |
+| `SENDSPIN_ENABLE_ARTWORK` | Artwork role |
+| `SENDSPIN_ENABLE_VISUALIZER` | Visualizer role |
+
+When `SENDSPIN_ENABLE_PLAYER` is `OFF`, the micro-flac and micro-opus dependencies are not fetched.
+
+### ESP-IDF (Kconfig)
+
+Role flags are exposed via Kconfig under `Component config → sendspin-cpp`:
+
+```kconfig
+CONFIG_SENDSPIN_ENABLE_PLAYER=y
+CONFIG_SENDSPIN_ENABLE_CONTROLLER=y
+CONFIG_SENDSPIN_ENABLE_METADATA=y
+CONFIG_SENDSPIN_ENABLE_ARTWORK=y
+CONFIG_SENDSPIN_ENABLE_VISUALIZER=y
+```
+
+### Effect on the API
+
+When a role is disabled, its `add_*()` method, accessor method, and backing member are removed from `client.h` via `#ifdef` guards. Attempting to call `client.add_player()` when `SENDSPIN_ENABLE_PLAYER` is `OFF` produces a compile error. The corresponding role header can still be included (it defines protocol types and the listener interface), but the role class cannot be instantiated.
+
+---
 
 ## Configuration Reference
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -20,7 +20,7 @@ The only role with a required callback is the player role (`on_audio_write`). Al
 Include `sendspin/client.h` for the client class, config types, and shared types. Role headers must be included explicitly for any roles you use:
 
 ```cpp
-#include "sendspin/client.h"          // SendspinClient, config types, types.h
+#include "sendspin/client.h"          // SendspinClient, providers, listeners
 #include "sendspin/player_role.h"     // PlayerRole, PlayerRoleListener
 #include "sendspin/controller_role.h" // ControllerRole, ControllerRoleListener
 #include "sendspin/metadata_role.h"   // MetadataRole, MetadataRoleListener
@@ -28,7 +28,7 @@ Include `sendspin/client.h` for the client class, config types, and shared types
 #include "sendspin/visualizer_role.h" // VisualizerRole, VisualizerRoleListener
 ```
 
-Only include the role headers you need. `client.h` includes `sendspin/config.h` and `sendspin/types.h` transitively.
+Only include the role headers you need. `client.h` includes `sendspin/config.h` (all configuration structs, including `SendspinClientConfig`) and `sendspin/types.h` transitively.
 
 ## Step 1: Configure and Create the Client
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -116,7 +116,7 @@ Used for:
 - **`std::mutex`** on `SendspinTimeFilter::state_mutex_`: protects Kalman filter state (offset, drift, covariance).
 - **`std::atomic<bool>`** on `SendspinConnection::message_dispatch_enabled_`: allows the main loop to instantly suppress message delivery from the network thread.
 - **`std::atomic<bool/uint8_t/size_t>`** on `VisualizerRole::Impl`: network thread writes stream config atomically; drain thread reads it.
-- **`std::atomic<bool>`** on `ArtworkRole::Impl::stream_active_`: guards `handle_binary()` from writing when no stream is active.
+- **`std::atomic<bool>`** on `ArtworkRole::Impl::stream_active`: guards `handle_binary()` from writing when no stream is active.
 - **`std::atomic<uint8_t>`** on `ArtworkRole::Impl::SlotBuffer::write_idx`: tracks which of two double-buffers the network thread writes to next.
 - **`std::atomic<bool>`** on `ArtworkRole::Impl::SlotBuffer::drain_active`: set by the drain thread while decoding, checked by the network thread to avoid overwriting an in-use buffer.
 - **`std::atomic<uint8_t>`** on `SendspinClient::high_performance_ref_count_`: ref-counted high-performance networking requests from time sync and playback.

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -2,6 +2,14 @@
 
 This document describes the internal architecture of the sendspin-cpp library, focusing on threading, inter-class communication, and the ordering guarantees that keep everything correct.
 
+## Pimpl Architecture
+
+Each role class uses the pimpl (pointer to implementation) pattern. The public header (`include/sendspin/<role>_role.h`) exposes only the consumer-facing API: protocol types, the listener interface, and a thin role class with `struct Impl; std::unique_ptr<Impl> impl_;`. All private state, internal methods, and thread-management code live in a private impl header (`src/<role>_role_impl.h`) and the corresponding `.cpp` file.
+
+`SendspinClient` is a `friend` of each role class, giving it access to `impl_->` for internal dispatch (message routing, event draining, lifecycle management). The `SyncTask` holds a `PlayerRole::Impl*` directly (passed at init time), so it accesses player state without indirection through the public `PlayerRole` class.
+
+Throughout this document, internal field and method references use the `Impl` qualification (e.g., `PlayerRole::Impl::drain_events()`) to reflect the actual code location.
+
 ## Thread Model
 
 The library uses a small number of long-lived threads. All state mutations and user-facing callbacks happen on the caller's main loop thread unless explicitly noted otherwise.
@@ -11,36 +19,36 @@ The library uses a small number of long-lived threads. All state mutations and u
 | Thread | Name | Created by | Stack (ESP) | Priority (ESP) | Purpose |
 |--------|------|-----------|-------------|-----------------|---------|
 | **Main loop** | (caller's) | User code | - | - | Drives `SendspinClient::loop()`. All role event processing and listener callbacks run here. |
-| **Sync task** | `Sendspin` | `PlayerRole::start()` → `SyncTask::start()` | 6192 B | 2 | Decodes audio, synchronizes to server timestamps, writes PCM to the audio sink via `on_audio_write`. |
-| **Visualizer drain** | `SsVis` | `VisualizerRole::start()` | 4096 B | 2 | Reads visualization frames from a ring buffer and delivers them to the listener at the correct playback time. |
-| **Artwork drain** | `SsArt` | `ArtworkRole::start()` | 4096 B | 2 | Receives image notifications, calls decode callback, then waits for the correct timestamp to call the display callback. |
+| **Sync task** | `Sendspin` | `PlayerRole::Impl::start()` → `SyncTask::start()` | 6192 B | 2 | Decodes audio, synchronizes to server timestamps, writes PCM to the audio sink via `on_audio_write`. |
+| **Visualizer drain** | `SsVis` | `VisualizerRole::Impl::start()` | 4096 B | 2 | Reads visualization frames from a ring buffer and delivers them to the listener at the correct playback time. |
+| **Artwork drain** | `SsArt` | `ArtworkRole::Impl::start()` | 4096 B | 2 | Receives image notifications, calls decode callback, then waits for the correct timestamp to call the display callback. |
 | **Network** | (library-internal) | IXWebSocket (host) or esp_http_server (ESP) | - | - | WebSocket I/O. Callbacks fire on these threads and must defer work to the main loop. |
 
 On host builds, `platform_configure_thread()` is a no-op; threads use OS defaults. On ESP-IDF it calls `esp_pthread_set_cfg()` to set stack size, priority, name, and optional PSRAM allocation before the `std::thread` is constructed.
 
 ### Thread Lifecycle
 
-**Sync task** (`src/sync_task.cpp:92`):
+**Sync task** (`src/sync_task.cpp:620`):
 
 1. `SyncTask::start()` configures the thread and spawns it.
 2. The caller blocks until the thread reaches IDLE state (`TASK_IDLE` event flag) or exits early due to an allocation failure (`TASK_STOPPED`).
 3. The thread runs a persistent outer loop for the lifetime of the client.
-4. `SyncTask::stop_()` sets `COMMAND_STOP` and joins the thread. Called from `SyncTask`'s destructor, which is triggered by `sync_task_.reset()` in `PlayerRole`'s destructor.
+4. `SyncTask::stop()` sets `COMMAND_STOP` and joins the thread. Called from `SyncTask`'s destructor, which is triggered by `sync_task_.reset()` in `PlayerRole::Impl`'s destructor.
 
-**Visualizer drain** (`src/visualizer_role.cpp:122`):
+**Visualizer drain** (`src/visualizer_role.cpp:120`):
 
-1. `VisualizerRole::start()` spawns the drain thread.
+1. `VisualizerRole::Impl::start()` spawns the drain thread.
 2. The thread blocks on ring buffer receives with a 50 ms timeout.
-3. `VisualizerRole::stop_()` sets `COMMAND_STOP` and joins.
+3. `VisualizerRole::Impl` destructor sets `COMMAND_STOP` and joins.
 
 **Artwork drain** (`src/artwork_role.cpp`):
 
-1. `ArtworkRole::start()` spawns the drain thread.
+1. `ArtworkRole::Impl::start()` spawns the drain thread.
 2. The thread blocks on notification queue receives with a 100 ms timeout.
 3. On notification: calls `on_image_decode()` immediately, then sleeps until the server timestamp to call `on_image_display()`. Sleep is interruptible via `EventFlags`.
-4. `ArtworkRole::stop_()` sets `COMMAND_STOP` and joins.
+4. `ArtworkRole::Impl` destructor sets `COMMAND_STOP` and joins.
 
-**Destruction order** matters because external audio callbacks may still reference the sync task. `PlayerRole`'s destructor resets the sync task first (`sync_task_.reset()`) before tearing down anything else, so the thread is fully joined before any shared state is destroyed.
+**Destruction order** matters because external audio callbacks may still reference the sync task. `PlayerRole::Impl`'s destructor resets the sync task first (`sync_task_.reset()`) before tearing down anything else, so the thread is fully joined before any shared state is destroyed.
 
 ## Synchronization Primitives
 
@@ -55,10 +63,8 @@ COMMAND_STOP         (1 << 0)   Stop the thread
 COMMAND_STREAM_END   (1 << 1)   End current stream
 COMMAND_STREAM_CLEAR (1 << 2)   Clear all buffered audio
 COMMAND_START        (1 << 3)   Main loop acknowledged stream start
-TASK_STARTING        (1 << 7)
 TASK_RUNNING         (1 << 8)   Actively decoding
-TASK_STOPPING        (1 << 9)
-TASK_STOPPED         (1 << 10)
+TASK_STOPPED         (1 << 10)  Thread has exited
 TASK_ERROR           (1 << 11)  Allocation or decode failure
 TASK_IDLE            (1 << 12)  Waiting for work
 ```
@@ -71,12 +77,12 @@ Fixed-depth FIFO queue with timed send/receive. Used to defer events from networ
 
 | Queue | Depth | Data | Producer | Consumer |
 |-------|-------|------|----------|----------|
-| `PlayerRole::stream_queue` | 8 | `StreamCallbackType` | Network thread | Main loop (`drain_events`) |
-| `PlayerRole::state_queue` | 4 | `SendspinClientState` | Sync task thread | Main loop (`drain_events`) |
+| `PlayerRole::Impl::stream_queue` | 8 | `PlayerStreamCallbackType` | Network thread | Main loop (`drain_events`) |
+| `PlayerRole::Impl::state_queue` | 4 | `SendspinClientState` | Sync task thread | Main loop (`drain_events`) |
 | `Client::time_queue` | 16 | `TimeResponseEvent` | Network thread | Main loop (`loop`) |
-| `ArtworkRole::notify_queue` | 8 | `ArtworkNotification` | Network thread | Artwork drain thread |
-| `ArtworkRole::queue` | 8 | `ArtworkEventType` | Network thread | Main loop (`drain_events`) |
-| `VisualizerRole::queue` | - | `VisualizerEventType` | Network thread | Main loop (`drain_events`) |
+| `ArtworkRole::Impl::notify_queue` | 8 | `ArtworkNotification` | Network thread | Artwork drain thread |
+| `ArtworkRole::Impl::queue` | 8 | `ArtworkEventType` | Network thread | Main loop (`drain_events`) |
+| `VisualizerRole::Impl::queue` | 8 | `VisualizerEventType` | Network thread | Main loop (`drain_events`) |
 
 ### ShadowSlot (`src/platform/shadow_slot.h`)
 
@@ -85,12 +91,12 @@ Single-slot state container with "latest wins" or custom merge semantics. The ne
 | Shadow Slot | Data | Merge Strategy |
 |-------------|------|----------------|
 | `Client::shadow_group` | `GroupUpdateObject` | Field-by-field delta merge |
-| `PlayerRole::shadow_stream_params` | `ServerPlayerStreamObject` | Latest wins |
-| `PlayerRole::shadow_command` | `ServerCommandMessage` | Field-by-field merge (volume, mute, delay independent) |
-| `ControllerRole::shadow` | `ServerStateControllerObject` | Latest wins |
-| `MetadataRole::shadow` | `ServerMetadataStateObject` | Field-by-field delta merge |
-| `ArtworkRole::shadow_config` | `ServerArtworkStreamObject` | Latest wins |
-| `VisualizerRole::shadow_config` | `ServerVisualizerStreamObject` | Latest wins |
+| `PlayerRole::Impl::shadow_stream_params` | `ServerPlayerStreamObject` | Latest wins |
+| `PlayerRole::Impl::shadow_command` | `ServerCommandMessage` | Field-by-field merge (volume, mute, delay independent) |
+| `ControllerRole::Impl::shadow` | `ServerStateControllerObject` | Latest wins |
+| `MetadataRole::Impl::shadow` | `ServerMetadataStateObject` | Field-by-field delta merge |
+| `ArtworkRole::Impl::shadow_config` | `ServerArtworkStreamObject` | Latest wins |
+| `VisualizerRole::Impl::shadow_config` | `ServerVisualizerStreamObject` | Latest wins |
 | `SyncTask::playback_progress_slot_` | `PlaybackProgress` | Sum `frames_played`, keep latest `finish_timestamp` |
 
 The merge strategy for `shadow_command` is important: if a volume change and a mute change arrive between two drain ticks, both are preserved because the merge function only overwrites fields that have values in the delta.
@@ -109,10 +115,10 @@ Used for:
 - **`std::mutex`** on `ConnectionManager::conn_mutex_`: protects deferred connection event vectors.
 - **`std::mutex`** on `SendspinTimeFilter::state_mutex_`: protects Kalman filter state (offset, drift, covariance).
 - **`std::atomic<bool>`** on `SendspinConnection::message_dispatch_enabled_`: allows the main loop to instantly suppress message delivery from the network thread.
-- **`std::atomic<bool/uint8_t/size_t>`** on `VisualizerRole`: network thread writes stream config atomically; drain thread reads it.
-- **`std::atomic<bool>`** on `ArtworkRole::stream_active_`: guards `handle_binary()` from writing when no stream is active.
-- **`std::atomic<uint8_t>`** on `ArtworkRole::SlotBuffer::write_idx`: tracks which of two double-buffers the network thread writes to next.
-- **`std::atomic<bool>`** on `ArtworkRole::SlotBuffer::drain_active`: set by the drain thread while decoding, checked by the network thread to avoid overwriting an in-use buffer.
+- **`std::atomic<bool/uint8_t/size_t>`** on `VisualizerRole::Impl`: network thread writes stream config atomically; drain thread reads it.
+- **`std::atomic<bool>`** on `ArtworkRole::Impl::stream_active_`: guards `handle_binary()` from writing when no stream is active.
+- **`std::atomic<uint8_t>`** on `ArtworkRole::Impl::SlotBuffer::write_idx`: tracks which of two double-buffers the network thread writes to next.
+- **`std::atomic<bool>`** on `ArtworkRole::Impl::SlotBuffer::drain_active`: set by the drain thread while decoding, checked by the network thread to avoid overwriting an in-use buffer.
 - **`std::atomic<uint8_t>`** on `SendspinClient::high_performance_ref_count_`: ref-counted high-performance networking requests from time sync and playback.
 
 ## Message Flow
@@ -135,38 +141,38 @@ Network thread (IXWebSocket / esp_http_server)
 
 ### JSON Message Dispatch (network thread)
 
-`process_json_message_()` (`src/client.cpp:406`) parses the message type and routes:
+`process_json_message()` (`src/client.cpp:457`) parses the message type and routes:
 
 | Message | Action on Network Thread |
 |---------|------------------------|
 | `SERVER_HELLO` | Enqueues `ServerHelloEvent` into `ConnectionManager`'s mutex-protected vector |
 | `SERVER_TIME` | Enqueues `TimeResponseEvent` into `time_queue` |
-| `SERVER_STATE` | Writes to `ControllerRole::shadow` and `MetadataRole::shadow` |
-| `SERVER_COMMAND` | Merges into `PlayerRole::shadow_command` |
+| `SERVER_STATE` | Writes to `ControllerRole::Impl::shadow` and `MetadataRole::Impl::shadow` |
+| `SERVER_COMMAND` | Merges into `PlayerRole::Impl::shadow_command` |
 | `GROUP_UPDATE` | Merges into `Client::shadow_group` |
-| `STREAM_START` | Writes to `PlayerRole::shadow_stream_params`, enqueues `STREAM_START` into `stream_queue`. Writes to `ArtworkRole::shadow_config` and `VisualizerRole::shadow_config`, enqueues start events. |
+| `STREAM_START` | Writes to `PlayerRole::Impl::shadow_stream_params`, enqueues `STREAM_START` into `stream_queue`. Writes to `ArtworkRole::Impl::shadow_config` and `VisualizerRole::Impl::shadow_config`, enqueues start events. |
 | `STREAM_END` | Enqueues `STREAM_END` into player/artwork/visualizer queues, signals sync task `COMMAND_STREAM_END` |
 | `STREAM_CLEAR` | Enqueues `STREAM_CLEAR` into player/artwork/visualizer queues, signals sync task `COMMAND_STREAM_CLEAR` |
 
 ### Binary Message Dispatch (network thread)
 
-`process_binary_message_()` (`src/client.cpp:363`) extracts the type byte and routes:
+`process_binary_message()` extracts the type byte and routes:
 
 | Binary Type | Handler |
 |-------------|---------|
-| Player audio | `PlayerRole::handle_binary()`: writes to encoded audio ring buffer |
-| Artwork image | `ArtworkRole::handle_binary()`: copies image data to a per-slot double buffer and enqueues a notification for the artwork drain thread |
-| Visualizer frame/beat | `VisualizerRole::handle_binary()`: writes to visualizer ring buffer |
+| Player audio | `PlayerRole::Impl::handle_binary()`: writes to encoded audio ring buffer |
+| Artwork image | `ArtworkRole::Impl::handle_binary()`: copies image data to a per-slot double buffer and enqueues a notification for the artwork drain thread |
+| Visualizer frame/beat | `VisualizerRole::Impl::handle_binary()`: writes to visualizer ring buffer |
 
 ### Main Loop Processing
 
-`SendspinClient::loop()` (`src/client.cpp:179`) runs the following steps **in order** on each tick:
+`SendspinClient::loop()` (`src/client.cpp:148`) runs the following steps **in order** on each tick:
 
 ```api
 1. connection_manager_->loop()
    ├─ Start WS server if network ready
    ├─ Swap deferred connection events under mutex
-   ├─ Process close/disconnect events (on_connection_lost_)
+   ├─ Process close/disconnect events (on_connection_lost)
    ├─ Process hello events (handshake completion, handoff decisions)
    ├─ Call loop() on current and pending connections
    └─ Check hello retry timer
@@ -179,12 +185,12 @@ Network thread (IXWebSocket / esp_http_server)
 3. Drain time_queue
    └─ Feed time responses into time_burst_->on_time_response()
 
-4. Role event draining (each role's drain_events())
-   ├─ player_->drain_events()
-   ├─ controller_->drain_events()
-   ├─ metadata_->drain_events()
-   ├─ artwork_->drain_events()
-   └─ visualizer_->drain_events()
+4. Role event draining (each role's impl_->drain_events())
+   ├─ player_->impl_->drain_events()
+   ├─ controller_->impl_->drain_events()
+   ├─ metadata_->impl_->drain_events()
+   ├─ artwork_->impl_->drain_events()
+   └─ visualizer_->impl_->drain_events()
 
 5. Drain shadow_group
    └─ Apply group deltas, fire on_group_update, persist last played server
@@ -196,7 +202,7 @@ This ordering matters: connection lifecycle events are processed before role eve
 
 Each role implements `drain_events()` to process its deferred events on the main loop thread. This is the mechanism that converts thread-safe queue/shadow writes into sequential, single-threaded callback delivery.
 
-### PlayerRole::drain_events() (`src/player_role.cpp:297`)
+### PlayerRole::Impl::drain_events() (`src/player_role.cpp:341`)
 
 Three stages, processed in order:
 
@@ -221,7 +227,7 @@ stream_queue → awaiting_sync_idle_events_ list
                 Signal sync task COMMAND_START
 ```
 
-The `awaiting_sync_idle_events_` list is the key ordering mechanism. STREAM_END/CLEAR callbacks are held until the sync task has reached its IDLE state, preventing the main loop from processing a new STREAM_START before the sync task has finished with the old stream. Events ahead of the blocked event also wait, preserving FIFO order.
+The `awaiting_sync_idle_events` list (on `PlayerRole::Impl`) is the key ordering mechanism. STREAM_END/CLEAR callbacks are held until the sync task has reached its IDLE state, preventing the main loop from processing a new STREAM_START before the sync task has finished with the old stream. Events ahead of the blocked event also wait, preserving FIFO order.
 
 ### Other Roles
 
@@ -243,8 +249,8 @@ The sync task (`SyncTask::thread_entry`, `src/sync_task.cpp`) runs a two-level s
 │                    │                                      │
 │  ┌─────────────────┴──────────────────┐                  │
 │  │           IDLE STATE               │                  │
-│  │  • Clear TASK_RUNNING, TASK_STOPPING│                  │
-│  │    and all COMMAND flags            │                  │
+│  │  • Clear TASK_RUNNING and all      │                  │
+│  │    COMMAND flags                   │                  │
 │  │  • Set TASK_IDLE                   │                  │
 │  │  • Reset context + progress queue  │                  │
 │  │  • Wait for codec header (500ms)   │◄──┐              │
@@ -272,8 +278,7 @@ The sync task (`SyncTask::thread_entry`, `src/sync_task.cpp`) runs a two-level s
 │               │ STOP/END/CLEAR                           │
 │               ▼                                          │
 │  ┌────────────────────────────────────┐                  │
-│  │  Return borrowed ring buffer entry │                  │
-│  │  Set TASK_STOPPING                 │──────→ loop back │
+│  │  Return borrowed ring buffer entry │──────→ loop back │
 │  └────────────────────────────────────┘                  │
 └──────────────────────────────────────────────────────────┘
 ```
@@ -376,12 +381,12 @@ The `ConnectionManager` maintains up to three connection slots:
 
 ### Disconnection and Cleanup
 
-When a connection is lost (`on_connection_lost_`):
+When a connection is lost (`on_connection_lost`):
 
 ```api
 1. conn->disable_message_dispatch()      ← atomic, immediate on network thread
 2. time_burst_->reset()                  ← stop time sync
-3. client_->cleanup_connection_state_()  ← drain all role queues/shadows, signal stream end
+3. client_->cleanup_connection_state()  ← drain all role queues/shadows, signal stream end
 4. current_connection_.reset()           ← destroy connection
 5. Promote pending to current if exists
 ```

--- a/examples/basic_client/main.cpp
+++ b/examples/basic_client/main.cpp
@@ -194,7 +194,7 @@ int main(int argc, char* argv[]) {
     SendspinClient client(std::move(config));
 
     // Add roles
-    PlayerRole::Config player_config;
+    PlayerRoleConfig player_config;
     player_config.audio_formats = {
         {SendspinCodecFormat::FLAC, 2, 44100, 16},
         {SendspinCodecFormat::FLAC, 2, 48000, 16},

--- a/examples/tui_client/main.cpp
+++ b/examples/tui_client/main.cpp
@@ -492,7 +492,7 @@ int main(int argc, char* argv[]) {
     SendspinClient client(std::move(config));
 
     // Add roles
-    PlayerRole::Config player_config;
+    PlayerRoleConfig player_config;
     player_config.audio_formats = std::move(audio_formats);
     auto& player = client.add_player(std::move(player_config));
     player.set_static_delay_adjustable(true);
@@ -517,7 +517,7 @@ int main(int argc, char* argv[]) {
             .f_max = 16000,
             .rate_max = 30,
         };
-        vis_role = &client.add_visualizer(VisualizerRole::Config{.support = vis});
+        vis_role = &client.add_visualizer(VisualizerRoleConfig{.support = vis});
     }
 
     // --- Listener implementations ---

--- a/examples/tui_client/tui.h
+++ b/examples/tui_client/tui.h
@@ -17,6 +17,7 @@
 #include "sendspin/client.h"
 #include "sendspin/controller_role.h"
 #include "sendspin/metadata_role.h"
+#include "sendspin/player_role.h"
 
 #include <ftxui/component/component.hpp>
 #include <ftxui/component/screen_interactive.hpp>

--- a/include/sendspin/artwork_role.h
+++ b/include/sendspin/artwork_role.h
@@ -144,11 +144,9 @@ class ArtworkRole {
     friend class SendspinClient;
 
 public:
-    using Config = ArtworkRoleConfig;
-
     struct Impl;
 
-    ArtworkRole(Config config, SendspinClient* client);
+    ArtworkRole(ArtworkRoleConfig config, SendspinClient* client);
     ~ArtworkRole();
 
     /// @brief Sets the listener for artwork events

--- a/include/sendspin/artwork_role.h
+++ b/include/sendspin/artwork_role.h
@@ -17,7 +17,8 @@
 
 #pragma once
 
-#include <atomic>
+#include "sendspin/config.h"
+
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -28,25 +29,10 @@
 namespace sendspin {
 
 class SendspinClient;
-struct ClientHelloMessage;
 
 // ============================================================================
 // Artwork types
 // ============================================================================
-
-/// @brief Image format for artwork
-enum class SendspinImageFormat : uint8_t {
-    JPEG,  // JPEG compressed image
-    PNG,   // PNG image
-    BMP,   // BMP image
-};
-
-/// @brief Source type for an artwork image
-enum class SendspinImageSource : uint8_t {
-    ALBUM,   // Album cover art
-    ARTIST,  // Artist photo
-    NONE,    // No image
-};
 
 /// @brief Format and resolution for a single supported artwork channel
 struct ArtworkChannelFormatObject {
@@ -72,15 +58,6 @@ struct ServerArtworkChannelObject {
 /// @brief Artwork stream parameters sent by the server in stream/start messages
 struct ServerArtworkStreamObject {
     std::optional<std::vector<ServerArtworkChannelObject>> channels;
-};
-
-/// @brief Preference for an image slot's format and resolution
-struct ImageSlotPreference {
-    uint8_t slot{};
-    SendspinImageSource source{};
-    SendspinImageFormat format{};
-    uint16_t width{};
-    uint16_t height{};
 };
 
 /// @brief Listener for artwork role events
@@ -137,7 +114,7 @@ public:
  *
  * Usage:
  * 1. Implement ArtworkRoleListener with on_image_decode() and on_image_display()
- * 2. Build an ArtworkRole::Config with the desired slot/format/resolution preferences
+ * 2. Build an ArtworkRoleConfig with the desired slot/format/resolution preferences
  * 3. Add the role to the client via SendspinClient::add_artwork()
  * 4. Call set_listener() with your listener implementation
  *
@@ -156,7 +133,7 @@ public:
  * };
  *
  * MyArtworkListener listener;
- * ArtworkRole::Config config;
+ * ArtworkRoleConfig config;
  * config.preferred_formats = {{0, SendspinImageSource::ALBUM,
  *                               SendspinImageFormat::JPEG, 240, 240}};
  * auto& artwork = client.add_artwork(config);
@@ -167,12 +144,9 @@ class ArtworkRole {
     friend class SendspinClient;
 
 public:
-    /// @brief Configuration for the artwork role
-    struct Config {
-        std::vector<ImageSlotPreference> preferred_formats{};
-        bool psram_stack{false};  ///< Allocate drain thread stack in PSRAM (ESP-IDF only)
-        unsigned priority{2};     ///< FreeRTOS priority for the drain thread (ESP-IDF only)
-    };
+    using Config = ArtworkRoleConfig;
+
+    struct Impl;
 
     ArtworkRole(Config config, SendspinClient* client);
     ~ArtworkRole();
@@ -180,57 +154,10 @@ public:
     /// @brief Sets the listener for artwork events
     /// @note The listener must outlive this role.
     /// @param listener Pointer to the listener implementation; must outlive this role
-    void set_listener(ArtworkRoleListener* listener) {
-        this->listener_ = listener;
-    }
+    void set_listener(ArtworkRoleListener* listener);
 
 private:
-    /// @brief Starts the drain thread
-    /// @return True if the thread is running, false on failure.
-    bool start();
-    /// @brief Signals the drain thread to stop and waits for it to exit
-    void stop();
-    /// @brief Adds the artwork role and configured channels to the hello message
-    /// @param msg The hello message being assembled.
-    void build_hello_fields(ClientHelloMessage& msg);
-    /// @brief Copies image data to a per-slot buffer and signals the drain thread
-    /// @param slot Artwork slot index this image belongs to.
-    /// @param data Pointer to the binary payload (8-byte big-endian timestamp followed by image
-    /// data).
-    /// @param len Length of the binary payload in bytes.
-    void handle_binary(uint8_t slot, const uint8_t* data, size_t len);
-    /// @brief Caches stream config, signals the drain thread to flush, and enqueues a start event
-    /// @param stream Stream parameters received from the server.
-    void handle_stream_start(const ServerArtworkStreamObject& stream);
-    /// @brief Marks the stream inactive, flushes the drain thread, and enqueues a stream-end event
-    void handle_stream_end();
-    /// @brief Marks the stream inactive, flushes the drain thread, and enqueues a stream-clear
-    /// event
-    void handle_stream_clear();
-    /// @brief Delivers pending stream lifecycle events (start, end, clear) to the listener
-    void drain_events();
-    /// @brief Resets pending events, flushes the drain thread, and enqueues a stream-end event
-    void cleanup();
-
-    /// @brief Entry point for the drain thread; processes image decode and display callbacks
-    /// @param self The ArtworkRole instance that owns this thread.
-    static void drain_thread_func(ArtworkRole* self);
-
-    struct DrainTask;
-    struct EventState;
-
-    // Struct fields
-    Config config_;
-    std::vector<ArtworkChannelFormatObject> artwork_channels_;
-
-    // Pointer fields
-    SendspinClient* client_;
-    std::unique_ptr<DrainTask> drain_task_;
-    std::unique_ptr<EventState> event_state_;
-    ArtworkRoleListener* listener_{nullptr};
-
-    // 8-bit fields
-    std::atomic<bool> stream_active_{false};
+    std::unique_ptr<Impl> impl_;
 };
 
 }  // namespace sendspin

--- a/include/sendspin/client.h
+++ b/include/sendspin/client.h
@@ -128,39 +128,6 @@ class ConnectionManager;
 class SendspinConnection;
 class SendspinTimeBurst;
 
-/// @brief Configuration for a SendspinClient instance
-/// Filled in by the platform (e.g., ESPHome) before calling start_server()
-struct SendspinClientConfig {
-    std::string client_id;         ///< Unique client identifier (e.g., MAC address)
-    std::string name;              ///< Friendly display name
-    std::string product_name;      ///< Device product name
-    std::string manufacturer;      ///< Manufacturer name (e.g., "ESPHome")
-    std::string software_version;  ///< Software version string
-
-    bool httpd_psram_stack{false};  ///< Allocate httpd task stack in PSRAM (ESP-IDF only)
-
-    /// @brief Default FreeRTOS priority for the HTTP server task (ESP-IDF only)
-    static constexpr unsigned DEFAULT_HTTPD_PRIORITY = 17U;
-
-    unsigned httpd_priority{DEFAULT_HTTPD_PRIORITY};  ///< FreeRTOS priority for the HTTP server
-                                                      ///< task (ESP-IDF only)
-    unsigned websocket_priority{5};  ///< FreeRTOS priority for the WebSocket client task
-                                     ///< (ESP-IDF only)
-
-    uint8_t server_max_connections{2};  ///< Maximum simultaneous connections (default: 2 for
-                                        ///< handoff protocol)
-    uint16_t httpd_ctrl_port{0};        ///< ESP-IDF httpd control port; 0 = ESP_HTTPD_DEF_CTRL_PORT
-                                        ///< + 1 (avoids conflict with web_server component)
-
-    static constexpr int64_t DEFAULT_BURST_INTERVAL_MS = 10000;  ///< Default ms between bursts
-    static constexpr int64_t DEFAULT_BURST_TIMEOUT_MS = 10000;   ///< Default burst timeout ms
-
-    uint8_t time_burst_size{8};  ///< Number of messages per time sync burst
-    int64_t time_burst_interval_ms{DEFAULT_BURST_INTERVAL_MS};  ///< Milliseconds between bursts
-    int64_t time_burst_response_timeout_ms{
-        DEFAULT_BURST_TIMEOUT_MS};  ///< Milliseconds before a burst message times out
-};
-
 /**
  * @brief Main orchestration class for the sendspin-cpp library
  *

--- a/include/sendspin/client.h
+++ b/include/sendspin/client.h
@@ -17,10 +17,8 @@
 
 #pragma once
 
-#include "sendspin/artwork_role.h"
-#include "sendspin/player_role.h"
+#include "sendspin/config.h"
 #include "sendspin/types.h"
-#include "sendspin/visualizer_role.h"
 
 #include <atomic>
 #include <cstdint>
@@ -31,9 +29,22 @@
 
 namespace sendspin {
 
-// Forward declarations for roles whose Config types are not used in this header's public API
+// Forward declarations for enabled roles
+#ifdef SENDSPIN_ENABLE_ARTWORK
+class ArtworkRole;
+#endif
+#ifdef SENDSPIN_ENABLE_CONTROLLER
 class ControllerRole;
+#endif
+#ifdef SENDSPIN_ENABLE_METADATA
 class MetadataRole;
+#endif
+#ifdef SENDSPIN_ENABLE_PLAYER
+class PlayerRole;
+#endif
+#ifdef SENDSPIN_ENABLE_VISUALIZER
+class VisualizerRole;
+#endif
 
 // Forward declarations for listener types
 struct GroupUpdateObject;
@@ -187,7 +198,7 @@ struct SendspinClientConfig {
  * config.manufacturer = "Acme";
  * config.software_version = "1.0.0";
  * SendspinClient client(config);
- * auto& player = client.add_player(PlayerRole::Config{});
+ * auto& player = client.add_player(PlayerRoleConfig{});
  * player.set_listener(&player_listener);
  * client.add_controller();
  * client.set_network_provider(&network_provider);
@@ -236,25 +247,36 @@ public:
     // Role registration (call before start_server)
     // ========================================
 
+#ifdef SENDSPIN_ENABLE_PLAYER
     /// @brief Adds the player role. Returns a reference for setting callbacks
-    PlayerRole& add_player(PlayerRole::Config config);
+    PlayerRole& add_player(PlayerRoleConfig config);
+#endif
 
+#ifdef SENDSPIN_ENABLE_CONTROLLER
     /// @brief Adds the controller role. Returns a reference for setting callbacks
     ControllerRole& add_controller();
+#endif
 
+#ifdef SENDSPIN_ENABLE_METADATA
     /// @brief Adds the metadata role. Returns a reference for setting callbacks
     MetadataRole& add_metadata();
+#endif
 
+#ifdef SENDSPIN_ENABLE_ARTWORK
     /// @brief Adds the artwork role. Returns a reference for setting callbacks
-    ArtworkRole& add_artwork(ArtworkRole::Config config);
+    ArtworkRole& add_artwork(ArtworkRoleConfig config);
+#endif
 
+#ifdef SENDSPIN_ENABLE_VISUALIZER
     /// @brief Adds the visualizer role. Returns a reference for setting callbacks
-    VisualizerRole& add_visualizer(VisualizerRole::Config config);
+    VisualizerRole& add_visualizer(VisualizerRoleConfig config);
+#endif
 
     // ========================================
     // Role access (nullptr if not added)
     // ========================================
 
+#ifdef SENDSPIN_ENABLE_ARTWORK
     /// @brief Returns the artwork role, or nullptr if not added
     /// @return Pointer to the artwork role, or nullptr
     ArtworkRole* artwork() {
@@ -265,6 +287,8 @@ public:
     const ArtworkRole* artwork() const {
         return this->artwork_.get();
     }
+#endif
+#ifdef SENDSPIN_ENABLE_CONTROLLER
     /// @brief Returns the controller role, or nullptr if not added
     /// @return Pointer to the controller role, or nullptr
     ControllerRole* controller() {
@@ -275,6 +299,8 @@ public:
     const ControllerRole* controller() const {
         return this->controller_.get();
     }
+#endif
+#ifdef SENDSPIN_ENABLE_METADATA
     /// @brief Returns the metadata role, or nullptr if not added
     /// @return Pointer to the metadata role, or nullptr
     MetadataRole* metadata() {
@@ -285,6 +311,8 @@ public:
     const MetadataRole* metadata() const {
         return this->metadata_.get();
     }
+#endif
+#ifdef SENDSPIN_ENABLE_PLAYER
     /// @brief Returns the player role, or nullptr if not added
     /// @return Pointer to the player role, or nullptr
     PlayerRole* player() {
@@ -295,6 +323,8 @@ public:
     const PlayerRole* player() const {
         return this->player_.get();
     }
+#endif
+#ifdef SENDSPIN_ENABLE_VISUALIZER
     /// @brief Returns the visualizer role, or nullptr if not added
     /// @return Pointer to the visualizer role, or nullptr
     VisualizerRole* visualizer() {
@@ -305,6 +335,7 @@ public:
     const VisualizerRole* visualizer() const {
         return this->visualizer_.get();
     }
+#endif
 
     // ========================================
     // Queries
@@ -434,17 +465,27 @@ private:
     GroupUpdateObject group_state_{};
 
     // Pointer fields
+#ifdef SENDSPIN_ENABLE_ARTWORK
     std::unique_ptr<ArtworkRole> artwork_;
+#endif
     std::unique_ptr<ConnectionManager> connection_manager_;
+#ifdef SENDSPIN_ENABLE_CONTROLLER
     std::unique_ptr<ControllerRole> controller_;
+#endif
     std::unique_ptr<EventState> event_state_;
     SendspinClientListener* listener_{nullptr};
+#ifdef SENDSPIN_ENABLE_METADATA
     std::unique_ptr<MetadataRole> metadata_;
+#endif
     SendspinNetworkProvider* network_provider_{nullptr};
     SendspinPersistenceProvider* persistence_provider_{nullptr};
+#ifdef SENDSPIN_ENABLE_PLAYER
     std::unique_ptr<PlayerRole> player_;
+#endif
     std::unique_ptr<SendspinTimeBurst> time_burst_;
+#ifdef SENDSPIN_ENABLE_VISUALIZER
     std::unique_ptr<VisualizerRole> visualizer_;
+#endif
 
     // 32-bit fields
     SendspinClientState state_{SendspinClientState::SYNCHRONIZED};

--- a/include/sendspin/config.h
+++ b/include/sendspin/config.h
@@ -1,0 +1,135 @@
+// Copyright 2026 Sendspin Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @file config.h
+/// @brief Configuration structs for Sendspin roles
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace sendspin {
+
+// ============================================================================
+// Player config types
+// ============================================================================
+
+/// @brief Audio codec format for a player stream
+enum class SendspinCodecFormat : uint8_t {
+    FLAC,         // FLAC lossless audio
+    OPUS,         // Opus compressed audio
+    PCM,          // Raw PCM audio
+    UNSUPPORTED,  // Codec not recognized
+};
+
+/// @brief One supported audio format entry advertised by the player in the hello message
+struct AudioSupportedFormatObject {
+    SendspinCodecFormat codec;
+    uint8_t channels;
+    uint32_t sample_rate;
+    uint8_t bit_depth;
+};
+
+/// @brief Configuration for the player role
+struct PlayerRoleConfig {
+    static constexpr size_t DEFAULT_AUDIO_BUFFER_CAPACITY = 1000000U;  ///< ~1MB default buffer
+    std::vector<AudioSupportedFormatObject> audio_formats{};
+    size_t audio_buffer_capacity{DEFAULT_AUDIO_BUFFER_CAPACITY};
+    int32_t fixed_delay_us{0};
+    uint16_t initial_static_delay_ms{0};
+    bool psram_stack{false};  ///< Allocate sync task stack in PSRAM (ESP-IDF only)
+    unsigned priority{2};     ///< FreeRTOS priority for the sync/decode task (ESP-IDF only)
+};
+
+// ============================================================================
+// Artwork config types
+// ============================================================================
+
+/// @brief Image format for artwork
+enum class SendspinImageFormat : uint8_t {
+    JPEG,  // JPEG compressed image
+    PNG,   // PNG image
+    BMP,   // BMP image
+};
+
+/// @brief Source type for an artwork image
+enum class SendspinImageSource : uint8_t {
+    ALBUM,   // Album cover art
+    ARTIST,  // Artist photo
+    NONE,    // No image
+};
+
+/// @brief Preference for an image slot's format and resolution
+struct ImageSlotPreference {
+    uint8_t slot{};
+    SendspinImageSource source{};
+    SendspinImageFormat format{};
+    uint16_t width{};
+    uint16_t height{};
+};
+
+/// @brief Configuration for the artwork role
+struct ArtworkRoleConfig {
+    std::vector<ImageSlotPreference> preferred_formats{};
+    bool psram_stack{false};  ///< Allocate drain thread stack in PSRAM (ESP-IDF only)
+    unsigned priority{2};     ///< FreeRTOS priority for the drain thread (ESP-IDF only)
+};
+
+// ============================================================================
+// Visualizer config types
+// ============================================================================
+
+/// @brief Visualizer data stream types
+enum class VisualizerDataType : uint8_t {
+    BEAT,      // Beat detection events
+    LOUDNESS,  // Overall loudness level
+    F_PEAK,    // Peak frequency
+    SPECTRUM,  // Full frequency spectrum bins
+};
+
+/// @brief Frequency scale used for spectrum visualization bins
+enum class VisualizerSpectrumScale : uint8_t {
+    MEL,  // Mel perceptual scale
+    LOG,  // Logarithmic scale
+    LIN,  // Linear scale
+};
+
+/// @brief Spectrum visualization parameters: bin count, frequency range, scale, and rate cap
+struct VisualizerSpectrumConfig {
+    uint8_t n_disp_bins;
+    VisualizerSpectrumScale scale;
+    uint16_t f_min;
+    uint16_t f_max;
+    uint16_t rate_max;
+};
+
+/// @brief Visualizer capabilities advertised to the server during the hello handshake
+struct VisualizerSupportObject {
+    std::vector<VisualizerDataType> types{};
+    size_t buffer_capacity{};
+    uint8_t batch_max{};
+    std::optional<VisualizerSpectrumConfig> spectrum;
+};
+
+/// @brief Configuration for the visualizer role
+struct VisualizerRoleConfig {
+    VisualizerSupportObject support;
+    bool psram_stack{false};  ///< Allocate drain thread stack in PSRAM (ESP-IDF only)
+    unsigned priority{2};     ///< FreeRTOS priority for the drain thread (ESP-IDF only)
+};
+
+}  // namespace sendspin

--- a/include/sendspin/config.h
+++ b/include/sendspin/config.h
@@ -13,16 +13,54 @@
 // limitations under the License.
 
 /// @file config.h
-/// @brief Configuration structs for Sendspin roles
+/// @brief Configuration structs for the Sendspin client and roles
 
 #pragma once
 
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <vector>
 
 namespace sendspin {
+
+// ============================================================================
+// Client config
+// ============================================================================
+
+/// @brief Configuration for a SendspinClient instance
+/// Filled in by the platform (e.g., ESPHome) before calling start_server()
+struct SendspinClientConfig {
+    std::string client_id;         ///< Unique client identifier (e.g., MAC address)
+    std::string name;              ///< Friendly display name
+    std::string product_name;      ///< Device product name
+    std::string manufacturer;      ///< Manufacturer name (e.g., "ESPHome")
+    std::string software_version;  ///< Software version string
+
+    bool httpd_psram_stack{false};  ///< Allocate httpd task stack in PSRAM (ESP-IDF only)
+
+    /// @brief Default FreeRTOS priority for the HTTP server task (ESP-IDF only)
+    static constexpr unsigned DEFAULT_HTTPD_PRIORITY = 17U;
+
+    unsigned httpd_priority{DEFAULT_HTTPD_PRIORITY};  ///< FreeRTOS priority for the HTTP server
+                                                      ///< task (ESP-IDF only)
+    unsigned websocket_priority{5};  ///< FreeRTOS priority for the WebSocket client task
+                                     ///< (ESP-IDF only)
+
+    uint8_t server_max_connections{2};  ///< Maximum simultaneous connections (default: 2 for
+                                        ///< handoff protocol)
+    uint16_t httpd_ctrl_port{0};        ///< ESP-IDF httpd control port; 0 = ESP_HTTPD_DEF_CTRL_PORT
+                                        ///< + 1 (avoids conflict with web_server component)
+
+    static constexpr int64_t DEFAULT_BURST_INTERVAL_MS = 10000;  ///< Default ms between bursts
+    static constexpr int64_t DEFAULT_BURST_TIMEOUT_MS = 10000;   ///< Default burst timeout ms
+
+    uint8_t time_burst_size{8};  ///< Number of messages per time sync burst
+    int64_t time_burst_interval_ms{DEFAULT_BURST_INTERVAL_MS};  ///< Milliseconds between bursts
+    int64_t time_burst_response_timeout_ms{
+        DEFAULT_BURST_TIMEOUT_MS};  ///< Milliseconds before a burst message times out
+};
 
 // ============================================================================
 // Player config types

--- a/include/sendspin/controller_role.h
+++ b/include/sendspin/controller_role.h
@@ -21,13 +21,11 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <string>
 #include <vector>
 
 namespace sendspin {
 
 class SendspinClient;
-struct ClientHelloMessage;
 
 // ============================================================================
 // Controller types
@@ -97,48 +95,26 @@ class ControllerRole {
     friend class SendspinClient;
 
 public:
+    struct Impl;
+
     explicit ControllerRole(SendspinClient* client);
     ~ControllerRole();
 
     /// @brief Returns the current controller state from the server
     /// @return Const reference to the last received server controller state
-    const ServerStateControllerObject& get_controller_state() const {
-        return this->controller_state_;
-    }
+    const ServerStateControllerObject& get_controller_state() const;
 
     /// @brief Sets the listener for controller events
     /// @note The listener must outlive this role
     /// @param listener Pointer to the listener implementation
-    void set_listener(ControllerRoleListener* listener) {
-        this->listener_ = listener;
-    }
+    void set_listener(ControllerRoleListener* listener);
 
     /// @brief Sends a controller command to the server
     void send_command(SendspinControllerCommand cmd, std::optional<uint8_t> volume = {},
                       std::optional<bool> mute = {});
 
 private:
-    /// @brief Adds the controller role to the supported roles list in the hello message
-    /// @param msg The hello message being assembled.
-    void build_hello_fields(ClientHelloMessage& msg);
-    /// @brief Stores an incoming server controller state update for delivery on the main thread
-    /// Only the most recent update is retained; earlier pending updates are overwritten.
-    /// @param state The controller state received from the server.
-    void handle_server_state(ServerStateControllerObject state);
-    /// @brief Delivers any pending controller state update to the listener
-    void drain_events();
-    /// @brief Resets the controller state and clears any pending events
-    void cleanup();
-
-    struct EventState;
-
-    // Struct fields
-    ServerStateControllerObject controller_state_{};
-
-    // Pointer fields
-    SendspinClient* client_;
-    std::unique_ptr<EventState> event_state_;
-    ControllerRoleListener* listener_{nullptr};
+    std::unique_ptr<Impl> impl_;
 };
 
 }  // namespace sendspin

--- a/include/sendspin/metadata_role.h
+++ b/include/sendspin/metadata_role.h
@@ -25,7 +25,6 @@
 namespace sendspin {
 
 class SendspinClient;
-struct ClientHelloMessage;
 
 // ============================================================================
 // Metadata types
@@ -101,15 +100,15 @@ class MetadataRole {
     friend class SendspinClient;
 
 public:
+    struct Impl;
+
     explicit MetadataRole(SendspinClient* client);
     ~MetadataRole();
 
     /// @brief Sets the listener for metadata events
     /// @note The listener must outlive this role
     /// @param listener Pointer to the listener implementation
-    void set_listener(MetadataRoleListener* listener) {
-        this->listener_ = listener;
-    }
+    void set_listener(MetadataRoleListener* listener);
 
     /// @brief Returns the track duration in milliseconds
     /// @return Track duration in milliseconds, or 0 if unknown or the stream is live
@@ -121,26 +120,7 @@ public:
     uint32_t get_track_progress_ms() const;
 
 private:
-    /// @brief Adds the metadata role to the supported roles list in the hello message
-    /// @param msg The hello message being assembled.
-    void build_hello_fields(ClientHelloMessage& msg);
-    /// @brief Merges an incoming server metadata delta into the pending shadow state
-    /// @param state The metadata delta received from the server.
-    void handle_server_state(ServerMetadataStateObject state);
-    /// @brief Applies any pending metadata delta and notifies the listener
-    void drain_events();
-    /// @brief Resets the metadata state and clears any pending events
-    void cleanup();
-
-    struct EventState;
-
-    // Struct fields
-    ServerMetadataStateObject metadata_{};
-
-    // Pointer fields
-    SendspinClient* client_;
-    std::unique_ptr<EventState> event_state_;
-    MetadataRoleListener* listener_{nullptr};
+    std::unique_ptr<Impl> impl_;
 };
 
 }  // namespace sendspin

--- a/include/sendspin/player_role.h
+++ b/include/sendspin/player_role.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "sendspin/config.h"
 #include "sendspin/types.h"
 
 #include <cstddef>
@@ -24,36 +25,15 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <vector>
 
 namespace sendspin {
 
 class SendspinClient;
 class SendspinPersistenceProvider;
-class SyncTask;
-struct ClientHelloMessage;
-struct ClientStateMessage;
-struct StreamStartMessage;
 
 // ============================================================================
 // Player types
 // ============================================================================
-
-/// @brief Audio codec format for a player stream
-enum class SendspinCodecFormat : uint8_t {
-    FLAC,         // FLAC lossless audio
-    OPUS,         // Opus compressed audio
-    PCM,          // Raw PCM audio
-    UNSUPPORTED,  // Codec not recognized
-};
-
-/// @brief One supported audio format entry advertised by the player in the hello message
-struct AudioSupportedFormatObject {
-    SendspinCodecFormat codec;
-    uint8_t channels;
-    uint32_t sample_rate;
-    uint8_t bit_depth;
-};
 
 /// @brief Command types the server can send to the player role
 enum class SendspinPlayerCommand : uint8_t {
@@ -150,7 +130,7 @@ public:
  * };
  *
  * MyPlayerListener listener;
- * PlayerRole::Config config;
+ * PlayerRoleConfig config;
  * config.audio_formats = {{SendspinCodecFormat::FLAC, 2, 44100, 16}};
  * auto& player = client.add_player(config);
  * player.set_listener(&listener);
@@ -161,25 +141,15 @@ class PlayerRole {
     friend class SyncTask;
 
 public:
-    /// @brief Configuration for the player role
-    struct Config {
-        static constexpr size_t DEFAULT_AUDIO_BUFFER_CAPACITY = 1000000U;  ///< ~1MB default buffer
-        std::vector<AudioSupportedFormatObject> audio_formats{};
-        size_t audio_buffer_capacity{DEFAULT_AUDIO_BUFFER_CAPACITY};
-        int32_t fixed_delay_us{0};
-        uint16_t initial_static_delay_ms{0};
-        bool psram_stack{false};  ///< Allocate sync task stack in PSRAM (ESP-IDF only)
-        unsigned priority{2};     ///< FreeRTOS priority for the sync/decode task (ESP-IDF only)
-    };
+    using Config = PlayerRoleConfig;
+    struct Impl;
 
     PlayerRole(Config config, SendspinClient* client, SendspinPersistenceProvider* persistence);
     ~PlayerRole();
 
     /// @brief Sets the listener for player events
     /// @param listener Pointer to the listener implementation; must outlive this role
-    void set_listener(PlayerRoleListener* listener) {
-        this->listener_ = listener;
-    }
+    void set_listener(PlayerRoleListener* listener);
 
     // ========================================
     // Audio
@@ -216,107 +186,26 @@ public:
 
     /// @brief Returns a reference to the current stream parameters
     /// @return Const reference to the active stream parameters.
-    const ServerPlayerStreamObject& get_current_stream_params() const {
-        return this->current_stream_params_;
-    }
+    const ServerPlayerStreamObject& get_current_stream_params() const;
 
     /// @brief Returns the fixed delay in microseconds (from config)
     /// @return Fixed pipeline delay in microseconds.
-    int32_t get_fixed_delay_us() const {
-        return this->config_.fixed_delay_us;
-    }
+    int32_t get_fixed_delay_us() const;
 
     /// @brief Returns true if currently muted
     /// @return true if muted, false otherwise.
-    bool get_muted() const {
-        return this->muted_;
-    }
+    bool get_muted() const;
 
     /// @brief Returns the current static delay in milliseconds
     /// @return Static playback delay in milliseconds.
-    uint16_t get_static_delay_ms() const {
-        return this->static_delay_ms_;
-    }
+    uint16_t get_static_delay_ms() const;
 
     /// @brief Returns the current volume level
     /// @return Current volume level (0-255).
-    uint8_t get_volume() const {
-        return this->volume_;
-    }
+    uint8_t get_volume() const;
 
 private:
-    // ========================================
-    // Deferred event types
-    // ========================================
-
-    /// @brief Deferred stream lifecycle callback types queued from the network thread
-    enum class StreamCallbackType : uint8_t {
-        STREAM_START,  // New stream is starting
-        STREAM_END,    // Stream ended normally
-        STREAM_CLEAR,  // Stream cleared immediately
-    };
-
-    // ========================================
-    // Private integration methods
-    // ========================================
-
-    /// @brief Starts the player role and registers it with the client
-    bool start();
-    /// @brief Adds player role information to the outgoing hello message
-    void build_hello_fields(ClientHelloMessage& msg);
-    /// @brief Adds the current player state fields to an outgoing state message
-    void build_state_fields(ClientStateMessage& msg) const;
-    /// @brief Handles an incoming binary audio chunk from the server
-    void handle_binary(const uint8_t* data, size_t len);
-    /// @brief Handles a stream-start message from the server
-    void handle_stream_start(const StreamStartMessage& stream_msg);
-    /// @brief Handles a stream-end message from the server
-    void handle_stream_end();
-    /// @brief Handles a stream-clear message from the server
-    void handle_stream_clear();
-    /// @brief Handles an incoming server command message
-    void handle_server_command(const ServerCommandMessage& cmd);
-    /// @brief Delivers pending stream lifecycle events to the listener
-    void drain_events();
-    /// @brief Cleans up player state when the connection is lost
-    void cleanup();
-
-    // ========================================
-    // Helpers
-    // ========================================
-
-    /// @brief Sends an audio chunk to the sync task ring buffer
-    /// @param chunk_type A ChunkType value cast to uint8_t (avoids exposing internal enum)
-    bool send_audio_chunk(const uint8_t* data, size_t data_size, int64_t timestamp,
-                          uint8_t chunk_type, uint32_t timeout_ms);
-    /// @brief Enqueues a state change for delivery on the main thread
-    void enqueue_state_update(SendspinClientState state);
-    /// @brief Loads the static delay preference from persistent storage
-    void load_static_delay();
-    /// @brief Persists the current static delay to storage
-    void persist_static_delay();
-
-    // Struct fields
-    Config config_;
-    ServerPlayerStreamObject current_stream_params_{};
-    std::vector<StreamCallbackType> awaiting_sync_idle_events_;
-    struct EventState;
-
-    // Pointer fields
-    SendspinClient* client_;
-    std::unique_ptr<EventState> event_state_;
-    PlayerRoleListener* listener_{nullptr};
-    SendspinPersistenceProvider* persistence_;
-    std::unique_ptr<SyncTask> sync_task_;
-
-    // 16-bit fields
-    uint16_t static_delay_ms_{0};
-
-    // 8-bit fields
-    bool high_performance_requested_for_playback_{false};
-    bool muted_{false};
-    bool static_delay_adjustable_{false};
-    uint8_t volume_{0};
+    std::unique_ptr<Impl> impl_;
 };
 
 }  // namespace sendspin

--- a/include/sendspin/player_role.h
+++ b/include/sendspin/player_role.h
@@ -138,7 +138,6 @@ public:
  */
 class PlayerRole {
     friend class SendspinClient;
-    friend class SyncTask;
 
 public:
     using Config = PlayerRoleConfig;

--- a/include/sendspin/player_role.h
+++ b/include/sendspin/player_role.h
@@ -140,10 +140,10 @@ class PlayerRole {
     friend class SendspinClient;
 
 public:
-    using Config = PlayerRoleConfig;
     struct Impl;
 
-    PlayerRole(Config config, SendspinClient* client, SendspinPersistenceProvider* persistence);
+    PlayerRole(PlayerRoleConfig config, SendspinClient* client,
+               SendspinPersistenceProvider* persistence);
     ~PlayerRole();
 
     /// @brief Sets the listener for player events

--- a/include/sendspin/player_role.h
+++ b/include/sendspin/player_role.h
@@ -156,7 +156,7 @@ public:
 
     /// @brief Called by the audio output when it has played audio frames. Thread-safe.
     /// @param frames Number of audio frames played
-    /// @param timestamp Server timestamp corresponding to the played position
+    /// @param timestamp Client timestamp in microseconds when the audio will finish playing
     void notify_audio_played(uint32_t frames, int64_t timestamp);
 
     // ========================================

--- a/include/sendspin/visualizer_role.h
+++ b/include/sendspin/visualizer_role.h
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include <atomic>
-#include <cstddef>
+#include "sendspin/config.h"
+
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -27,43 +27,10 @@
 namespace sendspin {
 
 class SendspinClient;
-struct ClientHelloMessage;
 
 // ============================================================================
 // Visualizer types
 // ============================================================================
-
-/// @brief Visualizer data stream types
-enum class VisualizerDataType : uint8_t {
-    BEAT,      // Beat detection events
-    LOUDNESS,  // Overall loudness level
-    F_PEAK,    // Peak frequency
-    SPECTRUM,  // Full frequency spectrum bins
-};
-
-/// @brief Frequency scale used for spectrum visualization bins
-enum class VisualizerSpectrumScale : uint8_t {
-    MEL,  // Mel perceptual scale
-    LOG,  // Logarithmic scale
-    LIN,  // Linear scale
-};
-
-/// @brief Spectrum visualization parameters: bin count, frequency range, scale, and rate cap
-struct VisualizerSpectrumConfig {
-    uint8_t n_disp_bins;
-    VisualizerSpectrumScale scale;
-    uint16_t f_min;
-    uint16_t f_max;
-    uint16_t rate_max;
-};
-
-/// @brief Visualizer capabilities advertised to the server during the hello handshake
-struct VisualizerSupportObject {
-    std::vector<VisualizerDataType> types{};
-    size_t buffer_capacity{};
-    uint8_t batch_max{};
-    std::optional<VisualizerSpectrumConfig> spectrum;
-};
 
 /// @brief Visualizer stream parameters sent by the server in stream/start messages
 struct ServerVisualizerStreamObject {
@@ -131,7 +98,7 @@ public:
  * };
  *
  * MyVisualizerListener listener;
- * VisualizerRole::Config config;
+ * VisualizerRoleConfig config;
  * config.support.types = {VisualizerDataType::SPECTRUM, VisualizerDataType::BEAT};
  * config.support.buffer_capacity = 4096;
  * config.support.batch_max = 4;
@@ -143,81 +110,19 @@ class VisualizerRole {
     friend class SendspinClient;
 
 public:
-    /// @brief Configuration for the visualizer role
-    struct Config {
-        VisualizerSupportObject support;
-        bool psram_stack{false};  ///< Allocate drain thread stack in PSRAM (ESP-IDF only)
-        unsigned priority{2};     ///< FreeRTOS priority for the drain thread (ESP-IDF only)
-    };
+    using Config = VisualizerRoleConfig;
+
+    struct Impl;
 
     VisualizerRole(Config config, SendspinClient* client);
     ~VisualizerRole();
 
     /// @brief Sets the listener for visualizer events
     /// @note The listener must outlive this role
-    void set_listener(VisualizerRoleListener* listener) {
-        this->listener_ = listener;
-    }
+    void set_listener(VisualizerRoleListener* listener);
 
 private:
-    /// @brief Starts the drain thread if the ring buffer is ready
-    /// @return True if the thread is running, false if the ring buffer is not initialized.
-    bool start();
-    /// @brief Signals the drain thread to stop and waits for it to exit
-    void stop();
-    /// @brief Adds the visualizer role and support config to the hello message
-    /// @param msg The hello message being assembled.
-    void build_hello_fields(ClientHelloMessage& msg);
-    /// @brief Parses incoming visualizer binary frames and writes them to the ring buffer
-    /// @param binary_type Protocol binary type tag identifying the frame format.
-    /// @param data Pointer to the raw frame data.
-    /// @param len Length of the frame data in bytes.
-    void handle_binary(uint8_t binary_type, const uint8_t* data, size_t len);
-    /// @brief Caches stream config, signals the drain thread to flush, and enqueues a start event
-    /// @param stream Stream parameters received from the server.
-    void handle_stream_start(const ServerVisualizerStreamObject& stream);
-    /// @brief Marks the stream inactive, flushes the ring buffer, and enqueues a stream-end event
-    void handle_stream_end();
-    /// @brief Marks the stream inactive, flushes the ring buffer, and enqueues a stream-clear
-    /// event.
-    void handle_stream_clear();
-    /// @brief Delivers pending stream lifecycle events (start, end, clear) to the listener
-    void drain_events();
-    /// @brief Resets pending events, flushes the ring buffer, and enqueues a stream-end event
-    void cleanup();
-    /// @brief Drains all pending items from the ring buffer without delivering them
-    void flush_ring_buffer();
-
-    /// @brief Entry point for the drain thread; reads ring buffer items and calls the listener
-    /// @param self The VisualizerRole instance that owns this thread.
-    static void drain_thread_func(VisualizerRole* self);
-
-    struct DrainTask;
-    struct EventState;
-
-    // Struct fields
-    Config config_;
-    std::optional<VisualizerSupportObject> visualizer_support_;
-
-    // Pointer fields
-    SendspinClient* client_;
-    // Drain task (pimpl to avoid exposing platform headers)
-    std::unique_ptr<DrainTask> drain_task_;
-    std::unique_ptr<EventState> event_state_;
-    VisualizerRoleListener* listener_{nullptr};
-
-    // size_t fields
-    // Cached stream config, written by the network thread in handle_stream_start(),
-    // read by the network thread in handle_binary(). stream_active_ is also cleared
-    // by cleanup() on the main thread.
-    std::atomic<size_t> raw_frame_size_{0};
-
-    // 8-bit fields
-    std::atomic<bool> has_f_peak_{false};
-    std::atomic<bool> has_loudness_{false};
-    std::atomic<bool> has_spectrum_{false};
-    std::atomic<uint8_t> spectrum_bin_count_{0};
-    std::atomic<bool> stream_active_{false};
+    std::unique_ptr<Impl> impl_;
 };
 
 }  // namespace sendspin

--- a/include/sendspin/visualizer_role.h
+++ b/include/sendspin/visualizer_role.h
@@ -110,11 +110,9 @@ class VisualizerRole {
     friend class SendspinClient;
 
 public:
-    using Config = VisualizerRoleConfig;
-
     struct Impl;
 
-    VisualizerRole(Config config, SendspinClient* client);
+    VisualizerRole(VisualizerRoleConfig config, SendspinClient* client);
     ~VisualizerRole();
 
     /// @brief Sets the listener for visualizer events

--- a/src/artwork_role.cpp
+++ b/src/artwork_role.cpp
@@ -92,7 +92,7 @@ bool ArtworkRole::Impl::start() {
     return true;
 }
 
-void ArtworkRole::Impl::stop() {
+void ArtworkRole::Impl::stop() const {
     if (!this->drain_task || !this->drain_task->drain_thread.joinable()) {
         return;
     }
@@ -100,7 +100,7 @@ void ArtworkRole::Impl::stop() {
     this->drain_task->drain_thread.join();
 }
 
-void ArtworkRole::Impl::build_hello_fields(ClientHelloMessage& msg) {
+void ArtworkRole::Impl::build_hello_fields(ClientHelloMessage& msg) const {
     if (this->artwork_channels.empty()) {
         return;
     }

--- a/src/artwork_role.cpp
+++ b/src/artwork_role.cpp
@@ -12,34 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "sendspin/artwork_role.h"
-
+#include "artwork_role_impl.h"
 #include "constants.h"
-#include "platform/event_flags.h"
 #include "platform/logging.h"
-#include "platform/memory.h"
-#include "platform/shadow_slot.h"
 #include "platform/thread.h"
-#include "platform/thread_safe_queue.h"
 #include "platform/time.h"
 #include "protocol_messages.h"
 #include "sendspin/client.h"
 
 #include <cstring>
-#include <thread>
 
 static const char* const TAG = "sendspin.artwork";
-
-namespace {
-
-/// @brief Deferred artwork event types
-enum class ArtworkEventType : uint8_t {
-    STREAM_START,
-    STREAM_END,
-    STREAM_CLEAR,
-};
-
-}  // namespace
 
 // ============================================================================
 // Constants
@@ -47,9 +30,6 @@ enum class ArtworkEventType : uint8_t {
 
 /// @brief Size of the big-endian 64-bit timestamp at the start of artwork binary messages
 static constexpr size_t BINARY_TIMESTAMP_SIZE = 8;
-
-/// @brief Maximum number of artwork slots (2-bit slot field in protocol binary type byte)
-static constexpr size_t MAX_SLOTS = 4;
 
 /// @brief Timeout for blocking queue receive in drain thread (allows periodic command checks)
 static constexpr uint32_t DRAIN_RECEIVE_TIMEOUT_MS = 100U;
@@ -74,101 +54,58 @@ static int64_t be64_to_host(const uint8_t* bytes) {
 namespace sendspin {
 
 // ============================================================================
-// Internal types
+// ArtworkRole::Impl lifecycle
 // ============================================================================
 
-/// @brief Double-buffered image storage for a single artwork slot
-struct SlotBuffer {
-    PlatformBuffer buffers[2];
-    std::atomic<uint8_t> write_idx{0};      ///< Which buffer the network thread writes to next
-    std::atomic<bool> drain_active{false};  ///< True while the drain thread is using a buffer
-    uint8_t drain_buf_idx{0};               ///< Which buffer the drain thread is currently using
-};
-
-/// @brief Notification sent from the network thread to the drain thread when new image data arrives
-///
-/// All metadata is carried in the notification itself (not in SlotBuffer) so that the
-/// ThreadSafeQueue's internal mutex provides the happens-before guarantee between the
-/// network thread's writes and the drain thread's reads.
-struct ArtworkNotification {
-    uint8_t slot;
-    uint8_t buffer_idx;
-    size_t data_length;
-    int64_t timestamp;
-    SendspinImageFormat format;
-};
-
-// ============================================================================
-// Pimpl definitions
-// ============================================================================
-
-/// @brief Persistent drain thread context for artwork image decode and display delivery
-struct ArtworkRole::DrainTask {
-    ThreadSafeQueue<ArtworkNotification> notify_queue;
-    EventFlags event_flags;
-    std::thread drain_thread;
-    SlotBuffer slot_buffers[MAX_SLOTS];
-};
-
-/// @brief Deferred event state for thread-safe artwork stream lifecycle delivery
-struct ArtworkRole::EventState {
-    ThreadSafeQueue<ArtworkEventType> queue;
-    ShadowSlot<ServerArtworkStreamObject> shadow_config;
-};
-
-// ============================================================================
-// Lifecycle
-// ============================================================================
-
-ArtworkRole::ArtworkRole(Config config, SendspinClient* client)
-    : config_(std::move(config)),
-      client_(client),
-      drain_task_(std::make_unique<DrainTask>()),
-      event_state_(std::make_unique<EventState>()) {
-    for (const auto& pref : this->config_.preferred_formats) {
-        this->artwork_channels_.push_back({pref.source, pref.format, pref.width, pref.height});
+ArtworkRole::Impl::Impl(ArtworkRoleConfig config, SendspinClient* client)
+    : config(std::move(config)),
+      client(client),
+      drain_task(std::make_unique<DrainTask>()),
+      event_state(std::make_unique<EventState>()) {
+    for (const auto& pref : this->config.preferred_formats) {
+        this->artwork_channels.push_back({pref.source, pref.format, pref.width, pref.height});
     }
-    this->event_state_->queue.create(8);
-    this->drain_task_->notify_queue.create(8);
+    this->event_state->queue.create(8);
+    this->drain_task->notify_queue.create(8);
 }
 
-ArtworkRole::~ArtworkRole() {
+ArtworkRole::Impl::~Impl() {
     this->stop();
 }
 
-bool ArtworkRole::start() {
-    if (!this->drain_task_) {
+bool ArtworkRole::Impl::start() {
+    if (!this->drain_task) {
         return false;
     }
-    if (this->drain_task_->drain_thread.joinable()) {
+    if (this->drain_task->drain_thread.joinable()) {
         return true;  // Already running
     }
-    if (!this->drain_task_->event_flags.is_created() && !this->drain_task_->event_flags.create()) {
+    if (!this->drain_task->event_flags.is_created() && !this->drain_task->event_flags.create()) {
         return false;
     }
 
-    platform_configure_thread("SsArt", 4096, static_cast<int>(this->config_.priority),
-                              this->config_.psram_stack);
-    this->drain_task_->drain_thread = std::thread(drain_thread_func, this);
+    platform_configure_thread("SsArt", 4096, static_cast<int>(this->config.priority),
+                              this->config.psram_stack);
+    this->drain_task->drain_thread = std::thread(drain_thread_func, this);
     return true;
 }
 
-void ArtworkRole::stop() {
-    if (!this->drain_task_ || !this->drain_task_->drain_thread.joinable()) {
+void ArtworkRole::Impl::stop() {
+    if (!this->drain_task || !this->drain_task->drain_thread.joinable()) {
         return;
     }
-    this->drain_task_->event_flags.set(COMMAND_STOP);
-    this->drain_task_->drain_thread.join();
+    this->drain_task->event_flags.set(COMMAND_STOP);
+    this->drain_task->drain_thread.join();
 }
 
-void ArtworkRole::build_hello_fields(ClientHelloMessage& msg) {
-    if (this->artwork_channels_.empty()) {
+void ArtworkRole::Impl::build_hello_fields(ClientHelloMessage& msg) {
+    if (this->artwork_channels.empty()) {
         return;
     }
     msg.supported_roles.push_back(SendspinRole::ARTWORK);
 
     ArtworkSupportObject artwork_support{};
-    artwork_support.channels = this->artwork_channels_;
+    artwork_support.channels = this->artwork_channels;
     msg.artwork_v1_support = artwork_support;
 }
 
@@ -176,11 +113,11 @@ void ArtworkRole::build_hello_fields(ClientHelloMessage& msg) {
 // Binary handling (network thread)
 // ============================================================================
 
-void ArtworkRole::handle_binary(uint8_t slot, const uint8_t* data, size_t len) {
-    if (!this->stream_active_ || !this->drain_task_ || !this->listener_) {
+void ArtworkRole::Impl::handle_binary(uint8_t slot, const uint8_t* data, size_t len) {
+    if (!this->stream_active || !this->drain_task || !this->listener) {
         return;
     }
-    if (slot >= MAX_SLOTS) {
+    if (slot >= ARTWORK_MAX_SLOTS) {
         return;
     }
     if (len < BINARY_TIMESTAMP_SIZE) {
@@ -194,7 +131,7 @@ void ArtworkRole::handle_binary(uint8_t slot, const uint8_t* data, size_t len) {
 
     // Look up format for this slot
     SendspinImageFormat image_format = SendspinImageFormat::JPEG;
-    for (const auto& pref : this->config_.preferred_formats) {
+    for (const auto& pref : this->config.preferred_formats) {
         if (pref.slot == slot) {
             image_format = pref.format;
             break;
@@ -202,7 +139,7 @@ void ArtworkRole::handle_binary(uint8_t slot, const uint8_t* data, size_t len) {
     }
 
     // Copy into the back buffer for this slot (grow-only)
-    auto& sb = this->drain_task_->slot_buffers[slot];
+    auto& sb = this->drain_task->slot_buffers[slot];
     uint8_t write_idx = sb.write_idx.load(std::memory_order_acquire);
 
     // If the drain thread is actively using this buffer, skip to the other one.
@@ -228,73 +165,73 @@ void ArtworkRole::handle_binary(uint8_t slot, const uint8_t* data, size_t len) {
 
     // Signal drain thread with all metadata in the notification
     ArtworkNotification notif{slot, write_idx, image_len, timestamp, image_format};
-    this->drain_task_->notify_queue.send(notif, 0);
+    this->drain_task->notify_queue.send(notif, 0);
 }
 
 // ============================================================================
 // Stream lifecycle (network thread)
 // ============================================================================
 
-void ArtworkRole::handle_stream_start(const ServerArtworkStreamObject& stream) {
-    this->stream_active_ = true;
+void ArtworkRole::Impl::handle_stream_start(const ServerArtworkStreamObject& stream) {
+    this->stream_active = true;
 
     // Signal drain thread to flush any stale notifications
-    if (this->drain_task_) {
-        this->drain_task_->event_flags.set(COMMAND_FLUSH);
+    if (this->drain_task) {
+        this->drain_task->event_flags.set(COMMAND_FLUSH);
     }
 
     // Shadow the config for main-thread callback
-    this->event_state_->shadow_config.write(stream);
-    this->event_state_->queue.send(ArtworkEventType::STREAM_START, 0);
+    this->event_state->shadow_config.write(stream);
+    this->event_state->queue.send(ArtworkEventType::STREAM_START, 0);
 }
 
-void ArtworkRole::handle_stream_end() {
-    this->stream_active_ = false;
+void ArtworkRole::Impl::handle_stream_end() {
+    this->stream_active = false;
 
-    if (this->drain_task_) {
-        this->drain_task_->event_flags.set(COMMAND_FLUSH);
+    if (this->drain_task) {
+        this->drain_task->event_flags.set(COMMAND_FLUSH);
     }
 
-    this->event_state_->queue.send(ArtworkEventType::STREAM_END, 0);
+    this->event_state->queue.send(ArtworkEventType::STREAM_END, 0);
 }
 
-void ArtworkRole::handle_stream_clear() {
-    this->stream_active_ = false;
+void ArtworkRole::Impl::handle_stream_clear() {
+    this->stream_active = false;
 
-    if (this->drain_task_) {
-        this->drain_task_->event_flags.set(COMMAND_FLUSH);
+    if (this->drain_task) {
+        this->drain_task->event_flags.set(COMMAND_FLUSH);
     }
 
-    this->event_state_->queue.send(ArtworkEventType::STREAM_CLEAR, 0);
+    this->event_state->queue.send(ArtworkEventType::STREAM_CLEAR, 0);
 }
 
 // ============================================================================
 // Event draining (main thread) - lifecycle events only
 // ============================================================================
 
-void ArtworkRole::drain_events() {
+void ArtworkRole::Impl::drain_events() {
     ArtworkEventType event_type{};
-    while (this->event_state_->queue.receive(event_type, 0)) {
+    while (this->event_state->queue.receive(event_type, 0)) {
         switch (event_type) {
             case ArtworkEventType::STREAM_START: {
                 ServerArtworkStreamObject config{};
-                if (this->event_state_->shadow_config.take(config) && this->listener_) {
-                    this->listener_->on_artwork_stream_start(config);
+                if (this->event_state->shadow_config.take(config) && this->listener) {
+                    this->listener->on_artwork_stream_start(config);
                 }
                 break;
             }
             case ArtworkEventType::STREAM_END:
-                if (this->listener_) {
-                    for (const auto& pref : this->config_.preferred_formats) {
-                        this->listener_->on_image_clear(pref.slot);
+                if (this->listener) {
+                    for (const auto& pref : this->config.preferred_formats) {
+                        this->listener->on_image_clear(pref.slot);
                     }
-                    this->listener_->on_artwork_stream_end();
+                    this->listener->on_artwork_stream_end();
                 }
                 break;
             case ArtworkEventType::STREAM_CLEAR:
-                if (this->listener_) {
-                    for (const auto& pref : this->config_.preferred_formats) {
-                        this->listener_->on_image_clear(pref.slot);
+                if (this->listener) {
+                    for (const auto& pref : this->config.preferred_formats) {
+                        this->listener->on_image_clear(pref.slot);
                     }
                 }
                 break;
@@ -306,27 +243,27 @@ void ArtworkRole::drain_events() {
 // Cleanup (main thread)
 // ============================================================================
 
-void ArtworkRole::cleanup() {
-    this->stream_active_ = false;
+void ArtworkRole::Impl::cleanup() {
+    this->stream_active = false;
 
-    if (this->drain_task_) {
-        this->drain_task_->event_flags.set(COMMAND_FLUSH);
+    if (this->drain_task) {
+        this->drain_task->event_flags.set(COMMAND_FLUSH);
     }
 
-    this->event_state_->queue.reset();
-    this->event_state_->shadow_config.reset();
-    this->event_state_->queue.send(ArtworkEventType::STREAM_END, 0);
+    this->event_state->queue.reset();
+    this->event_state->shadow_config.reset();
+    this->event_state->queue.send(ArtworkEventType::STREAM_END, 0);
 }
 
 // ============================================================================
 // Drain thread
 // ============================================================================
 
-void ArtworkRole::drain_thread_func(ArtworkRole* self) {
+void ArtworkRole::Impl::drain_thread_func(ArtworkRole::Impl* self) {
     SS_LOGD(TAG, "Drain thread started");
 
-    auto& queue = self->drain_task_->notify_queue;
-    auto& flags = self->drain_task_->event_flags;
+    auto& queue = self->drain_task->notify_queue;
+    auto& flags = self->drain_task->event_flags;
 
     while (true) {
         // Non-blocking check for commands
@@ -349,11 +286,11 @@ void ArtworkRole::drain_thread_func(ArtworkRole* self) {
 
         uint8_t slot = notif.slot;
         uint8_t buf_idx = notif.buffer_idx;
-        if (slot >= MAX_SLOTS) {
+        if (slot >= ARTWORK_MAX_SLOTS) {
             continue;
         }
 
-        auto& sb = self->drain_task_->slot_buffers[slot];
+        auto& sb = self->drain_task->slot_buffers[slot];
         auto& buf = sb.buffers[buf_idx];
 
         if (notif.data_length == 0 || buf.data() == nullptr) {
@@ -365,20 +302,20 @@ void ArtworkRole::drain_thread_func(ArtworkRole* self) {
         sb.drain_active.store(true, std::memory_order_release);
 
         // Phase 1: Decode callback (immediate)
-        if (self->listener_) {
-            self->listener_->on_image_decode(slot, buf.data(), notif.data_length, notif.format);
+        if (self->listener) {
+            self->listener->on_image_decode(slot, buf.data(), notif.data_length, notif.format);
         }
 
         // Buffer is no longer needed after decode completes
         sb.drain_active.store(false, std::memory_order_release);
 
         // Wait for time sync before scheduling display
-        if (!self->client_->is_time_synced()) {
+        if (!self->client->is_time_synced()) {
             continue;
         }
 
         // Phase 2: Wait until display timestamp
-        int64_t client_ts = self->client_->get_client_time(notif.timestamp);
+        int64_t client_ts = self->client->get_client_time(notif.timestamp);
 
         if (client_ts == 0) {
             continue;
@@ -393,20 +330,33 @@ void ArtworkRole::drain_thread_func(ArtworkRole* self) {
                     break;
                 }
                 if (cmd & COMMAND_FLUSH) {
-                    ArtworkNotification dummy{};
-                    while (queue.receive(dummy, 0)) {}
+                    ArtworkNotification dummy2{};
+                    while (queue.receive(dummy2, 0)) {}
                     continue;
                 }
             }
         }
 
         // Display/swap callback
-        if (self->listener_) {
-            self->listener_->on_image_display(slot, client_ts);
+        if (self->listener) {
+            self->listener->on_image_display(slot, client_ts);
         }
     }
 
     SS_LOGD(TAG, "Drain thread stopped");
+}
+
+// ============================================================================
+// ArtworkRole public API (thin forwarding)
+// ============================================================================
+
+ArtworkRole::ArtworkRole(Config config, SendspinClient* client)
+    : impl_(std::make_unique<Impl>(std::move(config), client)) {}
+
+ArtworkRole::~ArtworkRole() = default;
+
+void ArtworkRole::set_listener(ArtworkRoleListener* listener) {
+    this->impl_->listener = listener;
 }
 
 }  // namespace sendspin

--- a/src/artwork_role.cpp
+++ b/src/artwork_role.cpp
@@ -75,12 +75,14 @@ ArtworkRole::Impl::~Impl() {
 
 bool ArtworkRole::Impl::start() {
     if (!this->drain_task) {
+        SS_LOGE(TAG, "Failed to start artwork: drain task not initialized");
         return false;
     }
     if (this->drain_task->drain_thread.joinable()) {
         return true;  // Already running
     }
     if (!this->drain_task->event_flags.is_created() && !this->drain_task->event_flags.create()) {
+        SS_LOGE(TAG, "Failed to create artwork event flags");
         return false;
     }
 

--- a/src/artwork_role.cpp
+++ b/src/artwork_role.cpp
@@ -352,7 +352,7 @@ void ArtworkRole::Impl::drain_thread_func(ArtworkRole::Impl* self) {
 // ArtworkRole public API (thin forwarding)
 // ============================================================================
 
-ArtworkRole::ArtworkRole(Config config, SendspinClient* client)
+ArtworkRole::ArtworkRole(ArtworkRoleConfig config, SendspinClient* client)
     : impl_(std::make_unique<Impl>(std::move(config), client)) {}
 
 ArtworkRole::~ArtworkRole() = default;

--- a/src/artwork_role_impl.h
+++ b/src/artwork_role_impl.h
@@ -94,7 +94,7 @@ struct ArtworkRole::Impl {
     // ========================================
 
     bool start();
-    void build_hello_fields(ClientHelloMessage& msg);
+    void build_hello_fields(ClientHelloMessage& msg) const;
     void handle_binary(uint8_t slot, const uint8_t* data, size_t len);
     void handle_stream_start(const ServerArtworkStreamObject& stream);
     void handle_stream_end();
@@ -106,7 +106,7 @@ struct ArtworkRole::Impl {
     // Helpers
     // ========================================
 
-    void stop();
+    void stop() const;
     static void drain_thread_func(ArtworkRole::Impl* self);
 
     // ========================================

--- a/src/artwork_role_impl.h
+++ b/src/artwork_role_impl.h
@@ -1,0 +1,130 @@
+// Copyright 2026 Sendspin Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @file artwork_role_impl.h
+/// @brief Private implementation for the artwork role (pimpl)
+
+#pragma once
+
+#include "platform/event_flags.h"
+#include "platform/memory.h"
+#include "platform/shadow_slot.h"
+#include "platform/thread_safe_queue.h"
+#include "sendspin/artwork_role.h"
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <thread>
+#include <vector>
+
+namespace sendspin {
+
+class SendspinClient;
+struct ClientHelloMessage;
+
+/// @brief Deferred artwork event types
+enum class ArtworkEventType : uint8_t {
+    STREAM_START,
+    STREAM_END,
+    STREAM_CLEAR,
+};
+
+/// @brief Maximum number of artwork slots (2-bit slot field in protocol binary type byte)
+static constexpr size_t ARTWORK_MAX_SLOTS = 4;
+
+/// @brief Double-buffered image storage for a single artwork slot
+struct SlotBuffer {
+    PlatformBuffer buffers[2];
+    std::atomic<uint8_t> write_idx{0};      ///< Which buffer the network thread writes to next
+    std::atomic<bool> drain_active{false};  ///< True while the drain thread is using a buffer
+    uint8_t drain_buf_idx{0};               ///< Which buffer the drain thread is currently using
+};
+
+/// @brief Notification sent from the network thread to the drain thread when new image data arrives
+///
+/// All metadata is carried in the notification itself (not in SlotBuffer) so that the
+/// ThreadSafeQueue's internal mutex provides the happens-before guarantee between the
+/// network thread's writes and the drain thread's reads.
+struct ArtworkNotification {
+    uint8_t slot;
+    uint8_t buffer_idx;
+    size_t data_length;
+    int64_t timestamp;
+    SendspinImageFormat format;
+};
+
+/// @brief Private implementation of the artwork role
+struct ArtworkRole::Impl {
+    Impl(ArtworkRoleConfig config, SendspinClient* client);
+    ~Impl();
+
+    // ========================================
+    // Nested types
+    // ========================================
+
+    /// @brief Persistent drain thread context for artwork image decode and display delivery
+    struct DrainTask {
+        ThreadSafeQueue<ArtworkNotification> notify_queue;
+        EventFlags event_flags;
+        std::thread drain_thread;
+        SlotBuffer slot_buffers[ARTWORK_MAX_SLOTS];
+    };
+
+    /// @brief Deferred event state for thread-safe artwork stream lifecycle delivery
+    struct EventState {
+        ThreadSafeQueue<ArtworkEventType> queue;
+        ShadowSlot<ServerArtworkStreamObject> shadow_config;
+    };
+
+    // ========================================
+    // Internal integration methods (called by SendspinClient)
+    // ========================================
+
+    bool start();
+    void build_hello_fields(ClientHelloMessage& msg);
+    void handle_binary(uint8_t slot, const uint8_t* data, size_t len);
+    void handle_stream_start(const ServerArtworkStreamObject& stream);
+    void handle_stream_end();
+    void handle_stream_clear();
+    void drain_events();
+    void cleanup();
+
+    // ========================================
+    // Helpers
+    // ========================================
+
+    void stop();
+    static void drain_thread_func(ArtworkRole::Impl* self);
+
+    // ========================================
+    // Fields
+    // ========================================
+
+    // Struct fields
+    ArtworkRoleConfig config;
+    std::vector<ArtworkChannelFormatObject> artwork_channels;
+
+    // Pointer fields
+    SendspinClient* client;
+    std::unique_ptr<DrainTask> drain_task;
+    std::unique_ptr<EventState> event_state;
+    ArtworkRoleListener* listener{nullptr};
+
+    // 8-bit fields
+    std::atomic<bool> stream_active{false};
+};
+
+}  // namespace sendspin

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -622,7 +622,8 @@ void SendspinClient::process_json_message(SendspinConnection* conn, const std::s
 
 #ifdef SENDSPIN_ENABLE_METADATA
                 if (this->metadata_ && state_msg.metadata.has_value()) {
-                    this->metadata_->impl_->handle_server_state(state_msg.metadata.value());
+                    this->metadata_->impl_->handle_server_state(
+                        std::move(state_msg.metadata.value()));
                 }
 #endif
             }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -21,12 +21,22 @@
 #include "platform/shadow_slot.h"
 #include "platform/thread_safe_queue.h"
 #include "platform/time.h"
+#ifdef SENDSPIN_ENABLE_ARTWORK
+#include "artwork_role_impl.h"
+#endif
+#ifdef SENDSPIN_ENABLE_CONTROLLER
+#include "controller_role_impl.h"
+#endif
+#ifdef SENDSPIN_ENABLE_METADATA
+#include "metadata_role_impl.h"
+#endif
+#ifdef SENDSPIN_ENABLE_PLAYER
+#include "player_role_impl.h"
+#endif
 #include "protocol_messages.h"
-#include "sendspin/artwork_role.h"
-#include "sendspin/controller_role.h"
-#include "sendspin/metadata_role.h"
-#include "sendspin/player_role.h"
-#include "sendspin/visualizer_role.h"
+#ifdef SENDSPIN_ENABLE_VISUALIZER
+#include "visualizer_role_impl.h"
+#endif
 #include "time_burst.h"
 #include <ArduinoJson.h>
 
@@ -67,9 +77,15 @@ SendspinClient::SendspinClient(SendspinClientConfig config)
 
 SendspinClient::~SendspinClient() {
     // Stop background threads before tearing down connections.
+#ifdef SENDSPIN_ENABLE_PLAYER
     this->player_.reset();
+#endif
+#ifdef SENDSPIN_ENABLE_VISUALIZER
     this->visualizer_.reset();
+#endif
+#ifdef SENDSPIN_ENABLE_ARTWORK
     this->artwork_.reset();
+#endif
     this->connection_manager_.reset();
 }
 
@@ -91,23 +107,29 @@ bool SendspinClient::start_server() {
     // Load persisted state
     this->load_last_played_server();
 
+#ifdef SENDSPIN_ENABLE_PLAYER
     if (this->player_) {
-        if (!this->player_->start()) {
+        if (!this->player_->impl_->start()) {
             return false;
         }
     }
+#endif
 
+#ifdef SENDSPIN_ENABLE_VISUALIZER
     if (this->visualizer_) {
-        if (!this->visualizer_->start()) {
+        if (!this->visualizer_->impl_->start()) {
             return false;
         }
     }
+#endif
 
+#ifdef SENDSPIN_ENABLE_ARTWORK
     if (this->artwork_) {
-        if (!this->artwork_->start()) {
+        if (!this->artwork_->impl_->start()) {
             return false;
         }
     }
+#endif
 
     // Create and configure the WebSocket server (started later when network is ready)
     this->connection_manager_->init_server(this);
@@ -163,21 +185,31 @@ void SendspinClient::loop() {
     }
 
     // --- Role events (each role handles its own synchronization) ---
+#ifdef SENDSPIN_ENABLE_PLAYER
     if (this->player_) {
-        this->player_->drain_events();
+        this->player_->impl_->drain_events();
     }
+#endif
+#ifdef SENDSPIN_ENABLE_CONTROLLER
     if (this->controller_) {
-        this->controller_->drain_events();
+        this->controller_->impl_->drain_events();
     }
+#endif
+#ifdef SENDSPIN_ENABLE_METADATA
     if (this->metadata_) {
-        this->metadata_->drain_events();
+        this->metadata_->impl_->drain_events();
     }
+#endif
+#ifdef SENDSPIN_ENABLE_ARTWORK
     if (this->artwork_) {
-        this->artwork_->drain_events();
+        this->artwork_->impl_->drain_events();
     }
+#endif
+#ifdef SENDSPIN_ENABLE_VISUALIZER
     if (this->visualizer_) {
-        this->visualizer_->drain_events();
+        this->visualizer_->impl_->drain_events();
     }
+#endif
 
     // --- Group update events ---
     {
@@ -215,7 +247,8 @@ void SendspinClient::loop() {
 // Role registration (call before start_server)
 // ============================================================================
 
-PlayerRole& SendspinClient::add_player(PlayerRole::Config config) {
+#ifdef SENDSPIN_ENABLE_PLAYER
+PlayerRole& SendspinClient::add_player(PlayerRoleConfig config) {
     if (this->started_) {
         SS_LOGW(TAG, "add_player() called after start_server(); role may not initialize correctly");
     }
@@ -223,7 +256,9 @@ PlayerRole& SendspinClient::add_player(PlayerRole::Config config) {
         std::make_unique<PlayerRole>(std::move(config), this, this->persistence_provider_);
     return *this->player_;
 }
+#endif
 
+#ifdef SENDSPIN_ENABLE_CONTROLLER
 ControllerRole& SendspinClient::add_controller() {
     if (this->started_) {
         SS_LOGW(TAG, "add_controller() called after start_server()");
@@ -231,7 +266,9 @@ ControllerRole& SendspinClient::add_controller() {
     this->controller_ = std::make_unique<ControllerRole>(this);
     return *this->controller_;
 }
+#endif
 
+#ifdef SENDSPIN_ENABLE_METADATA
 MetadataRole& SendspinClient::add_metadata() {
     if (this->started_) {
         SS_LOGW(TAG, "add_metadata() called after start_server()");
@@ -239,22 +276,27 @@ MetadataRole& SendspinClient::add_metadata() {
     this->metadata_ = std::make_unique<MetadataRole>(this);
     return *this->metadata_;
 }
+#endif
 
-ArtworkRole& SendspinClient::add_artwork(ArtworkRole::Config config) {
+#ifdef SENDSPIN_ENABLE_ARTWORK
+ArtworkRole& SendspinClient::add_artwork(ArtworkRoleConfig config) {
     if (this->started_) {
         SS_LOGW(TAG, "add_artwork() called after start_server()");
     }
     this->artwork_ = std::make_unique<ArtworkRole>(std::move(config), this);
     return *this->artwork_;
 }
+#endif
 
-VisualizerRole& SendspinClient::add_visualizer(VisualizerRole::Config config) {
+#ifdef SENDSPIN_ENABLE_VISUALIZER
+VisualizerRole& SendspinClient::add_visualizer(VisualizerRoleConfig config) {
     if (this->started_) {
         SS_LOGW(TAG, "add_visualizer() called after start_server()");
     }
     this->visualizer_ = std::make_unique<VisualizerRole>(std::move(config), this);
     return *this->visualizer_;
 }
+#endif
 
 // ============================================================================
 // Queries
@@ -332,21 +374,31 @@ void SendspinClient::cleanup_connection_state() {
     this->event_state_->time_queue.reset();
     this->event_state_->shadow_group.reset();
 
+#ifdef SENDSPIN_ENABLE_PLAYER
     if (this->player_) {
-        this->player_->cleanup();
+        this->player_->impl_->cleanup();
     }
+#endif
+#ifdef SENDSPIN_ENABLE_CONTROLLER
     if (this->controller_) {
-        this->controller_->cleanup();
+        this->controller_->impl_->cleanup();
     }
+#endif
+#ifdef SENDSPIN_ENABLE_METADATA
     if (this->metadata_) {
-        this->metadata_->cleanup();
+        this->metadata_->impl_->cleanup();
     }
+#endif
+#ifdef SENDSPIN_ENABLE_ARTWORK
     if (this->artwork_) {
-        this->artwork_->cleanup();
+        this->artwork_->impl_->cleanup();
     }
+#endif
+#ifdef SENDSPIN_ENABLE_VISUALIZER
     if (this->visualizer_) {
-        this->visualizer_->cleanup();
+        this->visualizer_->impl_->cleanup();
     }
+#endif
 
     // Release high-performance networking for time sync
     if (this->high_performance_held_for_time_) {
@@ -369,21 +421,31 @@ std::string SendspinClient::build_hello_message() {
     msg.version = 1;
 
     // Let each role add its fields to the hello message
+#ifdef SENDSPIN_ENABLE_PLAYER
     if (this->player_) {
-        this->player_->build_hello_fields(msg);
+        this->player_->impl_->build_hello_fields(msg);
     }
+#endif
+#ifdef SENDSPIN_ENABLE_CONTROLLER
     if (this->controller_) {
-        this->controller_->build_hello_fields(msg);
+        this->controller_->impl_->build_hello_fields(msg);
     }
+#endif
+#ifdef SENDSPIN_ENABLE_METADATA
     if (this->metadata_) {
-        this->metadata_->build_hello_fields(msg);
+        this->metadata_->impl_->build_hello_fields(msg);
     }
+#endif
+#ifdef SENDSPIN_ENABLE_ARTWORK
     if (this->artwork_) {
-        this->artwork_->build_hello_fields(msg);
+        this->artwork_->impl_->build_hello_fields(msg);
     }
+#endif
+#ifdef SENDSPIN_ENABLE_VISUALIZER
     if (this->visualizer_) {
-        this->visualizer_->build_hello_fields(msg);
+        this->visualizer_->impl_->build_hello_fields(msg);
     }
+#endif
 
     return format_client_hello_message(&msg);
 }
@@ -414,17 +476,23 @@ void SendspinClient::process_json_message(SendspinConnection* conn, const std::s
                 break;
             }
 
+#ifdef SENDSPIN_ENABLE_PLAYER
             if (this->player_) {
-                this->player_->handle_stream_start(stream_msg);
+                this->player_->impl_->handle_stream_start(stream_msg);
             }
+#endif
 
+#ifdef SENDSPIN_ENABLE_ARTWORK
             if (this->artwork_ && stream_msg.artwork.has_value()) {
-                this->artwork_->handle_stream_start(stream_msg.artwork.value());
+                this->artwork_->impl_->handle_stream_start(stream_msg.artwork.value());
             }
+#endif
 
+#ifdef SENDSPIN_ENABLE_VISUALIZER
             if (this->visualizer_ && stream_msg.visualizer.has_value()) {
-                this->visualizer_->handle_stream_start(stream_msg.visualizer.value());
+                this->visualizer_->impl_->handle_stream_start(stream_msg.visualizer.value());
             }
+#endif
             break;
         }
         case SendspinServerToClientMessageType::STREAM_END: {
@@ -449,17 +517,23 @@ void SendspinClient::process_json_message(SendspinConnection* conn, const std::s
                 SS_LOGD(TAG, "Stream ended - player:%d artwork:%d visualizer:%d", end_player,
                         end_artwork, end_visualizer);
 
+#ifdef SENDSPIN_ENABLE_PLAYER
                 if (this->player_ && end_player) {
-                    this->player_->handle_stream_end();
+                    this->player_->impl_->handle_stream_end();
                 }
+#endif
 
+#ifdef SENDSPIN_ENABLE_ARTWORK
                 if (this->artwork_ && end_artwork) {
-                    this->artwork_->handle_stream_end();
+                    this->artwork_->impl_->handle_stream_end();
                 }
+#endif
 
+#ifdef SENDSPIN_ENABLE_VISUALIZER
                 if (this->visualizer_ && end_visualizer) {
-                    this->visualizer_->handle_stream_end();
+                    this->visualizer_->impl_->handle_stream_end();
                 }
+#endif
             }
             break;
         }
@@ -485,17 +559,23 @@ void SendspinClient::process_json_message(SendspinConnection* conn, const std::s
                 SS_LOGD(TAG, "Stream clear - player:%d artwork:%d visualizer:%d", clear_player,
                         clear_artwork, clear_visualizer);
 
+#ifdef SENDSPIN_ENABLE_PLAYER
                 if (this->player_ && clear_player) {
-                    this->player_->handle_stream_clear();
+                    this->player_->impl_->handle_stream_clear();
                 }
+#endif
 
+#ifdef SENDSPIN_ENABLE_ARTWORK
                 if (this->artwork_ && clear_artwork) {
-                    this->artwork_->handle_stream_clear();
+                    this->artwork_->impl_->handle_stream_clear();
                 }
+#endif
 
+#ifdef SENDSPIN_ENABLE_VISUALIZER
                 if (this->visualizer_ && clear_visualizer) {
-                    this->visualizer_->handle_stream_clear();
+                    this->visualizer_->impl_->handle_stream_clear();
                 }
+#endif
             }
             break;
         }
@@ -533,23 +613,30 @@ void SendspinClient::process_json_message(SendspinConnection* conn, const std::s
         case SendspinServerToClientMessageType::SERVER_STATE: {
             ServerStateMessage state_msg;
             if (process_server_state_message(root, &state_msg)) {
+#ifdef SENDSPIN_ENABLE_CONTROLLER
                 if (this->controller_ && state_msg.controller.has_value()) {
-                    this->controller_->handle_server_state(std::move(state_msg.controller.value()));
+                    this->controller_->impl_->handle_server_state(
+                        std::move(state_msg.controller.value()));
                 }
+#endif
 
+#ifdef SENDSPIN_ENABLE_METADATA
                 if (this->metadata_ && state_msg.metadata.has_value()) {
-                    this->metadata_->handle_server_state(state_msg.metadata.value());
+                    this->metadata_->impl_->handle_server_state(state_msg.metadata.value());
                 }
+#endif
             }
             break;
         }
         case SendspinServerToClientMessageType::SERVER_COMMAND: {
+#ifdef SENDSPIN_ENABLE_PLAYER
             if (this->player_) {
                 ServerCommandMessage cmd_msg;
                 if (process_server_command_message(root, &cmd_msg)) {
-                    this->player_->handle_server_command(cmd_msg);
+                    this->player_->impl_->handle_server_command(cmd_msg);
                 }
             }
+#endif
             break;
         }
         case SendspinServerToClientMessageType::GROUP_UPDATE: {
@@ -584,25 +671,31 @@ void SendspinClient::process_binary_message(const uint8_t* payload, size_t len) 
 
     switch (role) {
         case SENDSPIN_ROLE_PLAYER: {
+#ifdef SENDSPIN_ENABLE_PLAYER
             if (this->player_) {
                 if (slot == 0) {
-                    this->player_->handle_binary(data, data_len);
+                    this->player_->impl_->handle_binary(data, data_len);
                 } else {
                     SS_LOGW(TAG, "Unknown player binary slot %d", slot);
                 }
             }
+#endif
             break;
         }
         case SENDSPIN_ROLE_ARTWORK: {
+#ifdef SENDSPIN_ENABLE_ARTWORK
             if (this->artwork_) {
-                this->artwork_->handle_binary(slot, data, data_len);
+                this->artwork_->impl_->handle_binary(slot, data, data_len);
             }
+#endif
             break;
         }
         case SENDSPIN_ROLE_VISUALIZER: {
+#ifdef SENDSPIN_ENABLE_VISUALIZER
             if (this->visualizer_) {
-                this->visualizer_->handle_binary(binary_type, data, data_len);
+                this->visualizer_->impl_->handle_binary(binary_type, data, data_len);
             }
+#endif
             break;
         }
         default: {
@@ -624,9 +717,11 @@ void SendspinClient::publish_client_state(SendspinConnection* conn) {
     ClientStateMessage state_msg;
     state_msg.state = this->state_;
 
+#ifdef SENDSPIN_ENABLE_PLAYER
     if (this->player_) {
-        this->player_->build_state_fields(state_msg);
+        this->player_->impl_->build_state_fields(state_msg);
     }
+#endif
 
     std::string state_message = format_client_state_message(&state_msg);
     conn->send_text_message(state_message, nullptr);

--- a/src/controller_role.cpp
+++ b/src/controller_role.cpp
@@ -51,7 +51,8 @@ void ControllerRole::send_command(SendspinControllerCommand cmd, std::optional<u
 // ============================================================================
 
 void ControllerRole::Impl::send_command(SendspinControllerCommand cmd,
-                                        std::optional<uint8_t> volume, std::optional<bool> mute) {
+                                        std::optional<uint8_t> volume,
+                                        std::optional<bool> mute) const {
     std::string command_message = format_client_command_message(cmd, volume, mute);
     this->client->send_text(command_message);
 }
@@ -60,7 +61,7 @@ void ControllerRole::Impl::build_hello_fields(ClientHelloMessage& msg) {
     msg.supported_roles.push_back(SendspinRole::CONTROLLER);
 }
 
-void ControllerRole::Impl::handle_server_state(ServerStateControllerObject state) {
+void ControllerRole::Impl::handle_server_state(ServerStateControllerObject state) const {
     this->event_state->shadow.write(std::move(state));
 }
 

--- a/src/controller_role.cpp
+++ b/src/controller_role.cpp
@@ -12,63 +12,71 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "sendspin/controller_role.h"
-
-#include "platform/shadow_slot.h"
+#include "controller_role_impl.h"
 #include "protocol_messages.h"
 #include "sendspin/client.h"
 
 namespace sendspin {
 
-/// @brief Deferred event state for thread-safe controller state delivery
-struct ControllerRole::EventState {
-    ShadowSlot<ServerStateControllerObject> shadow;
-};
-
 // ============================================================================
-// Lifecycle
+// Impl constructor / destructor
 // ============================================================================
 
-ControllerRole::ControllerRole(SendspinClient* client)
-    : client_(client), event_state_(std::make_unique<EventState>()) {}
+ControllerRole::Impl::Impl(SendspinClient* client)
+    : client(client), event_state(std::make_unique<EventState>()) {}
+
+// ============================================================================
+// ControllerRole forwarding (public API → Impl)
+// ============================================================================
+
+ControllerRole::ControllerRole(SendspinClient* client) : impl_(std::make_unique<Impl>(client)) {}
 
 ControllerRole::~ControllerRole() = default;
 
-// ============================================================================
-// Core API
-// ============================================================================
+const ServerStateControllerObject& ControllerRole::get_controller_state() const {
+    return this->impl_->controller_state;
+}
+
+void ControllerRole::set_listener(ControllerRoleListener* listener) {
+    this->impl_->listener = listener;
+}
 
 void ControllerRole::send_command(SendspinControllerCommand cmd, std::optional<uint8_t> volume,
                                   std::optional<bool> mute) {
-    std::string command_message = format_client_command_message(cmd, volume, mute);
-    this->client_->send_text(command_message);
+    this->impl_->send_command(cmd, volume, mute);
 }
 
 // ============================================================================
-// Internal Helpers
+// Impl method implementations
 // ============================================================================
 
-void ControllerRole::build_hello_fields(ClientHelloMessage& msg) {
+void ControllerRole::Impl::send_command(SendspinControllerCommand cmd,
+                                        std::optional<uint8_t> volume, std::optional<bool> mute) {
+    std::string command_message = format_client_command_message(cmd, volume, mute);
+    this->client->send_text(command_message);
+}
+
+void ControllerRole::Impl::build_hello_fields(ClientHelloMessage& msg) {
     msg.supported_roles.push_back(SendspinRole::CONTROLLER);
 }
 
-void ControllerRole::handle_server_state(ServerStateControllerObject state) {
-    this->event_state_->shadow.write(std::move(state));
+void ControllerRole::Impl::handle_server_state(ServerStateControllerObject state) {
+    this->event_state->shadow.write(std::move(state));
 }
 
-void ControllerRole::drain_events() {
+void ControllerRole::Impl::drain_events() {
     ServerStateControllerObject state;
-    if (this->event_state_->shadow.take(state)) {
-        this->controller_state_ = std::move(state);
-        if (this->listener_) {
-            this->listener_->on_controller_state(this->controller_state_);
+    if (this->event_state->shadow.take(state)) {
+        this->controller_state = std::move(state);
+        if (this->listener) {
+            this->listener->on_controller_state(this->controller_state);
         }
     }
 }
 
-void ControllerRole::cleanup() {
-    this->event_state_->shadow.reset();
-    this->controller_state_ = {};
+void ControllerRole::Impl::cleanup() {
+    this->event_state->shadow.reset();
+    this->controller_state = {};
 }
 
 }  // namespace sendspin

--- a/src/controller_role_impl.h
+++ b/src/controller_role_impl.h
@@ -45,7 +45,7 @@ struct ControllerRole::Impl {
     // ========================================
 
     void build_hello_fields(ClientHelloMessage& msg);
-    void handle_server_state(ServerStateControllerObject state);
+    void handle_server_state(ServerStateControllerObject state) const;
     void drain_events();
     void cleanup();
 
@@ -54,7 +54,7 @@ struct ControllerRole::Impl {
     // ========================================
 
     void send_command(SendspinControllerCommand cmd, std::optional<uint8_t> volume,
-                      std::optional<bool> mute);
+                      std::optional<bool> mute) const;
 
     // ========================================
     // Fields

--- a/src/controller_role_impl.h
+++ b/src/controller_role_impl.h
@@ -1,0 +1,72 @@
+// Copyright 2026 Sendspin Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @file controller_role_impl.h
+/// @brief Private implementation for the controller role (pimpl)
+
+#pragma once
+
+#include "platform/shadow_slot.h"
+#include "sendspin/controller_role.h"
+
+#include <memory>
+
+namespace sendspin {
+
+class SendspinClient;
+struct ClientHelloMessage;
+
+/// @brief Private implementation of the controller role
+struct ControllerRole::Impl {
+    explicit Impl(SendspinClient* client);
+    ~Impl() = default;
+
+    // ========================================
+    // Event state
+    // ========================================
+
+    struct EventState {
+        ShadowSlot<ServerStateControllerObject> shadow;
+    };
+
+    // ========================================
+    // Internal integration methods (called by SendspinClient)
+    // ========================================
+
+    void build_hello_fields(ClientHelloMessage& msg);
+    void handle_server_state(ServerStateControllerObject state);
+    void drain_events();
+    void cleanup();
+
+    // ========================================
+    // Consumer-facing method implementations
+    // ========================================
+
+    void send_command(SendspinControllerCommand cmd, std::optional<uint8_t> volume,
+                      std::optional<bool> mute);
+
+    // ========================================
+    // Fields
+    // ========================================
+
+    // Struct fields
+    ServerStateControllerObject controller_state{};
+
+    // Pointer fields
+    SendspinClient* client;
+    std::unique_ptr<EventState> event_state;
+    ControllerRoleListener* listener{nullptr};
+};
+
+}  // namespace sendspin

--- a/src/metadata_role.cpp
+++ b/src/metadata_role.cpp
@@ -98,7 +98,7 @@ void MetadataRole::Impl::build_hello_fields(ClientHelloMessage& msg) {
     msg.supported_roles.push_back(SendspinRole::METADATA);
 }
 
-void MetadataRole::Impl::handle_server_state(ServerMetadataStateObject state) {
+void MetadataRole::Impl::handle_server_state(ServerMetadataStateObject state) const {
     this->event_state->shadow.merge(
         [](ServerMetadataStateObject& current, ServerMetadataStateObject&& delta) {
             apply_metadata_state_deltas(&current, delta);

--- a/src/metadata_role.cpp
+++ b/src/metadata_role.cpp
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "sendspin/metadata_role.h"
-
 #include "audio_stream_info.h"
-#include "platform/shadow_slot.h"
+#include "metadata_role_impl.h"
 #include "platform/time.h"
 #include "protocol_messages.h"
 #include "sendspin/client.h"
@@ -24,44 +22,57 @@
 
 namespace sendspin {
 
-/// @brief Deferred event state for thread-safe metadata delivery to the main thread
-struct MetadataRole::EventState {
-    ShadowSlot<ServerMetadataStateObject> shadow;
-};
-
 // ============================================================================
-// Lifecycle
+// Impl constructor / destructor
 // ============================================================================
 
-MetadataRole::MetadataRole(SendspinClient* client)
-    : client_(client), event_state_(std::make_unique<EventState>()) {}
+MetadataRole::Impl::Impl(SendspinClient* client)
+    : client(client), event_state(std::make_unique<EventState>()) {}
+
+// ============================================================================
+// MetadataRole forwarding (public API → Impl)
+// ============================================================================
+
+MetadataRole::MetadataRole(SendspinClient* client) : impl_(std::make_unique<Impl>(client)) {}
 
 MetadataRole::~MetadataRole() = default;
 
-// ============================================================================
-// Public API
-// ============================================================================
+void MetadataRole::set_listener(MetadataRoleListener* listener) {
+    this->impl_->listener = listener;
+}
 
 uint32_t MetadataRole::get_track_duration_ms() const {
-    if (!this->metadata_.progress.has_value()) {
-        return 0;
-    }
-    return this->metadata_.progress.value().track_duration;
+    return this->impl_->get_track_duration_ms();
 }
 
 uint32_t MetadataRole::get_track_progress_ms() const {
-    if (!this->metadata_.progress.has_value()) {
+    return this->impl_->get_track_progress_ms();
+}
+
+// ============================================================================
+// Impl method implementations
+// ============================================================================
+
+uint32_t MetadataRole::Impl::get_track_duration_ms() const {
+    if (!this->metadata.progress.has_value()) {
+        return 0;
+    }
+    return this->metadata.progress.value().track_duration;
+}
+
+uint32_t MetadataRole::Impl::get_track_progress_ms() const {
+    if (!this->metadata.progress.has_value()) {
         return 0;
     }
 
-    const auto& progress = this->metadata_.progress.value();
+    const auto& progress = this->metadata.progress.value();
 
     // If paused (playback_speed == 0), return the snapshot value directly
     if (progress.playback_speed == 0) {
         return progress.track_progress;
     }
 
-    int64_t client_target = this->client_->get_client_time(this->metadata_.timestamp);
+    int64_t client_target = this->client->get_client_time(this->metadata.timestamp);
     if (client_target == 0) {
         return progress.track_progress;
     }
@@ -83,35 +94,31 @@ uint32_t MetadataRole::get_track_progress_ms() const {
     return static_cast<uint32_t>(calculated);
 }
 
-// ============================================================================
-// Internal Helpers
-// ============================================================================
-
-void MetadataRole::build_hello_fields(ClientHelloMessage& msg) {
+void MetadataRole::Impl::build_hello_fields(ClientHelloMessage& msg) {
     msg.supported_roles.push_back(SendspinRole::METADATA);
 }
 
-void MetadataRole::handle_server_state(ServerMetadataStateObject state) {
-    this->event_state_->shadow.merge(
+void MetadataRole::Impl::handle_server_state(ServerMetadataStateObject state) {
+    this->event_state->shadow.merge(
         [](ServerMetadataStateObject& current, ServerMetadataStateObject&& delta) {
             apply_metadata_state_deltas(&current, delta);
         },
         std::move(state));
 }
 
-void MetadataRole::drain_events() {
+void MetadataRole::Impl::drain_events() {
     ServerMetadataStateObject delta{};
-    if (this->event_state_->shadow.take(delta)) {
-        apply_metadata_state_deltas(&this->metadata_, delta);
-        if (this->listener_) {
-            this->listener_->on_metadata(this->metadata_);
+    if (this->event_state->shadow.take(delta)) {
+        apply_metadata_state_deltas(&this->metadata, delta);
+        if (this->listener) {
+            this->listener->on_metadata(this->metadata);
         }
     }
 }
 
-void MetadataRole::cleanup() {
-    this->event_state_->shadow.reset();
-    this->metadata_ = {};
+void MetadataRole::Impl::cleanup() {
+    this->event_state->shadow.reset();
+    this->metadata = {};
 }
 
 }  // namespace sendspin

--- a/src/metadata_role_impl.h
+++ b/src/metadata_role_impl.h
@@ -1,0 +1,72 @@
+// Copyright 2026 Sendspin Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @file metadata_role_impl.h
+/// @brief Private implementation for the metadata role (pimpl)
+
+#pragma once
+
+#include "platform/shadow_slot.h"
+#include "sendspin/metadata_role.h"
+
+#include <memory>
+
+namespace sendspin {
+
+class SendspinClient;
+struct ClientHelloMessage;
+
+/// @brief Private implementation of the metadata role
+struct MetadataRole::Impl {
+    explicit Impl(SendspinClient* client);
+    ~Impl() = default;
+
+    // ========================================
+    // Event state
+    // ========================================
+
+    struct EventState {
+        ShadowSlot<ServerMetadataStateObject> shadow;
+    };
+
+    // ========================================
+    // Internal integration methods (called by SendspinClient)
+    // ========================================
+
+    void build_hello_fields(ClientHelloMessage& msg);
+    void handle_server_state(ServerMetadataStateObject state);
+    void drain_events();
+    void cleanup();
+
+    // ========================================
+    // Consumer-facing method implementations
+    // ========================================
+
+    uint32_t get_track_duration_ms() const;
+    uint32_t get_track_progress_ms() const;
+
+    // ========================================
+    // Fields
+    // ========================================
+
+    // Struct fields
+    ServerMetadataStateObject metadata{};
+
+    // Pointer fields
+    SendspinClient* client;
+    std::unique_ptr<EventState> event_state;
+    MetadataRoleListener* listener{nullptr};
+};
+
+}  // namespace sendspin

--- a/src/metadata_role_impl.h
+++ b/src/metadata_role_impl.h
@@ -45,7 +45,7 @@ struct MetadataRole::Impl {
     // ========================================
 
     void build_hello_fields(ClientHelloMessage& msg);
-    void handle_server_state(ServerMetadataStateObject state);
+    void handle_server_state(ServerMetadataStateObject state) const;
     void drain_events();
     void cleanup();
 

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -297,17 +297,17 @@ void PlayerRole::Impl::handle_stream_start(const StreamStartMessage& stream_msg)
     }
 }
 
-void PlayerRole::Impl::handle_stream_end() {
+void PlayerRole::Impl::handle_stream_end() const {
     this->sync_task->signal_stream_end();
     this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_END, 0);
 }
 
-void PlayerRole::Impl::handle_stream_clear() {
+void PlayerRole::Impl::handle_stream_clear() const {
     this->sync_task->signal_stream_clear();
     this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_CLEAR, 0);
 }
 
-void PlayerRole::Impl::handle_server_command(const ServerCommandMessage& cmd) {
+void PlayerRole::Impl::handle_server_command(const ServerCommandMessage& cmd) const {
     if (!cmd.player.has_value()) {
         SS_LOGV(TAG, "Server command has no player commands");
         return;
@@ -465,7 +465,7 @@ void PlayerRole::Impl::cleanup() {
 // ============================================================================
 
 bool PlayerRole::Impl::send_audio_chunk(const uint8_t* data, size_t data_size, int64_t timestamp,
-                                        uint8_t chunk_type, uint32_t timeout_ms) {
+                                        uint8_t chunk_type, uint32_t timeout_ms) const {
     if (data == nullptr || data_size == 0) {
         SS_LOGE(TAG, "Invalid data passed to send_audio_chunk");
         return false;
@@ -475,7 +475,7 @@ bool PlayerRole::Impl::send_audio_chunk(const uint8_t* data, size_t data_size, i
                                               static_cast<ChunkType>(chunk_type), timeout_ms);
 }
 
-void PlayerRole::Impl::enqueue_state_update(SendspinClientState state) {
+void PlayerRole::Impl::enqueue_state_update(SendspinClientState state) const {
     this->event_state->state_queue.send(state, 0);
 }
 
@@ -503,7 +503,7 @@ void PlayerRole::Impl::load_static_delay() {
     }
 }
 
-void PlayerRole::Impl::persist_static_delay() {
+void PlayerRole::Impl::persist_static_delay() const {
     if (this->persistence) {
         if (this->persistence->save_static_delay(this->static_delay_ms)) {
             SS_LOGD(TAG, "Persisted static delay: %u ms", this->static_delay_ms);

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -218,7 +218,7 @@ void PlayerRole::Impl::build_state_fields(ClientStateMessage& msg) const {
     msg.player = player_state;
 }
 
-void PlayerRole::Impl::handle_binary(const uint8_t* data, size_t len) {
+void PlayerRole::Impl::handle_binary(const uint8_t* data, size_t len) const {
     if (this->config.audio_formats.empty()) {
         return;
     }

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -87,7 +87,7 @@ PlayerRole::Impl::~Impl() {
 // PlayerRole forwarding (public API → Impl)
 // ============================================================================
 
-PlayerRole::PlayerRole(Config config, SendspinClient* client,
+PlayerRole::PlayerRole(PlayerRoleConfig config, SendspinClient* client,
                        SendspinPersistenceProvider* persistence)
     : impl_(std::make_unique<Impl>(std::move(config), client, persistence)) {}
 

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -89,9 +89,7 @@ PlayerRole::Impl::~Impl() {
 
 PlayerRole::PlayerRole(Config config, SendspinClient* client,
                        SendspinPersistenceProvider* persistence)
-    : impl_(std::make_unique<Impl>(std::move(config), client, persistence)) {
-    impl_->owner = this;
-}
+    : impl_(std::make_unique<Impl>(std::move(config), client, persistence)) {}
 
 PlayerRole::~PlayerRole() = default;
 
@@ -174,7 +172,7 @@ bool PlayerRole::Impl::start() {
 
     if (!this->config.audio_formats.empty() && this->listener &&
         !this->sync_task->is_initialized()) {
-        if (!this->sync_task->init(this->owner, this->client, this->config.audio_buffer_capacity)) {
+        if (!this->sync_task->init(this, this->client, this->config.audio_buffer_capacity)) {
             SS_LOGE(TAG, "Failed to initialize sync task");
             return false;
         }
@@ -378,7 +376,7 @@ void PlayerRole::Impl::drain_events() {
             if (player_cmd.static_delay_ms.has_value()) {
                 this->update_static_delay(player_cmd.static_delay_ms.value());
                 if (this->listener) {
-                    this->listener->on_static_delay_changed(player_cmd.static_delay_ms.value());
+                    this->listener->on_static_delay_changed(this->static_delay_ms);
                 }
             }
         }

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -12,16 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "sendspin/player_role.h"
-
 #include "audio_types.h"
 #include "platform/base64.h"
 #include "platform/logging.h"
-#include "platform/shadow_slot.h"
-#include "platform/thread_safe_queue.h"
+#include "player_role_impl.h"
 #include "protocol_messages.h"
 #include "sendspin/client.h"
-#include "sync_task.h"
 
 static const char* const TAG = "sendspin.player";
 
@@ -66,92 +62,123 @@ static std::vector<uint8_t> base64_decode(const std::string& input) {
 }
 
 // ============================================================================
-// Event state (PIMPL, hides platform queue/shadow headers)
+// Impl constructor / destructor
 // ============================================================================
 
-/// @brief PIMPL event state: queues and shadow slots used to pass data from background threads
-/// (network thread and sync task thread) to the main loop thread for the player role
-struct PlayerRole::EventState {
-    ThreadSafeQueue<PlayerRole::StreamCallbackType> stream_queue;
-    ThreadSafeQueue<SendspinClientState> state_queue;
-    ShadowSlot<ServerPlayerStreamObject> shadow_stream_params;
-    ShadowSlot<ServerCommandMessage> shadow_command;
-};
+PlayerRole::Impl::Impl(PlayerRoleConfig config, SendspinClient* client,
+                       SendspinPersistenceProvider* persistence)
+    : config(std::move(config)),
+      client(client),
+      event_state(std::make_unique<EventState>()),
+      persistence(persistence),
+      sync_task(std::make_unique<SyncTask>()) {
+    this->event_state->stream_queue.create(8);
+    this->event_state->state_queue.create(4);
+}
+
+PlayerRole::Impl::~Impl() {
+    // Stop the sync task thread first, before destroying other members.
+    // External callbacks (e.g., PortAudio) may still call notify_audio_played() on another thread,
+    // so the sync task must be stopped while it's still valid.
+    this->sync_task.reset();
+}
 
 // ============================================================================
-// Constructor / Destructor
+// PlayerRole forwarding (public API → Impl)
 // ============================================================================
 
 PlayerRole::PlayerRole(Config config, SendspinClient* client,
                        SendspinPersistenceProvider* persistence)
-    : config_(std::move(config)),
-      client_(client),
-      event_state_(std::make_unique<EventState>()),
-      persistence_(persistence),
-      sync_task_(std::make_unique<SyncTask>()) {
-    this->event_state_->stream_queue.create(8);
-    this->event_state_->state_queue.create(4);
+    : impl_(std::make_unique<Impl>(std::move(config), client, persistence)) {
+    impl_->owner = this;
 }
 
-PlayerRole::~PlayerRole() {
-    // Stop the sync task thread first, before destroying other members.
-    // External callbacks (e.g., PortAudio) may still call notify_audio_played() on another thread,
-    // so the sync task must be stopped while it's still valid.
-    this->sync_task_.reset();
-}
+PlayerRole::~PlayerRole() = default;
 
-// ============================================================================
-// Audio
-// ============================================================================
+void PlayerRole::set_listener(PlayerRoleListener* listener) {
+    this->impl_->listener = listener;
+}
 
 void PlayerRole::notify_audio_played(uint32_t frames, int64_t timestamp) {
-    if (this->sync_task_ && this->sync_task_->is_running()) {
-        this->sync_task_->notify_audio_played(frames, timestamp);
+    if (this->impl_->sync_task && this->impl_->sync_task->is_running()) {
+        this->impl_->sync_task->notify_audio_played(frames, timestamp);
     }
 }
 
-// ============================================================================
-// State updates
-// ============================================================================
-
 void PlayerRole::update_volume(uint8_t volume) {
-    this->volume_ = volume;
-    this->client_->publish_state();
+    this->impl_->update_volume(volume);
 }
 
 void PlayerRole::update_muted(bool muted) {
-    this->muted_ = muted;
-    this->client_->publish_state();
+    this->impl_->update_muted(muted);
 }
 
 void PlayerRole::update_static_delay(uint16_t delay_ms) {
-    if (delay_ms > MAX_STATIC_DELAY_MS) {
-        delay_ms = MAX_STATIC_DELAY_MS;
-    }
-    this->static_delay_ms_ = delay_ms;
-    this->persist_static_delay();
-    this->client_->publish_state();
+    this->impl_->update_static_delay(delay_ms);
 }
 
 void PlayerRole::set_static_delay_adjustable(bool adjustable) {
-    this->static_delay_adjustable_ = adjustable;
-    this->client_->publish_state();
+    this->impl_->static_delay_adjustable = adjustable;
+    this->impl_->client->publish_state();
+}
+
+const ServerPlayerStreamObject& PlayerRole::get_current_stream_params() const {
+    return this->impl_->current_stream_params;
+}
+
+int32_t PlayerRole::get_fixed_delay_us() const {
+    return this->impl_->config.fixed_delay_us;
+}
+
+bool PlayerRole::get_muted() const {
+    return this->impl_->muted;
+}
+
+uint16_t PlayerRole::get_static_delay_ms() const {
+    return this->impl_->static_delay_ms;
+}
+
+uint8_t PlayerRole::get_volume() const {
+    return this->impl_->volume;
 }
 
 // ============================================================================
-// Private integration methods
+// Impl: State updates
 // ============================================================================
 
-bool PlayerRole::start() {
+void PlayerRole::Impl::update_volume(uint8_t volume) {
+    this->volume = volume;
+    this->client->publish_state();
+}
+
+void PlayerRole::Impl::update_muted(bool muted) {
+    this->muted = muted;
+    this->client->publish_state();
+}
+
+void PlayerRole::Impl::update_static_delay(uint16_t delay_ms) {
+    if (delay_ms > MAX_STATIC_DELAY_MS) {
+        delay_ms = MAX_STATIC_DELAY_MS;
+    }
+    this->static_delay_ms = delay_ms;
+    this->persist_static_delay();
+    this->client->publish_state();
+}
+
+// ============================================================================
+// Impl: Internal integration methods
+// ============================================================================
+
+bool PlayerRole::Impl::start() {
     this->load_static_delay();
 
-    if (!this->config_.audio_formats.empty() && this->listener_ &&
-        !this->sync_task_->is_initialized()) {
-        if (!this->sync_task_->init(this, this->client_, this->config_.audio_buffer_capacity)) {
+    if (!this->config.audio_formats.empty() && this->listener &&
+        !this->sync_task->is_initialized()) {
+        if (!this->sync_task->init(this->owner, this->client, this->config.audio_buffer_capacity)) {
             SS_LOGE(TAG, "Failed to initialize sync task");
             return false;
         }
-        if (!this->sync_task_->start(this->config_.psram_stack, this->config_.priority)) {
+        if (!this->sync_task->start(this->config.psram_stack, this->config.priority)) {
             SS_LOGE(TAG, "Failed to start sync task thread");
             return false;
         }
@@ -159,8 +186,8 @@ bool PlayerRole::start() {
     return true;
 }
 
-void PlayerRole::build_hello_fields(ClientHelloMessage& msg) {
-    if (this->config_.audio_formats.empty()) {
+void PlayerRole::Impl::build_hello_fields(ClientHelloMessage& msg) {
+    if (this->config.audio_formats.empty()) {
         return;
     }
 
@@ -169,8 +196,8 @@ void PlayerRole::build_hello_fields(ClientHelloMessage& msg) {
     // Advertise 80% of the buffer capacity to account for ring buffer metadata overhead
     // and rapid stop/start scenarios
     PlayerSupportObject player_support = {
-        .supported_formats = this->config_.audio_formats,
-        .buffer_capacity = this->config_.audio_buffer_capacity *
+        .supported_formats = this->config.audio_formats,
+        .buffer_capacity = this->config.audio_buffer_capacity *
                            (AUDIO_BUFFER_ADVERTISE_DENOMINATOR - 1) /
                            AUDIO_BUFFER_ADVERTISE_DENOMINATOR,
         .supported_commands = {SendspinPlayerCommand::VOLUME, SendspinPlayerCommand::MUTE},
@@ -178,23 +205,23 @@ void PlayerRole::build_hello_fields(ClientHelloMessage& msg) {
     msg.player_v1_support = player_support;
 }
 
-void PlayerRole::build_state_fields(ClientStateMessage& msg) const {
-    if (this->config_.audio_formats.empty()) {
+void PlayerRole::Impl::build_state_fields(ClientStateMessage& msg) const {
+    if (this->config.audio_formats.empty()) {
         return;
     }
 
     ClientPlayerStateObject player_state{};
-    player_state.volume = this->volume_;
-    player_state.muted = this->muted_;
-    player_state.static_delay_ms = this->static_delay_ms_;
-    if (this->static_delay_adjustable_) {
+    player_state.volume = this->volume;
+    player_state.muted = this->muted;
+    player_state.static_delay_ms = this->static_delay_ms;
+    if (this->static_delay_adjustable) {
         player_state.supported_commands = {SendspinPlayerCommand::SET_STATIC_DELAY};
     }
     msg.player = player_state;
 }
 
-void PlayerRole::handle_binary(const uint8_t* data, size_t len) {
-    if (this->config_.audio_formats.empty()) {
+void PlayerRole::Impl::handle_binary(const uint8_t* data, size_t len) {
+    if (this->config.audio_formats.empty()) {
         return;
     }
     if (len < BINARY_TIMESTAMP_SIZE) {
@@ -208,17 +235,17 @@ void PlayerRole::handle_binary(const uint8_t* data, size_t len) {
     }
 }
 
-void PlayerRole::handle_stream_start(const StreamStartMessage& stream_msg) {
-    if (this->config_.audio_formats.empty()) {
+void PlayerRole::Impl::handle_stream_start(const StreamStartMessage& stream_msg) {
+    if (this->config.audio_formats.empty()) {
         // No audio formats, just defer stream start callback
-        this->event_state_->stream_queue.send(StreamCallbackType::STREAM_START, 0);
+        this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_START, 0);
         return;
     }
 
     // Request high-performance networking for playback
-    if (!this->high_performance_requested_for_playback_) {
-        this->client_->acquire_high_performance();
-        this->high_performance_requested_for_playback_ = true;
+    if (!this->high_performance_requested_for_playback) {
+        this->client->acquire_high_performance();
+        this->high_performance_requested_for_playback = true;
     }
 
     if (stream_msg.player.has_value()) {
@@ -258,36 +285,36 @@ void PlayerRole::handle_stream_start(const StreamStartMessage& stream_msg) {
 
         if (!header_sent) {
             SS_LOGE(TAG, "Failed to send codec header");
-            this->sync_task_->signal_stream_end();
-            this->event_state_->stream_queue.send(StreamCallbackType::STREAM_END, 0);
+            this->sync_task->signal_stream_end();
+            this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_END, 0);
             return;
         }
 
         // Shadow stream params for main thread, then signal
-        this->event_state_->shadow_stream_params.write(player_obj);
-        this->event_state_->stream_queue.send(StreamCallbackType::STREAM_START, 0);
+        this->event_state->shadow_stream_params.write(player_obj);
+        this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_START, 0);
     } else {
         // No player in stream start -- sync task is already running (idle)
-        this->event_state_->stream_queue.send(StreamCallbackType::STREAM_START, 0);
+        this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_START, 0);
     }
 }
 
-void PlayerRole::handle_stream_end() {
-    this->sync_task_->signal_stream_end();
-    this->event_state_->stream_queue.send(StreamCallbackType::STREAM_END, 0);
+void PlayerRole::Impl::handle_stream_end() {
+    this->sync_task->signal_stream_end();
+    this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_END, 0);
 }
 
-void PlayerRole::handle_stream_clear() {
-    this->sync_task_->signal_stream_clear();
-    this->event_state_->stream_queue.send(StreamCallbackType::STREAM_CLEAR, 0);
+void PlayerRole::Impl::handle_stream_clear() {
+    this->sync_task->signal_stream_clear();
+    this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_CLEAR, 0);
 }
 
-void PlayerRole::handle_server_command(const ServerCommandMessage& cmd) {
+void PlayerRole::Impl::handle_server_command(const ServerCommandMessage& cmd) {
     if (!cmd.player.has_value()) {
         SS_LOGV(TAG, "Server command has no player commands");
         return;
     }
-    this->event_state_->shadow_command.merge(
+    this->event_state->shadow_command.merge(
         [](ServerCommandMessage& current, ServerCommandMessage&& delta) {
             if (!delta.player.has_value()) {
                 return;
@@ -313,92 +340,92 @@ void PlayerRole::handle_server_command(const ServerCommandMessage& cmd) {
         cmd);
 }
 
-void PlayerRole::drain_events() {
+void PlayerRole::Impl::drain_events() {
     // --- Client state events (from sync task) ---
     SendspinClientState state{};
     SendspinClientState last_state{};
     bool has_state = false;
-    while (this->event_state_->state_queue.receive(state, 0)) {
+    while (this->event_state->state_queue.receive(state, 0)) {
         last_state = state;
         has_state = true;
     }
     if (has_state) {
-        this->client_->update_state(last_state);
+        this->client->update_state(last_state);
     }
 
     // --- Server command events (volume, mute, static delay) ---
     // Check each field independently since multiple command types may have been
     // merged into one shadow slot between drain ticks.
     ServerCommandMessage cmd_msg{};
-    if (this->event_state_->shadow_command.take(cmd_msg)) {
+    if (this->event_state->shadow_command.take(cmd_msg)) {
         if (cmd_msg.player.has_value()) {
             const ServerPlayerCommandObject& player_cmd = cmd_msg.player.value();
 
             if (player_cmd.volume.has_value()) {
                 this->update_volume(player_cmd.volume.value());
-                if (this->listener_) {
-                    this->listener_->on_volume_changed(player_cmd.volume.value());
+                if (this->listener) {
+                    this->listener->on_volume_changed(player_cmd.volume.value());
                 }
             }
 
             if (player_cmd.mute.has_value()) {
                 this->update_muted(player_cmd.mute.value());
-                if (this->listener_) {
-                    this->listener_->on_mute_changed(player_cmd.mute.value());
+                if (this->listener) {
+                    this->listener->on_mute_changed(player_cmd.mute.value());
                 }
             }
 
             if (player_cmd.static_delay_ms.has_value()) {
                 this->update_static_delay(player_cmd.static_delay_ms.value());
-                if (this->listener_) {
-                    this->listener_->on_static_delay_changed(player_cmd.static_delay_ms.value());
+                if (this->listener) {
+                    this->listener->on_static_delay_changed(player_cmd.static_delay_ms.value());
                 }
             }
         }
     }
 
     // --- Stream lifecycle callback events ---
-    StreamCallbackType stream_event{};
-    while (this->event_state_->stream_queue.receive(stream_event, 0)) {
-        this->awaiting_sync_idle_events_.push_back(stream_event);
+    PlayerStreamCallbackType stream_event{};
+    while (this->event_state->stream_queue.receive(stream_event, 0)) {
+        this->awaiting_sync_idle_events.push_back(stream_event);
     }
 
     // --- Process awaiting sync idle events ---
-    if (!this->awaiting_sync_idle_events_.empty()) {
-        bool sync_idle = !this->sync_task_->is_running();
+    if (!this->awaiting_sync_idle_events.empty()) {
+        bool sync_idle = !this->sync_task->is_running();
         size_t processed = 0;
 
-        for (auto& event : this->awaiting_sync_idle_events_) {
-            if ((event == StreamCallbackType::STREAM_END ||
-                 event == StreamCallbackType::STREAM_CLEAR) &&
+        for (auto& event : this->awaiting_sync_idle_events) {
+            if ((event == PlayerStreamCallbackType::STREAM_END ||
+                 event == PlayerStreamCallbackType::STREAM_CLEAR) &&
                 !sync_idle) {
                 break;  // Wait for sync task to go idle before firing this and anything after it
             }
 
             switch (event) {
-                case StreamCallbackType::STREAM_END:
-                    if (this->listener_) {
-                        this->listener_->on_stream_end();
+                case PlayerStreamCallbackType::STREAM_END:
+                    if (this->listener) {
+                        this->listener->on_stream_end();
                     }
-                    if (this->high_performance_requested_for_playback_) {
-                        this->client_->release_high_performance();
-                        this->high_performance_requested_for_playback_ = false;
-                    }
-                    break;
-                case StreamCallbackType::STREAM_CLEAR:
-                    if (this->listener_) {
-                        this->listener_->on_stream_clear();
+                    if (this->high_performance_requested_for_playback) {
+                        this->client->release_high_performance();
+                        this->high_performance_requested_for_playback = false;
                     }
                     break;
-                case StreamCallbackType::STREAM_START: {
+                case PlayerStreamCallbackType::STREAM_CLEAR:
+                    if (this->listener) {
+                        this->listener->on_stream_clear();
+                    }
+                    break;
+                case PlayerStreamCallbackType::STREAM_START: {
                     ServerPlayerStreamObject stream_params;
-                    if (this->event_state_->shadow_stream_params.take(stream_params)) {
-                        this->current_stream_params_ = std::move(stream_params);
+                    if (this->event_state->shadow_stream_params.take(stream_params)) {
+                        this->current_stream_params = std::move(stream_params);
                     }
-                    if (this->listener_) {
-                        this->listener_->on_stream_start();
+                    if (this->listener) {
+                        this->listener->on_stream_start();
                     }
-                    this->sync_task_->signal_stream_start();
+                    this->sync_task->signal_stream_start();
                     break;
                 }
             }
@@ -406,82 +433,82 @@ void PlayerRole::drain_events() {
         }
 
         if (processed > 0) {
-            this->awaiting_sync_idle_events_.erase(
-                this->awaiting_sync_idle_events_.begin(),
-                this->awaiting_sync_idle_events_.begin() + static_cast<ptrdiff_t>(processed));
+            this->awaiting_sync_idle_events.erase(
+                this->awaiting_sync_idle_events.begin(),
+                this->awaiting_sync_idle_events.begin() + static_cast<ptrdiff_t>(processed));
         }
     }
 }
 
-void PlayerRole::cleanup() {
+void PlayerRole::Impl::cleanup() {
     // Clear all buffered audio immediately
-    this->sync_task_->signal_stream_clear();
+    this->sync_task->signal_stream_clear();
 
     // Discard stale events from the dead connection
-    this->event_state_->stream_queue.reset();
-    this->event_state_->state_queue.reset();
-    this->event_state_->shadow_stream_params.reset();
-    this->event_state_->shadow_command.reset();
+    this->event_state->stream_queue.reset();
+    this->event_state->state_queue.reset();
+    this->event_state->shadow_stream_params.reset();
+    this->event_state->shadow_command.reset();
 
     // Enqueue a clean STREAM_END - drain_events() will fire the callback
-    this->event_state_->stream_queue.send(StreamCallbackType::STREAM_END, 0);
+    this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_END, 0);
 
     // Clear awaiting events too (main-thread only, no mutex needed)
-    this->awaiting_sync_idle_events_.clear();
+    this->awaiting_sync_idle_events.clear();
 
-    if (this->high_performance_requested_for_playback_) {
-        this->client_->release_high_performance();
-        this->high_performance_requested_for_playback_ = false;
+    if (this->high_performance_requested_for_playback) {
+        this->client->release_high_performance();
+        this->high_performance_requested_for_playback = false;
     }
 }
 
 // ============================================================================
-// Helpers
+// Impl: Helpers
 // ============================================================================
 
-bool PlayerRole::send_audio_chunk(const uint8_t* data, size_t data_size, int64_t timestamp,
-                                  uint8_t chunk_type, uint32_t timeout_ms) {
+bool PlayerRole::Impl::send_audio_chunk(const uint8_t* data, size_t data_size, int64_t timestamp,
+                                        uint8_t chunk_type, uint32_t timeout_ms) {
     if (data == nullptr || data_size == 0) {
         SS_LOGE(TAG, "Invalid data passed to send_audio_chunk");
         return false;
     }
 
-    return this->sync_task_->write_audio_chunk(data, data_size, timestamp,
-                                               static_cast<ChunkType>(chunk_type), timeout_ms);
+    return this->sync_task->write_audio_chunk(data, data_size, timestamp,
+                                              static_cast<ChunkType>(chunk_type), timeout_ms);
 }
 
-void PlayerRole::enqueue_state_update(SendspinClientState state) {
-    this->event_state_->state_queue.send(state, 0);
+void PlayerRole::Impl::enqueue_state_update(SendspinClientState state) {
+    this->event_state->state_queue.send(state, 0);
 }
 
-void PlayerRole::load_static_delay() {
-    if (!this->persistence_) {
+void PlayerRole::Impl::load_static_delay() {
+    if (!this->persistence) {
         // No persistence provider - use initial value from config
-        if (this->config_.initial_static_delay_ms > 0) {
-            this->static_delay_ms_ = this->config_.initial_static_delay_ms;
-            SS_LOGI(TAG, "Using initial static delay from config: %u ms", this->static_delay_ms_);
+        if (this->config.initial_static_delay_ms > 0) {
+            this->static_delay_ms = this->config.initial_static_delay_ms;
+            SS_LOGI(TAG, "Using initial static delay from config: %u ms", this->static_delay_ms);
         }
         return;
     }
 
-    auto delay = this->persistence_->load_static_delay();
+    auto delay = this->persistence->load_static_delay();
     if (delay.has_value()) {
         if (delay.value() <= MAX_STATIC_DELAY_MS) {
-            this->static_delay_ms_ = delay.value();
-            SS_LOGI(TAG, "Loaded static delay: %u ms", this->static_delay_ms_);
+            this->static_delay_ms = delay.value();
+            SS_LOGI(TAG, "Loaded static delay: %u ms", this->static_delay_ms);
         } else {
             SS_LOGW(TAG, "Persisted static delay out of range (%u), ignoring", delay.value());
         }
-    } else if (this->config_.initial_static_delay_ms > 0) {
-        this->static_delay_ms_ = this->config_.initial_static_delay_ms;
-        SS_LOGI(TAG, "Using initial static delay from config: %u ms", this->static_delay_ms_);
+    } else if (this->config.initial_static_delay_ms > 0) {
+        this->static_delay_ms = this->config.initial_static_delay_ms;
+        SS_LOGI(TAG, "Using initial static delay from config: %u ms", this->static_delay_ms);
     }
 }
 
-void PlayerRole::persist_static_delay() {
-    if (this->persistence_) {
-        if (this->persistence_->save_static_delay(this->static_delay_ms_)) {
-            SS_LOGD(TAG, "Persisted static delay: %u ms", this->static_delay_ms_);
+void PlayerRole::Impl::persist_static_delay() {
+    if (this->persistence) {
+        if (this->persistence->save_static_delay(this->static_delay_ms)) {
+            SS_LOGD(TAG, "Persisted static delay: %u ms", this->static_delay_ms);
         } else {
             SS_LOGW(TAG, "Failed to persist static delay");
         }

--- a/src/player_role_impl.h
+++ b/src/player_role_impl.h
@@ -102,7 +102,6 @@ struct PlayerRole::Impl {
     SendspinClient* client;
     std::unique_ptr<EventState> event_state;
     PlayerRoleListener* listener{nullptr};
-    PlayerRole* owner{nullptr};  // Back-pointer to owning PlayerRole (set after construction)
     SendspinPersistenceProvider* persistence;
     std::unique_ptr<SyncTask> sync_task;
 

--- a/src/player_role_impl.h
+++ b/src/player_role_impl.h
@@ -1,0 +1,119 @@
+// Copyright 2026 Sendspin Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @file player_role_impl.h
+/// @brief Private implementation for the player role (pimpl)
+
+#pragma once
+
+#include "platform/shadow_slot.h"
+#include "platform/thread_safe_queue.h"
+#include "sendspin/player_role.h"
+#include "sync_task.h"
+
+#include <memory>
+#include <vector>
+
+namespace sendspin {
+
+class SendspinClient;
+class SendspinPersistenceProvider;
+struct ClientHelloMessage;
+struct ClientStateMessage;
+struct StreamStartMessage;
+
+/// @brief Deferred stream lifecycle callback types queued from the network thread
+enum class PlayerStreamCallbackType : uint8_t {
+    STREAM_START,  // New stream is starting
+    STREAM_END,    // Stream ended normally
+    STREAM_CLEAR,  // Stream cleared immediately
+};
+
+/// @brief Private implementation of the player role
+struct PlayerRole::Impl {
+    Impl(PlayerRoleConfig config, SendspinClient* client, SendspinPersistenceProvider* persistence);
+    ~Impl();
+
+    // ========================================
+    // Event state
+    // ========================================
+
+    struct EventState {
+        ThreadSafeQueue<PlayerStreamCallbackType> stream_queue;
+        ThreadSafeQueue<SendspinClientState> state_queue;
+        ShadowSlot<ServerPlayerStreamObject> shadow_stream_params;
+        ShadowSlot<ServerCommandMessage> shadow_command;
+    };
+
+    // ========================================
+    // Internal integration methods (called by SendspinClient)
+    // ========================================
+
+    bool start();
+    void build_hello_fields(ClientHelloMessage& msg);
+    void build_state_fields(ClientStateMessage& msg) const;
+    void handle_binary(const uint8_t* data, size_t len);
+    void handle_stream_start(const StreamStartMessage& stream_msg);
+    void handle_stream_end();
+    void handle_stream_clear();
+    void handle_server_command(const ServerCommandMessage& cmd);
+    void drain_events();
+    void cleanup();
+
+    // ========================================
+    // Consumer-facing method implementations
+    // ========================================
+
+    void update_volume(uint8_t volume);
+    void update_muted(bool muted);
+    void update_static_delay(uint16_t delay_ms);
+
+    // ========================================
+    // Helpers
+    // ========================================
+
+    bool send_audio_chunk(const uint8_t* data, size_t data_size, int64_t timestamp,
+                          uint8_t chunk_type, uint32_t timeout_ms);
+    void enqueue_state_update(SendspinClientState state);
+    void load_static_delay();
+    void persist_static_delay();
+
+    // ========================================
+    // Fields
+    // ========================================
+
+    // Struct fields
+    PlayerRoleConfig config;
+    ServerPlayerStreamObject current_stream_params{};
+    std::vector<PlayerStreamCallbackType> awaiting_sync_idle_events;
+
+    // Pointer fields
+    SendspinClient* client;
+    std::unique_ptr<EventState> event_state;
+    PlayerRoleListener* listener{nullptr};
+    PlayerRole* owner{nullptr};  // Back-pointer to owning PlayerRole (set after construction)
+    SendspinPersistenceProvider* persistence;
+    std::unique_ptr<SyncTask> sync_task;
+
+    // 16-bit fields
+    uint16_t static_delay_ms{0};
+
+    // 8-bit fields
+    bool high_performance_requested_for_playback{false};
+    bool muted{false};
+    bool static_delay_adjustable{false};
+    uint8_t volume{0};
+};
+
+}  // namespace sendspin

--- a/src/player_role_impl.h
+++ b/src/player_role_impl.h
@@ -63,7 +63,7 @@ struct PlayerRole::Impl {
     bool start();
     void build_hello_fields(ClientHelloMessage& msg);
     void build_state_fields(ClientStateMessage& msg) const;
-    void handle_binary(const uint8_t* data, size_t len);
+    void handle_binary(const uint8_t* data, size_t len) const;
     void handle_stream_start(const StreamStartMessage& stream_msg);
     void handle_stream_end() const;
     void handle_stream_clear() const;

--- a/src/player_role_impl.h
+++ b/src/player_role_impl.h
@@ -65,9 +65,9 @@ struct PlayerRole::Impl {
     void build_state_fields(ClientStateMessage& msg) const;
     void handle_binary(const uint8_t* data, size_t len);
     void handle_stream_start(const StreamStartMessage& stream_msg);
-    void handle_stream_end();
-    void handle_stream_clear();
-    void handle_server_command(const ServerCommandMessage& cmd);
+    void handle_stream_end() const;
+    void handle_stream_clear() const;
+    void handle_server_command(const ServerCommandMessage& cmd) const;
     void drain_events();
     void cleanup();
 
@@ -84,10 +84,10 @@ struct PlayerRole::Impl {
     // ========================================
 
     bool send_audio_chunk(const uint8_t* data, size_t data_size, int64_t timestamp,
-                          uint8_t chunk_type, uint32_t timeout_ms);
-    void enqueue_state_update(SendspinClientState state);
+                          uint8_t chunk_type, uint32_t timeout_ms) const;
+    void enqueue_state_update(SendspinClientState state) const;
     void load_static_delay();
-    void persist_static_delay();
+    void persist_static_delay() const;
 
     // ========================================
     // Fields

--- a/src/sync_task.cpp
+++ b/src/sync_task.cpp
@@ -57,8 +57,8 @@ SyncTask::~SyncTask() {
     this->stop();
 }
 
-bool SyncTask::init(PlayerRole* player, SendspinClient* client, size_t buffer_size) {
-    this->player_ = player;
+bool SyncTask::init(PlayerRole::Impl* player_impl, SendspinClient* client, size_t buffer_size) {
+    this->player_impl_ = player_impl;
     this->client_ = client;
 
     if (!this->event_flags_.create()) {
@@ -456,8 +456,8 @@ DecodeResult SyncTask::decode_chunk(SyncContext& sync_context) {
                     sync_context.encoded_entry = nullptr;
                     return DecodeResult::ALLOCATION_FAILED;
                 }
-                if (this->player_->impl_->listener) {
-                    sync_context.decode_buffer->set_listener(this->player_->impl_->listener);
+                if (this->player_impl_->listener) {
+                    sync_context.decode_buffer->set_listener(this->player_impl_->listener);
                 }
             } else if (needed > sync_context.decode_buffer->capacity()) {
                 if (!sync_context.decode_buffer->reallocate(needed)) {
@@ -472,8 +472,8 @@ DecodeResult SyncTask::decode_chunk(SyncContext& sync_context) {
                (sync_context.encoded_entry->chunk_type == CHUNK_TYPE_ENCODED_AUDIO)) {
         int64_t client_timestamp =
             this->client_->get_client_time(sync_context.encoded_entry->timestamp) -
-            static_cast<int64_t>(this->player_->get_static_delay_ms()) * US_PER_MS -
-            this->player_->get_fixed_delay_us();
+            static_cast<int64_t>(this->player_impl_->static_delay_ms) * US_PER_MS -
+            this->player_impl_->config.fixed_delay_us;
 
         if (client_timestamp < sync_context.new_audio_client_playtime - HARD_SYNC_THRESHOLD_US) {
             // This chunk will arrive too late to be played, skip it!
@@ -632,9 +632,8 @@ void SyncTask::thread_entry(void* params) {
         return;
     }
 
-    if (this_task->player_->impl_->listener) {
-        sync_context.interpolation_transfer_buffer->set_listener(
-            this_task->player_->impl_->listener);
+    if (this_task->player_impl_->listener) {
+        sync_context.interpolation_transfer_buffer->set_listener(this_task->player_impl_->listener);
     }
     sync_context.decoder = std::make_unique<SendspinDecoder>();
 
@@ -704,7 +703,7 @@ void SyncTask::thread_entry(void* params) {
 
         this_task->event_flags_.set(EventGroupBits::TASK_RUNNING);
 
-        this_task->player_->impl_->enqueue_state_update(SendspinClientState::SYNCHRONIZED);
+        this_task->player_impl_->enqueue_state_update(SendspinClientState::SYNCHRONIZED);
 
         // Decode the initial codec header
         if (sync_context.encoded_entry != nullptr) {

--- a/src/sync_task.cpp
+++ b/src/sync_task.cpp
@@ -18,8 +18,8 @@
 #include "constants.h"
 #include "platform/logging.h"
 #include "platform/thread.h"
+#include "player_role_impl.h"
 #include "sendspin/client.h"
-#include "sendspin/player_role.h"
 
 #include <algorithm>
 #include <chrono>
@@ -456,8 +456,8 @@ DecodeResult SyncTask::decode_chunk(SyncContext& sync_context) {
                     sync_context.encoded_entry = nullptr;
                     return DecodeResult::ALLOCATION_FAILED;
                 }
-                if (this->player_->listener_) {
-                    sync_context.decode_buffer->set_listener(this->player_->listener_);
+                if (this->player_->impl_->listener) {
+                    sync_context.decode_buffer->set_listener(this->player_->impl_->listener);
                 }
             } else if (needed > sync_context.decode_buffer->capacity()) {
                 if (!sync_context.decode_buffer->reallocate(needed)) {
@@ -632,8 +632,9 @@ void SyncTask::thread_entry(void* params) {
         return;
     }
 
-    if (this_task->player_->listener_) {
-        sync_context.interpolation_transfer_buffer->set_listener(this_task->player_->listener_);
+    if (this_task->player_->impl_->listener) {
+        sync_context.interpolation_transfer_buffer->set_listener(
+            this_task->player_->impl_->listener);
     }
     sync_context.decoder = std::make_unique<SendspinDecoder>();
 
@@ -703,7 +704,7 @@ void SyncTask::thread_entry(void* params) {
 
         this_task->event_flags_.set(EventGroupBits::TASK_RUNNING);
 
-        this_task->player_->enqueue_state_update(SendspinClientState::SYNCHRONIZED);
+        this_task->player_->impl_->enqueue_state_update(SendspinClientState::SYNCHRONIZED);
 
         // Decode the initial codec header
         if (sync_context.encoded_entry != nullptr) {

--- a/src/sync_task.h
+++ b/src/sync_task.h
@@ -23,6 +23,7 @@
 #include "decoder.h"
 #include "platform/event_flags.h"
 #include "platform/shadow_slot.h"
+#include "sendspin/player_role.h"
 #include "transfer_buffer.h"
 
 #include <atomic>
@@ -31,7 +32,6 @@
 
 namespace sendspin {
 
-class PlayerRole;
 class SendspinClient;
 
 /// @brief Timing feedback from the audio output: frames played and the finish timestamp
@@ -110,11 +110,11 @@ public:
     ~SyncTask();
 
     /// @brief Initializes queues and creates the encoded ring buffer
-    /// @param player The owning PlayerRole, used for time sync, delay, and audio write access.
+    /// @param player_impl The owning PlayerRole::Impl, used for delay, listener, and state updates.
     /// @param client The owning SendspinClient, used for shared services.
     /// @param buffer_size Size of the encoded audio ring buffer in bytes.
     /// @return true on success, false on allocation failure.
-    bool init(PlayerRole* player, SendspinClient* client, size_t buffer_size);
+    bool init(PlayerRole::Impl* player_impl, SendspinClient* client, size_t buffer_size);
 
     /// @brief Creates and starts the persistent sync background thread
     /// Call once after init(). The thread idles until a codec header arrives in the ring buffer.
@@ -238,7 +238,7 @@ protected:
     // Pointer fields
     SendspinClient* client_{nullptr};
     std::unique_ptr<SendspinAudioRingBuffer> encoded_ring_buffer_;
-    PlayerRole* player_{nullptr};
+    PlayerRole::Impl* player_impl_{nullptr};
 };
 
 }  // namespace sendspin

--- a/src/visualizer_role.cpp
+++ b/src/visualizer_role.cpp
@@ -12,35 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "sendspin/visualizer_role.h"
-
 #include "constants.h"
-#include "platform/event_flags.h"
 #include "platform/logging.h"
-#include "platform/memory.h"
-#include "platform/shadow_slot.h"
-#include "platform/spsc_ring_buffer.h"
 #include "platform/thread.h"
-#include "platform/thread_safe_queue.h"
 #include "platform/time.h"
 #include "protocol_messages.h"
 #include "sendspin/client.h"
+#include "visualizer_role_impl.h"
 
 #include <cstring>
-#include <thread>
 
 static const char* const TAG = "sendspin.visualizer";
-
-namespace {
-
-/// @brief Deferred visualizer event types
-enum class VisualizerEventType : uint8_t {
-    STREAM_START,
-    STREAM_END,
-    STREAM_CLEAR,
-};
-
-}  // namespace
 
 // ============================================================================
 // Entry format constants
@@ -91,80 +73,79 @@ static uint16_t read_be16(const uint8_t* p) {
 namespace sendspin {
 
 // ============================================================================
-// Drain task pimpl
+// Impl constructor / destructor
 // ============================================================================
 
-/// @brief Persistent drain thread context and platform queue for visualizer data delivery
-struct VisualizerRole::DrainTask {
-    SpscRingBuffer ring_buffer;
-    PlatformBuffer ring_storage;
-    EventFlags event_flags;
-    std::thread drain_thread;
-};
+VisualizerRole::Impl::Impl(VisualizerRoleConfig config, SendspinClient* client)
+    : config(std::move(config)),
+      visualizer_support(std::move(this->config.support)),
+      client(client),
+      event_state(std::make_unique<EventState>()) {
+    this->event_state->queue.create(8);
 
-/// @brief Deferred event state for thread-safe visualizer stream lifecycle delivery
-struct VisualizerRole::EventState {
-    ThreadSafeQueue<VisualizerEventType> queue;
-    ShadowSlot<ServerVisualizerStreamObject> shadow_config;
-};
-
-// ============================================================================
-// Lifecycle
-// ============================================================================
-
-VisualizerRole::VisualizerRole(Config config, SendspinClient* client)
-    : config_(std::move(config)),
-      visualizer_support_(std::move(this->config_.support)),
-      client_(client),
-      event_state_(std::make_unique<EventState>()) {
-    this->event_state_->queue.create(8);
-
-    if (this->visualizer_support_.has_value()) {
-        this->drain_task_ = std::make_unique<DrainTask>();
+    if (this->visualizer_support.has_value()) {
+        this->drain_task = std::make_unique<DrainTask>();
 
         // The ring buffer needs more space than the raw data capacity because each entry
         // has internal overhead: an 8-byte ItemHeader plus our 1-2 byte entry header, all
         // aligned to 8 bytes. Allocate 3x the advertised capacity to account for this.
-        size_t capacity = this->visualizer_support_->buffer_capacity * 3;
-        if (this->drain_task_->ring_storage.allocate(capacity)) {
-            this->drain_task_->ring_buffer.create(capacity, this->drain_task_->ring_storage.data());
+        size_t capacity = this->visualizer_support->buffer_capacity * 3;
+        if (this->drain_task->ring_storage.allocate(capacity)) {
+            this->drain_task->ring_buffer.create(capacity, this->drain_task->ring_storage.data());
         }
     }
 }
 
-VisualizerRole::~VisualizerRole() {
+VisualizerRole::Impl::~Impl() {
     this->stop();
 }
 
-bool VisualizerRole::start() {
-    if (!this->drain_task_ || !this->drain_task_->ring_buffer.is_created()) {
+// ============================================================================
+// VisualizerRole forwarding (public API → Impl)
+// ============================================================================
+
+VisualizerRole::VisualizerRole(Config config, SendspinClient* client)
+    : impl_(std::make_unique<Impl>(std::move(config), client)) {}
+
+VisualizerRole::~VisualizerRole() = default;
+
+void VisualizerRole::set_listener(VisualizerRoleListener* listener) {
+    this->impl_->listener = listener;
+}
+
+// ============================================================================
+// Impl method implementations
+// ============================================================================
+
+bool VisualizerRole::Impl::start() {
+    if (!this->drain_task || !this->drain_task->ring_buffer.is_created()) {
         return false;
     }
-    if (this->drain_task_->drain_thread.joinable()) {
+    if (this->drain_task->drain_thread.joinable()) {
         return true;  // Already running
     }
-    if (!this->drain_task_->event_flags.is_created() && !this->drain_task_->event_flags.create()) {
+    if (!this->drain_task->event_flags.is_created() && !this->drain_task->event_flags.create()) {
         return false;
     }
 
-    platform_configure_thread("SsVis", 4096, static_cast<int>(this->config_.priority),
-                              this->config_.psram_stack);
-    this->drain_task_->drain_thread = std::thread(drain_thread_func, this);
+    platform_configure_thread("SsVis", 4096, static_cast<int>(this->config.priority),
+                              this->config.psram_stack);
+    this->drain_task->drain_thread = std::thread(drain_thread_func, this);
     return true;
 }
 
-void VisualizerRole::stop() {
-    if (!this->drain_task_ || !this->drain_task_->drain_thread.joinable()) {
+void VisualizerRole::Impl::stop() {
+    if (!this->drain_task || !this->drain_task->drain_thread.joinable()) {
         return;
     }
-    this->drain_task_->event_flags.set(COMMAND_STOP);
-    this->drain_task_->drain_thread.join();
+    this->drain_task->event_flags.set(COMMAND_STOP);
+    this->drain_task->drain_thread.join();
 }
 
-void VisualizerRole::build_hello_fields(ClientHelloMessage& msg) {
-    if (this->visualizer_support_.has_value()) {
+void VisualizerRole::Impl::build_hello_fields(ClientHelloMessage& msg) {
+    if (this->visualizer_support.has_value()) {
         msg.supported_roles.push_back(SendspinRole::VISUALIZER);
-        msg.visualizer_support = this->visualizer_support_.value();
+        msg.visualizer_support = this->visualizer_support.value();
     }
 }
 
@@ -172,21 +153,20 @@ void VisualizerRole::build_hello_fields(ClientHelloMessage& msg) {
 // Binary handling (network thread)
 // ============================================================================
 
-void VisualizerRole::handle_binary(uint8_t binary_type, const uint8_t* data, size_t len) {
-    if (!this->stream_active_ || !this->drain_task_ ||
-        !this->drain_task_->ring_buffer.is_created()) {
+void VisualizerRole::Impl::handle_binary(uint8_t binary_type, const uint8_t* data, size_t len) {
+    if (!this->stream_active || !this->drain_task || !this->drain_task->ring_buffer.is_created()) {
         return;
     }
 
     // Build the frame flags byte from cached config
     uint8_t flags = ENTRY_FRAME;
-    if (this->has_loudness_) {
+    if (this->has_loudness) {
         flags |= FLAG_HAS_LOUDNESS;
     }
-    if (this->has_f_peak_) {
+    if (this->has_f_peak) {
         flags |= FLAG_HAS_F_PEAK;
     }
-    if (this->has_spectrum_) {
+    if (this->has_spectrum) {
         flags |= FLAG_HAS_SPECTRUM;
     }
 
@@ -208,7 +188,7 @@ void VisualizerRole::handle_binary(uint8_t binary_type, const uint8_t* data, siz
             entry[0] = ENTRY_BEAT;
             std::memcpy(entry + BEAT_HEADER_SIZE, data + offset, TIMESTAMP_SIZE);
 
-            this->drain_task_->ring_buffer.send(entry, sizeof(entry), 0);
+            this->drain_task->ring_buffer.send(entry, sizeof(entry), 0);
             offset += TIMESTAMP_SIZE;
         }
     } else {
@@ -218,8 +198,8 @@ void VisualizerRole::handle_binary(uint8_t binary_type, const uint8_t* data, siz
         }
         uint8_t num_frames = data[0];
         size_t offset = 1;
-        size_t wire_frame_size = TIMESTAMP_SIZE + this->raw_frame_size_;
-        size_t entry_size = FRAME_HEADER_SIZE + TIMESTAMP_SIZE + this->raw_frame_size_;
+        size_t wire_frame_size = TIMESTAMP_SIZE + this->raw_frame_size;
+        size_t entry_size = FRAME_HEADER_SIZE + TIMESTAMP_SIZE + this->raw_frame_size;
 
         for (uint8_t i = 0; i < num_frames; ++i) {
             if (offset + wire_frame_size > len) {
@@ -228,17 +208,17 @@ void VisualizerRole::handle_binary(uint8_t binary_type, const uint8_t* data, siz
 
             // Build frame entry: [flags][bin_count][8-byte server_ts][raw field bytes]
             // Use acquire+commit to avoid double-copy
-            void* dest = this->drain_task_->ring_buffer.acquire(entry_size, 0);
+            void* dest = this->drain_task->ring_buffer.acquire(entry_size, 0);
             if (dest == nullptr) {
                 break;  // Buffer full, drop remaining frames
             }
 
             auto* entry = static_cast<uint8_t*>(dest);
             entry[0] = flags;
-            entry[1] = this->spectrum_bin_count_;
+            entry[1] = this->spectrum_bin_count;
             std::memcpy(entry + FRAME_HEADER_SIZE, data + offset, wire_frame_size);
 
-            this->drain_task_->ring_buffer.commit(dest);
+            this->drain_task->ring_buffer.commit(dest);
             offset += wire_frame_size;
         }
     }
@@ -248,85 +228,85 @@ void VisualizerRole::handle_binary(uint8_t binary_type, const uint8_t* data, siz
 // Stream lifecycle (network thread)
 // ============================================================================
 
-void VisualizerRole::handle_stream_start(const ServerVisualizerStreamObject& stream) {
+void VisualizerRole::Impl::handle_stream_start(const ServerVisualizerStreamObject& stream) {
     // Cache stream config for handle_binary (same thread)
-    this->has_loudness_ = false;
-    this->has_f_peak_ = false;
-    this->has_spectrum_ = false;
-    this->spectrum_bin_count_ = 0;
+    this->has_loudness = false;
+    this->has_f_peak = false;
+    this->has_spectrum = false;
+    this->spectrum_bin_count = 0;
 
     for (auto type : stream.types) {
         if (type == VisualizerDataType::LOUDNESS) {
-            this->has_loudness_ = true;
+            this->has_loudness = true;
         }
         if (type == VisualizerDataType::F_PEAK) {
-            this->has_f_peak_ = true;
+            this->has_f_peak = true;
         }
         if (type == VisualizerDataType::SPECTRUM) {
-            this->has_spectrum_ = true;
+            this->has_spectrum = true;
         }
     }
-    if (this->has_spectrum_ && stream.spectrum.has_value()) {
-        this->spectrum_bin_count_ = stream.spectrum->n_disp_bins;
+    if (this->has_spectrum && stream.spectrum.has_value()) {
+        this->spectrum_bin_count = stream.spectrum->n_disp_bins;
     }
 
-    this->raw_frame_size_ = (this->has_loudness_ ? 2 : 0) + (this->has_f_peak_ ? 2 : 0) +
-                            (this->has_spectrum_ ? 2 * this->spectrum_bin_count_ : 0);
-    this->stream_active_ = true;
+    this->raw_frame_size = (this->has_loudness ? 2 : 0) + (this->has_f_peak ? 2 : 0) +
+                           (this->has_spectrum ? 2 * this->spectrum_bin_count : 0);
+    this->stream_active = true;
 
     // Signal drain thread to flush old data
-    if (this->drain_task_) {
-        this->drain_task_->event_flags.set(COMMAND_FLUSH);
+    if (this->drain_task) {
+        this->drain_task->event_flags.set(COMMAND_FLUSH);
     }
 
     // Shadow the config for main-thread callback, then signal
-    this->event_state_->shadow_config.write(stream);
-    this->event_state_->queue.send(VisualizerEventType::STREAM_START, 0);
+    this->event_state->shadow_config.write(stream);
+    this->event_state->queue.send(VisualizerEventType::STREAM_START, 0);
 }
 
-void VisualizerRole::handle_stream_end() {
-    this->stream_active_ = false;
+void VisualizerRole::Impl::handle_stream_end() {
+    this->stream_active = false;
 
-    if (this->drain_task_) {
-        this->drain_task_->event_flags.set(COMMAND_FLUSH);
+    if (this->drain_task) {
+        this->drain_task->event_flags.set(COMMAND_FLUSH);
     }
 
-    this->event_state_->queue.send(VisualizerEventType::STREAM_END, 0);
+    this->event_state->queue.send(VisualizerEventType::STREAM_END, 0);
 }
 
-void VisualizerRole::handle_stream_clear() {
-    this->stream_active_ = false;
+void VisualizerRole::Impl::handle_stream_clear() {
+    this->stream_active = false;
 
-    if (this->drain_task_) {
-        this->drain_task_->event_flags.set(COMMAND_FLUSH);
+    if (this->drain_task) {
+        this->drain_task->event_flags.set(COMMAND_FLUSH);
     }
 
-    this->event_state_->queue.send(VisualizerEventType::STREAM_CLEAR, 0);
+    this->event_state->queue.send(VisualizerEventType::STREAM_CLEAR, 0);
 }
 
 // ============================================================================
 // Event draining (main thread) - lifecycle events only
 // ============================================================================
 
-void VisualizerRole::drain_events() {
+void VisualizerRole::Impl::drain_events() {
     VisualizerEventType event_type{};
-    while (this->event_state_->queue.receive(event_type, 0)) {
+    while (this->event_state->queue.receive(event_type, 0)) {
         switch (event_type) {
             case VisualizerEventType::STREAM_START: {
                 ServerVisualizerStreamObject config{};
-                if (this->event_state_->shadow_config.take(config) && this->listener_) {
-                    this->listener_->on_visualizer_stream_start(config);
+                if (this->event_state->shadow_config.take(config) && this->listener) {
+                    this->listener->on_visualizer_stream_start(config);
                 }
                 break;
             }
             case VisualizerEventType::STREAM_END:
-                if (this->listener_) {
-                    this->listener_->on_visualizer_stream_end();
+                if (this->listener) {
+                    this->listener->on_visualizer_stream_end();
                 }
                 break;
             case VisualizerEventType::STREAM_CLEAR:
-                if (this->listener_) {
-                    this->listener_->on_visualizer_stream_clear();
+                if (this->listener) {
+                    this->listener->on_visualizer_stream_clear();
                 }
                 break;
         }
@@ -337,38 +317,38 @@ void VisualizerRole::drain_events() {
 // Cleanup (main thread)
 // ============================================================================
 
-void VisualizerRole::cleanup() {
-    this->stream_active_ = false;
+void VisualizerRole::Impl::cleanup() {
+    this->stream_active = false;
 
-    if (this->drain_task_) {
-        this->drain_task_->event_flags.set(COMMAND_FLUSH);
+    if (this->drain_task) {
+        this->drain_task->event_flags.set(COMMAND_FLUSH);
     }
 
-    this->event_state_->queue.reset();
-    this->event_state_->shadow_config.reset();
-    this->event_state_->queue.send(VisualizerEventType::STREAM_END, 0);
+    this->event_state->queue.reset();
+    this->event_state->shadow_config.reset();
+    this->event_state->queue.send(VisualizerEventType::STREAM_END, 0);
 }
 
 // ============================================================================
-// Drain thread
+// Drain thread helpers
 // ============================================================================
 
-void VisualizerRole::flush_ring_buffer() {
-    if (!this->drain_task_) {
+void VisualizerRole::Impl::flush_ring_buffer() {
+    if (!this->drain_task) {
         return;
     }
     size_t item_size = 0;
     void* item = nullptr;
-    while ((item = this->drain_task_->ring_buffer.receive(&item_size, 0)) != nullptr) {
-        this->drain_task_->ring_buffer.return_item(item);
+    while ((item = this->drain_task->ring_buffer.receive(&item_size, 0)) != nullptr) {
+        this->drain_task->ring_buffer.return_item(item);
     }
 }
 
-void VisualizerRole::drain_thread_func(VisualizerRole* self) {
+void VisualizerRole::Impl::drain_thread_func(VisualizerRole::Impl* self) {
     SS_LOGD(TAG, "Drain thread started");
 
-    auto& rb = self->drain_task_->ring_buffer;
-    auto& flags = self->drain_task_->event_flags;
+    auto& rb = self->drain_task->ring_buffer;
+    auto& flags = self->drain_task->event_flags;
 
     while (true) {
         // Non-blocking check for commands
@@ -389,7 +369,7 @@ void VisualizerRole::drain_thread_func(VisualizerRole* self) {
         }
 
         // Wait for time sync
-        if (!self->client_->is_time_synced()) {
+        if (!self->client->is_time_synced()) {
             rb.return_item(item);
             continue;
         }
@@ -405,7 +385,7 @@ void VisualizerRole::drain_thread_func(VisualizerRole* self) {
             continue;
         }
         int64_t server_ts = read_be64(raw + ts_offset);
-        int64_t client_ts = self->client_->get_client_time(server_ts);
+        int64_t client_ts = self->client->get_client_time(server_ts);
 
         if (client_ts == 0) {
             rb.return_item(item);
@@ -438,7 +418,7 @@ void VisualizerRole::drain_thread_func(VisualizerRole* self) {
         }
 
         // Parse and deliver
-        if (is_frame && self->listener_) {
+        if (is_frame && self->listener) {
             uint8_t frame_flags = type_byte & FRAME_FLAGS_MASK;
             uint8_t bin_count = raw[1];
             const uint8_t* fields = raw + FRAME_HEADER_SIZE + TIMESTAMP_SIZE;
@@ -465,10 +445,10 @@ void VisualizerRole::drain_thread_func(VisualizerRole* self) {
             }
 
             rb.return_item(item);
-            self->listener_->on_visualizer_frame(frame);
-        } else if (!is_frame && self->listener_) {
+            self->listener->on_visualizer_frame(frame);
+        } else if (!is_frame && self->listener) {
             rb.return_item(item);
-            self->listener_->on_beat(client_ts);
+            self->listener->on_beat(client_ts);
         } else {
             rb.return_item(item);
         }

--- a/src/visualizer_role.cpp
+++ b/src/visualizer_role.cpp
@@ -104,7 +104,7 @@ VisualizerRole::Impl::~Impl() {
 // VisualizerRole forwarding (public API → Impl)
 // ============================================================================
 
-VisualizerRole::VisualizerRole(Config config, SendspinClient* client)
+VisualizerRole::VisualizerRole(VisualizerRoleConfig config, SendspinClient* client)
     : impl_(std::make_unique<Impl>(std::move(config), client)) {}
 
 VisualizerRole::~VisualizerRole() = default;

--- a/src/visualizer_role.cpp
+++ b/src/visualizer_role.cpp
@@ -136,7 +136,7 @@ bool VisualizerRole::Impl::start() {
     return true;
 }
 
-void VisualizerRole::Impl::stop() {
+void VisualizerRole::Impl::stop() const {
     if (!this->drain_task || !this->drain_task->drain_thread.joinable()) {
         return;
     }
@@ -290,7 +290,7 @@ void VisualizerRole::Impl::handle_stream_clear() {
 // Event draining (main thread) - lifecycle events only
 // ============================================================================
 
-void VisualizerRole::Impl::drain_events() {
+void VisualizerRole::Impl::drain_events() const {
     VisualizerEventType event_type{};
     while (this->event_state->queue.receive(event_type, 0)) {
         switch (event_type) {
@@ -335,7 +335,7 @@ void VisualizerRole::Impl::cleanup() {
 // Drain thread helpers
 // ============================================================================
 
-void VisualizerRole::Impl::flush_ring_buffer() {
+void VisualizerRole::Impl::flush_ring_buffer() const {
     if (!this->drain_task) {
         return;
     }

--- a/src/visualizer_role.cpp
+++ b/src/visualizer_role.cpp
@@ -119,12 +119,14 @@ void VisualizerRole::set_listener(VisualizerRoleListener* listener) {
 
 bool VisualizerRole::Impl::start() {
     if (!this->drain_task || !this->drain_task->ring_buffer.is_created()) {
+        SS_LOGE(TAG, "Failed to start visualizer: drain task not initialized");
         return false;
     }
     if (this->drain_task->drain_thread.joinable()) {
         return true;  // Already running
     }
     if (!this->drain_task->event_flags.is_created() && !this->drain_task->event_flags.create()) {
+        SS_LOGE(TAG, "Failed to create visualizer event flags");
         return false;
     }
 

--- a/src/visualizer_role_impl.h
+++ b/src/visualizer_role_impl.h
@@ -1,0 +1,112 @@
+// Copyright 2026 Sendspin Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @file visualizer_role_impl.h
+/// @brief Private implementation for the visualizer role (pimpl)
+
+#pragma once
+
+#include "platform/event_flags.h"
+#include "platform/memory.h"
+#include "platform/shadow_slot.h"
+#include "platform/spsc_ring_buffer.h"
+#include "platform/thread_safe_queue.h"
+#include "sendspin/visualizer_role.h"
+
+#include <atomic>
+#include <memory>
+#include <optional>
+#include <thread>
+
+namespace sendspin {
+
+class SendspinClient;
+struct ClientHelloMessage;
+
+/// @brief Deferred visualizer event types (used internally in the visualizer role)
+enum class VisualizerEventType : uint8_t {
+    STREAM_START,
+    STREAM_END,
+    STREAM_CLEAR,
+};
+
+/// @brief Private implementation of the visualizer role
+struct VisualizerRole::Impl {
+    explicit Impl(VisualizerRoleConfig config, SendspinClient* client);
+    ~Impl();
+
+    // ========================================
+    // Nested types
+    // ========================================
+
+    /// @brief Persistent drain thread context and platform ring buffer for visualizer data delivery
+    struct DrainTask {
+        SpscRingBuffer ring_buffer;
+        PlatformBuffer ring_storage;
+        EventFlags event_flags;
+        std::thread drain_thread;
+    };
+
+    /// @brief Deferred event state for thread-safe visualizer stream lifecycle delivery
+    struct EventState {
+        ThreadSafeQueue<VisualizerEventType> queue;
+        ShadowSlot<ServerVisualizerStreamObject> shadow_config;
+    };
+
+    // ========================================
+    // Internal integration methods (called by SendspinClient)
+    // ========================================
+
+    bool start();
+    void build_hello_fields(ClientHelloMessage& msg);
+    void handle_binary(uint8_t binary_type, const uint8_t* data, size_t len);
+    void handle_stream_start(const ServerVisualizerStreamObject& stream);
+    void handle_stream_end();
+    void handle_stream_clear();
+    void drain_events();
+    void cleanup();
+
+    // ========================================
+    // Internal helpers
+    // ========================================
+
+    void stop();
+    void flush_ring_buffer();
+
+    static void drain_thread_func(VisualizerRole::Impl* self);
+
+    // ========================================
+    // Fields
+    // ========================================
+
+    // Struct fields
+    VisualizerRoleConfig config;
+    std::optional<VisualizerSupportObject> visualizer_support;
+
+    // Pointer fields
+    SendspinClient* client;
+    std::unique_ptr<DrainTask> drain_task;
+    std::unique_ptr<EventState> event_state;
+    VisualizerRoleListener* listener{nullptr};
+
+    // Atomic fields (written by network thread, read by drain thread / cleanup)
+    std::atomic<size_t> raw_frame_size{0};
+    std::atomic<bool> has_f_peak{false};
+    std::atomic<bool> has_loudness{false};
+    std::atomic<bool> has_spectrum{false};
+    std::atomic<uint8_t> spectrum_bin_count{0};
+    std::atomic<bool> stream_active{false};
+};
+
+}  // namespace sendspin

--- a/src/visualizer_role_impl.h
+++ b/src/visualizer_role_impl.h
@@ -74,15 +74,15 @@ struct VisualizerRole::Impl {
     void handle_stream_start(const ServerVisualizerStreamObject& stream);
     void handle_stream_end();
     void handle_stream_clear();
-    void drain_events();
+    void drain_events() const;
     void cleanup();
 
     // ========================================
     // Internal helpers
     // ========================================
 
-    void stop();
-    void flush_ring_buffer();
+    void stop() const;
+    void flush_ring_buffer() const;
 
     static void drain_thread_func(VisualizerRole::Impl* self);
 


### PR DESCRIPTION
Uses PIMPL for roles to minimize the public API. This also enables selective role builds, controlled by defines/Kconfig so that you can build a minimal version with just the roles needed.

Several breaking changes here, primarily around the initial configuration. See the integration guide for the current guidance.