### PR TITLE
Only include/build microFLAC and microOpus when necessary

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,13 +1,17 @@
 ## IDF Component Manager Manifest File
 name: "sendspin-cpp"
 dependencies:
-  idf: ">=5.1"
+  idf: ">=5.5"
   espressif/esp_websocket_client: ">=1.0.0"
   bblanchon/arduinojson: ">=7.4.2"
   esphome/micro-flac:
     version: ">=0.1.1"
+    rules:
+      - if: "$CONFIG{SENDSPIN_ENABLE_PLAYER} == True"
   esphome/micro-opus:
     version: ">=0.3.5"
+    rules:
+      - if: "$CONFIG{SENDSPIN_ENABLE_PLAYER} == True"
 description: "Sendspin synchronized audio streaming client for ESP32"
 license: "Apache-2.0"
 maintainers:


### PR DESCRIPTION
Uses conditions in ``idf_component.yml`` to only include the audio decoding libraries if player support is enabled through Kconfig. This requires IDF 5.5 to reliably work (it sometimes works on IDF 5.4 depending on when you/PlatformIO downloaded the release), so that is now the minimum requirement.

Marked as a breaking change because of the IDF version bump. Functionally, nothing has changed beyond that minimum requirement.