### PR TITLE
Simplify Artwork Role API

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -273,7 +273,7 @@ struct MyArtworkListener : ArtworkRoleListener {
 
     // Called from the drain thread at the correct playback timestamp.
     // Swap the decoded image onto the display.
-    void on_image_display(uint8_t slot, int64_t client_timestamp) override {
+    void on_image_display(uint8_t slot) override {
         display.show_image(slot, decoded_images[slot]);
     }
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -281,10 +281,6 @@ struct MyArtworkListener : ArtworkRoleListener {
     void on_image_clear(uint8_t slot) override {
         display.clear_slot(slot);
     }
-
-    // Called from the main loop thread on stream lifecycle events.
-    void on_artwork_stream_start(const ServerArtworkStreamObject& stream) override { }
-    void on_artwork_stream_end() override { }
 };
 ```
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -95,7 +95,6 @@ Single-slot state container with "latest wins" or custom merge semantics. The ne
 | `PlayerRole::Impl::shadow_command` | `ServerCommandMessage` | Field-by-field merge (volume, mute, delay independent) |
 | `ControllerRole::Impl::shadow` | `ServerStateControllerObject` | Latest wins |
 | `MetadataRole::Impl::shadow` | `ServerMetadataStateObject` | Field-by-field delta merge |
-| `ArtworkRole::Impl::shadow_config` | `ServerArtworkStreamObject` | Latest wins |
 | `VisualizerRole::Impl::shadow_config` | `ServerVisualizerStreamObject` | Latest wins |
 | `SyncTask::playback_progress_slot_` | `PlaybackProgress` | Sum `frames_played`, keep latest `finish_timestamp` |
 
@@ -150,7 +149,7 @@ Network thread (IXWebSocket / esp_http_server)
 | `SERVER_STATE` | Writes to `ControllerRole::Impl::shadow` and `MetadataRole::Impl::shadow` |
 | `SERVER_COMMAND` | Merges into `PlayerRole::Impl::shadow_command` |
 | `GROUP_UPDATE` | Merges into `Client::shadow_group` |
-| `STREAM_START` | Writes to `PlayerRole::Impl::shadow_stream_params`, enqueues `STREAM_START` into `stream_queue`. Writes to `ArtworkRole::Impl::shadow_config` and `VisualizerRole::Impl::shadow_config`, enqueues start events. |
+| `STREAM_START` | Writes to `PlayerRole::Impl::shadow_stream_params`, enqueues `STREAM_START` into `stream_queue`. Marks the artwork stream active and flushes the drain thread. Writes to `VisualizerRole::Impl::shadow_config`, enqueues a start event. |
 | `STREAM_END` | Enqueues `STREAM_END` into player/artwork/visualizer queues, signals sync task `COMMAND_STREAM_END` |
 | `STREAM_CLEAR` | Enqueues `STREAM_CLEAR` into player/artwork/visualizer queues, signals sync task `COMMAND_STREAM_CLEAR` |
 
@@ -233,7 +232,7 @@ The `awaiting_sync_idle_events` list (on `PlayerRole::Impl`) is the key ordering
 
 - **ControllerRole**: Takes from shadow, fires `on_controller_state()`.
 - **MetadataRole**: Takes from shadow when the pending update's `timestamp` has been reached on the synced client clock (or immediately if time sync is not yet ready), applies deltas, fires `on_metadata()`.
-- **ArtworkRole**: Drains event queue, processes stream start/end/clear with shadow config. On `STREAM_END` and `STREAM_CLEAR`, fires `on_image_clear()` for each configured slot. Image data delivery (`on_image_decode` and `on_image_display`) happens on the dedicated artwork drain thread, not here.
+- **ArtworkRole**: Drains event queue for stream end/clear lifecycle events. On `STREAM_END` and `STREAM_CLEAR`, fires `on_image_clear()` for each configured slot. Image data delivery (`on_image_decode` and `on_image_display`) happens on the dedicated artwork drain thread, not here.
 - **VisualizerRole**: Drains event queue, processes stream start/end/clear with shadow config.
 
 ## Sync Task State Machine

--- a/include/sendspin/artwork_role.h
+++ b/include/sendspin/artwork_role.h
@@ -85,8 +85,7 @@ public:
     ///
     /// Fires after on_image_decode() once the server timestamp is reached.
     /// @param slot The artwork slot index.
-    /// @param client_timestamp Client-domain timestamp in microseconds.
-    virtual void on_image_display(uint8_t /*slot*/, int64_t /*client_timestamp*/) {}
+    virtual void on_image_display(uint8_t /*slot*/) {}
 
     /// @brief Called on the main loop thread when artwork should be cleared for a slot
     ///
@@ -124,7 +123,7 @@ public:
  *                          SendspinImageFormat format) override {
  *         decoded_images[slot] = decode(data, length, format);
  *     }
- *     void on_image_display(uint8_t slot, int64_t client_timestamp) override {
+ *     void on_image_display(uint8_t slot) override {
  *         display.show_image(slot, decoded_images[slot]);
  *     }
  *     void on_image_clear(uint8_t slot) override {

--- a/include/sendspin/artwork_role.h
+++ b/include/sendspin/artwork_role.h
@@ -22,49 +22,16 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <optional>
-#include <string>
-#include <vector>
 
 namespace sendspin {
 
 class SendspinClient;
 
-// ============================================================================
-// Artwork types
-// ============================================================================
-
-/// @brief Format and resolution for a single supported artwork channel
-struct ArtworkChannelFormatObject {
-    SendspinImageSource source{};
-    SendspinImageFormat format{};
-    uint16_t media_width{};
-    uint16_t media_height{};
-};
-
-/// @brief Server-side description of one artwork channel's format and dimensions
-struct ServerArtworkChannelObject {
-    std::optional<SendspinImageSource> source;
-    std::optional<SendspinImageFormat> format;
-    std::optional<uint16_t> width;
-    std::optional<uint16_t> height;
-
-    /// @brief Returns true if all fields in this channel have received data
-    bool is_complete() const {
-        return source.has_value() && format.has_value() && width.has_value() && height.has_value();
-    }
-};
-
-/// @brief Artwork stream parameters sent by the server in stream/start messages
-struct ServerArtworkStreamObject {
-    std::optional<std::vector<ServerArtworkChannelObject>> channels;
-};
-
 /// @brief Listener for artwork role events
 ///
 /// THREAD SAFETY: on_image_decode() and on_image_display() fire on a dedicated drain thread.
-/// Implementations must be thread-safe for these two methods. on_image_clear(),
-/// on_artwork_stream_start(), and on_artwork_stream_end() fire on the main loop thread.
+/// Implementations must be thread-safe for these two methods. on_image_clear() fires on the
+/// main loop thread.
 class ArtworkRoleListener {
 public:
     virtual ~ArtworkRoleListener() = default;
@@ -92,13 +59,6 @@ public:
     /// Fires on stream end or stream clear for each configured slot.
     /// @param slot The artwork slot index to clear.
     virtual void on_image_clear(uint8_t /*slot*/) {}
-
-    /// @brief Called on the main loop thread when a new artwork stream starts
-    /// @param stream Artwork stream parameters from the server.
-    virtual void on_artwork_stream_start(const ServerArtworkStreamObject& /*stream*/) {}
-
-    /// @brief Called on the main loop thread when the artwork stream ends
-    virtual void on_artwork_stream_end() {}
 };
 
 /**

--- a/src/artwork_role.cpp
+++ b/src/artwork_role.cpp
@@ -341,7 +341,7 @@ void ArtworkRole::Impl::drain_thread_func(ArtworkRole::Impl* self) {
 
         // Display/swap callback
         if (self->listener) {
-            self->listener->on_image_display(slot, client_ts);
+            self->listener->on_image_display(slot);
         }
     }
 

--- a/src/artwork_role.cpp
+++ b/src/artwork_role.cpp
@@ -174,17 +174,13 @@ void ArtworkRole::Impl::handle_binary(uint8_t slot, const uint8_t* data, size_t 
 // Stream lifecycle (network thread)
 // ============================================================================
 
-void ArtworkRole::Impl::handle_stream_start(const ServerArtworkStreamObject& stream) {
+void ArtworkRole::Impl::handle_stream_start() {
     this->stream_active = true;
 
     // Signal drain thread to flush any stale notifications
     if (this->drain_task) {
         this->drain_task->event_flags.set(COMMAND_FLUSH);
     }
-
-    // Shadow the config for main-thread callback
-    this->event_state->shadow_config.write(stream);
-    this->event_state->queue.send(ArtworkEventType::STREAM_START, 0);
 }
 
 void ArtworkRole::Impl::handle_stream_end() {
@@ -215,21 +211,7 @@ void ArtworkRole::Impl::drain_events() {
     ArtworkEventType event_type{};
     while (this->event_state->queue.receive(event_type, 0)) {
         switch (event_type) {
-            case ArtworkEventType::STREAM_START: {
-                ServerArtworkStreamObject config{};
-                if (this->event_state->shadow_config.take(config) && this->listener) {
-                    this->listener->on_artwork_stream_start(config);
-                }
-                break;
-            }
             case ArtworkEventType::STREAM_END:
-                if (this->listener) {
-                    for (const auto& pref : this->config.preferred_formats) {
-                        this->listener->on_image_clear(pref.slot);
-                    }
-                    this->listener->on_artwork_stream_end();
-                }
-                break;
             case ArtworkEventType::STREAM_CLEAR:
                 if (this->listener) {
                     for (const auto& pref : this->config.preferred_formats) {
@@ -253,7 +235,6 @@ void ArtworkRole::Impl::cleanup() {
     }
 
     this->event_state->queue.reset();
-    this->event_state->shadow_config.reset();
     this->event_state->queue.send(ArtworkEventType::STREAM_END, 0);
 }
 

--- a/src/artwork_role_impl.h
+++ b/src/artwork_role_impl.h
@@ -19,8 +19,8 @@
 
 #include "platform/event_flags.h"
 #include "platform/memory.h"
-#include "platform/shadow_slot.h"
 #include "platform/thread_safe_queue.h"
+#include "protocol_messages.h"
 #include "sendspin/artwork_role.h"
 
 #include <atomic>
@@ -37,7 +37,6 @@ struct ClientHelloMessage;
 
 /// @brief Deferred artwork event types
 enum class ArtworkEventType : uint8_t {
-    STREAM_START,
     STREAM_END,
     STREAM_CLEAR,
 };
@@ -86,7 +85,6 @@ struct ArtworkRole::Impl {
     /// @brief Deferred event state for thread-safe artwork stream lifecycle delivery
     struct EventState {
         ThreadSafeQueue<ArtworkEventType> queue;
-        ShadowSlot<ServerArtworkStreamObject> shadow_config;
     };
 
     // ========================================
@@ -96,7 +94,7 @@ struct ArtworkRole::Impl {
     bool start();
     void build_hello_fields(ClientHelloMessage& msg) const;
     void handle_binary(uint8_t slot, const uint8_t* data, size_t len);
-    void handle_stream_start(const ServerArtworkStreamObject& stream);
+    void handle_stream_start();
     void handle_stream_end();
     void handle_stream_clear();
     void drain_events();

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -484,7 +484,7 @@ void SendspinClient::process_json_message(SendspinConnection* conn, const std::s
 
 #ifdef SENDSPIN_ENABLE_ARTWORK
             if (this->artwork_ && stream_msg.artwork.has_value()) {
-                this->artwork_->impl_->handle_stream_start(stream_msg.artwork.value());
+                this->artwork_->impl_->handle_stream_start();
             }
 #endif
 

--- a/src/protocol_messages.h
+++ b/src/protocol_messages.h
@@ -441,6 +441,32 @@ inline std::optional<SendspinImageSource> image_source_from_string(const std::st
     return std::nullopt;
 }
 
+/// @brief Format and resolution for a single supported artwork channel
+struct ArtworkChannelFormatObject {
+    SendspinImageSource source{};
+    SendspinImageFormat format{};
+    uint16_t media_width{};
+    uint16_t media_height{};
+};
+
+/// @brief Server-side description of one artwork channel's format and dimensions
+struct ServerArtworkChannelObject {
+    std::optional<SendspinImageSource> source;
+    std::optional<SendspinImageFormat> format;
+    std::optional<uint16_t> width;
+    std::optional<uint16_t> height;
+
+    /// @brief Returns true if all fields in this channel have received data
+    bool is_complete() const {
+        return source.has_value() && format.has_value() && width.has_value() && height.has_value();
+    }
+};
+
+/// @brief Artwork stream parameters sent by the server in stream/start messages
+struct ServerArtworkStreamObject {
+    std::optional<std::vector<ServerArtworkChannelObject>> channels;
+};
+
 /// @brief Artwork capabilities advertised to the server during the hello handshake
 struct ArtworkSupportObject {
     std::vector<ArtworkChannelFormatObject> channels;


### PR DESCRIPTION
- Drops client timestamp from ``on_image_display``. The libraries internal thread already fires the ``on_image_display`` fires this callback when image should actually be displayed, so clients don't need this information.
- Removes the ``on_artwork_stream_start`` and ``on_artwork_stream_end`` listener interface methods. The Sendspin server guarantees they will provide the correctly formatted image from the hello message (for comparison, the player role may not always give the preferred format because we give a list of compatible formats, not just the one we need). The other existing callbacks, ``on_image_decode``, ``on_image_display``, and ``on_image_clear`` are sufficient to display artwork follow the protocol specifications. 