### PR TITLE
Add a generalized group state getter method

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -512,7 +512,7 @@ The client and roles expose query methods for polling state in your main loop or
 // Client state
 bool connected = client.is_connected();       // Active connection with completed handshake
 bool synced = client.is_time_synced();         // Time filter has received at least one measurement
-std::string group = client.get_group_name();   // Current group name (empty if none)
+const GroupUpdateObject& group = client.get_group_state();   // Group id, name, playback state (all optional)
 
 // Player state
 uint8_t vol = player.get_volume();

--- a/examples/tui_client/tui.cpp
+++ b/examples/tui_client/tui.cpp
@@ -938,7 +938,7 @@ void update_polled_state(TuiState& state, SendspinClient& client) {
     state.static_delay_ms = client.player() ? client.player()->get_static_delay_ms() : 0;
     state.player_volume = client.player() ? client.player()->get_volume() : 0;
     state.player_muted = client.player() ? client.player()->get_muted() : false;
-    state.group_name = client.get_group_name();
+    state.group_name = client.get_group_state().group_name.value_or("");
 
     if (client.controller()) {
         auto& cs = client.controller()->get_controller_state();

--- a/include/sendspin/client.h
+++ b/include/sendspin/client.h
@@ -325,10 +325,10 @@ public:
     /// @return Equivalent client-side timestamp in microseconds
     int64_t get_client_time(int64_t server_time) const;
 
-    /// @brief Returns the current group name (empty string if none)
-    /// @return Current group name string, or empty string if not in a group
-    std::string get_group_name() const {
-        return this->group_state_.group_name.value_or("");
+    /// @brief Returns the current group state
+    /// @return The current GroupUpdateObject (fields are optional and may be unset)
+    const GroupUpdateObject& get_group_state() const {
+        return this->group_state_;
     }
 
     // ========================================


### PR DESCRIPTION
Also removes the specific ``get_group_name`` method, as it can be accessed via the generalized group state getter. This follows the same pattern as the ``get_server_information()`` method.