### PR TITLE
Gate metadata update callbacks by the timestamps in the metadata message

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -222,7 +222,7 @@ The `ServerMetadataStateObject` contains these fields (all optional except `time
 
 | Field | Type | Description |
 |---|---|---|
-| `timestamp` | `int64_t` | Server timestamp |
+| `timestamp` | `int64_t` | Server clock µs at which this metadata becomes valid; delivery is held until the synced client clock reaches it |
 | `title` | `std::optional<std::string>` | Track title |
 | `artist` | `std::optional<std::string>` | Track artist |
 | `album_artist` | `std::optional<std::string>` | Album artist |

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -232,7 +232,7 @@ The `awaiting_sync_idle_events` list (on `PlayerRole::Impl`) is the key ordering
 ### Other Roles
 
 - **ControllerRole**: Takes from shadow, fires `on_controller_state()`.
-- **MetadataRole**: Takes from shadow, applies deltas, fires `on_metadata()`.
+- **MetadataRole**: Takes from shadow when the pending update's `timestamp` has been reached on the synced client clock (or immediately if time sync is not yet ready), applies deltas, fires `on_metadata()`.
 - **ArtworkRole**: Drains event queue, processes stream start/end/clear with shadow config. On `STREAM_END` and `STREAM_CLEAR`, fires `on_image_clear()` for each configured slot. Image data delivery (`on_image_decode` and `on_image_display`) happens on the dedicated artwork drain thread, not here.
 - **VisualizerRole**: Drains event queue, processes stream start/end/clear with shadow config.
 

--- a/include/sendspin/metadata_role.h
+++ b/include/sendspin/metadata_role.h
@@ -73,8 +73,10 @@ public:
  *
  * Maintains a local shadow of the server's metadata state, including track title, artist,
  * album, artwork URL, repeat/shuffle mode, and playback progress. Incoming metadata deltas
- * are merged into the shadow and delivered to the listener on the main loop thread. Progress
- * is interpolated locally using the server timestamp so callers always get a current value.
+ * are merged into the shadow and delivered to the listener on the main loop thread once the
+ * synchronized client clock reaches the update's `timestamp` (or immediately if time sync is
+ * not yet ready). Progress is interpolated locally using the server timestamp so callers
+ * always get a current value.
  *
  * Usage:
  * 1. Implement MetadataRoleListener to receive metadata updates

--- a/src/metadata_role.cpp
+++ b/src/metadata_role.cpp
@@ -108,11 +108,25 @@ void MetadataRole::Impl::handle_server_state(ServerMetadataStateObject state) co
 
 void MetadataRole::Impl::drain_events() {
     ServerMetadataStateObject delta{};
-    if (this->event_state->shadow.take(delta)) {
-        apply_metadata_state_deltas(&this->metadata, delta);
-        if (this->listener) {
-            this->listener->on_metadata(this->metadata);
-        }
+    // Caveat: merged deltas carry only the newest timestamp, so a past-valid field merged
+    // under a later future-valid update gets held back until the later deadline. Accepted
+    // since overlapping fields are last-writer-wins anyway.
+    const bool taken =
+        this->event_state->shadow.take_if(delta, [this](const ServerMetadataStateObject& pending) {
+            // Fire immediately if time sync isn't ready: without sync we can't honor the
+            // deadline anyway, and holding forever would starve the listener.
+            int64_t client_ts = this->client->get_client_time(pending.timestamp);
+            if (client_ts == 0) {
+                return true;
+            }
+            return client_ts <= platform_time_us();
+        });
+    if (!taken) {
+        return;
+    }
+    apply_metadata_state_deltas(&this->metadata, delta);
+    if (this->listener) {
+        this->listener->on_metadata(this->metadata);
     }
 }
 

--- a/src/platform/shadow_slot.h
+++ b/src/platform/shadow_slot.h
@@ -68,6 +68,24 @@ public:
         return true;
     }
 
+    /// @brief Move the accumulated value out if dirty and the predicate accepts it
+    /// @param[out] out Receives the stored value if taken.
+    /// @param pred Callable invoked as `bool(const T&)` under the lock; the value is taken
+    /// only if it returns true. The value is left in place unchanged if the predicate returns
+    /// false, so a later call can re-check.
+    /// @return true if a value was taken, false if the slot was clean or the predicate rejected.
+    template <typename Predicate>
+    bool take_if(T& out, Predicate&& pred) {
+        std::lock_guard<std::mutex> lock(this->mutex_);
+        if (!this->dirty_ || !pred(static_cast<const T&>(this->slot_))) {
+            return false;
+        }
+        out = std::move(this->slot_);
+        this->slot_ = T{};
+        this->dirty_ = false;
+        return true;
+    }
+
     /// @brief Discard any pending value
     void reset() {
         std::lock_guard<std::mutex> lock(this->mutex_);


### PR DESCRIPTION
The callbacks still fire from the main loop method. This simplifies end library implementations as they don't have to manually gate it themselves. One downside is if the loop method isn't called frequently, metadata updates may be slightly late. Presumably, the main loop is called frequent enough that this is not noticeable.