### PR TITLE
Refactor artwork thread

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -259,11 +259,11 @@ struct MyControllerListener : ControllerRoleListener {
 
 ### ArtworkRoleListener
 
-The artwork role uses a dedicated drain thread with two-phase delivery: `on_image_decode()` fires immediately when encoded image data arrives (for decoding), then `on_image_display()` fires at the correct server timestamp (for synchronized display). Lifecycle callbacks fire on the main loop thread.
+The artwork role uses a dedicated decode thread for the CPU-bound decode step and the main loop for scheduled display. `on_image_decode()` fires on the decode thread immediately when encoded image data arrives; once decode returns, the server display timestamp is handed off to the main loop, which fires `on_image_display()` once the timestamp is reached. If a newer frame for the same slot finishes decoding before its predecessor's display fires, only the newer one is delivered. Lifecycle callbacks also fire on the main loop thread.
 
 ```cpp
 struct MyArtworkListener : ArtworkRoleListener {
-    // THREAD SAFETY: Called from a dedicated drain thread.
+    // THREAD SAFETY: Called from the dedicated decode thread.
     // Decode the encoded image synchronously (e.g., JPEG to bitmap).
     // The data pointer is valid for the duration of this call.
     void on_image_decode(uint8_t slot, const uint8_t* data, size_t length,
@@ -271,7 +271,7 @@ struct MyArtworkListener : ArtworkRoleListener {
         decoded_images[slot] = decode_image(data, length, format);
     }
 
-    // Called from the drain thread at the correct playback timestamp.
+    // Called from the main loop thread once the server display timestamp is reached.
     // Swap the decoded image onto the display.
     void on_image_display(uint8_t slot) override {
         display.show_image(slot, decoded_images[slot]);
@@ -535,8 +535,8 @@ Most listener callbacks fire on the main loop thread (the thread calling `client
 | Callback | Thread |
 |---|---|
 | `PlayerRoleListener::on_audio_write()` | Sync task background thread |
-| `ArtworkRoleListener::on_image_decode()` | Dedicated artwork drain thread |
-| `ArtworkRoleListener::on_image_display()` | Dedicated artwork drain thread |
+| `ArtworkRoleListener::on_image_decode()` | Dedicated artwork decode thread |
+| `ArtworkRoleListener::on_image_display()` | Main loop thread |
 | `VisualizerRoleListener::on_visualizer_frame()` | Dedicated visualizer drain thread |
 | `VisualizerRoleListener::on_beat()` | Dedicated visualizer drain thread |
 | All other listener methods | Main loop thread |
@@ -692,8 +692,8 @@ Configuration passed to `client.add_artwork()`.
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `preferred_formats` | `std::vector<ImageSlotPreference>` | `{}` | Image slot preferences advertised to the server during the hello handshake. Each entry declares a slot index, image source, format, and resolution. |
-| `psram_stack` | `bool` | `false` | Allocate drain thread stack in PSRAM (ESP-IDF only) |
-| `priority` | `unsigned` | `2` | FreeRTOS priority for the drain thread (ESP-IDF only) |
+| `psram_stack` | `bool` | `false` | Allocate decode thread stack in PSRAM (ESP-IDF only) |
+| `priority` | `unsigned` | `2` | FreeRTOS priority for the decode thread (ESP-IDF only) |
 
 Each entry in `preferred_formats` is an `ImageSlotPreference`:
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -21,7 +21,7 @@ The library uses a small number of long-lived threads. All state mutations and u
 | **Main loop** | (caller's) | User code | - | - | Drives `SendspinClient::loop()`. All role event processing and listener callbacks run here. |
 | **Sync task** | `Sendspin` | `PlayerRole::Impl::start()` → `SyncTask::start()` | 6192 B | 2 | Decodes audio, synchronizes to server timestamps, writes PCM to the audio sink via `on_audio_write`. |
 | **Visualizer drain** | `SsVis` | `VisualizerRole::Impl::start()` | 4096 B | 2 | Reads visualization frames from a ring buffer and delivers them to the listener at the correct playback time. |
-| **Artwork drain** | `SsArt` | `ArtworkRole::Impl::start()` | 4096 B | 2 | Receives image notifications, calls decode callback, then waits for the correct timestamp to call the display callback. |
+| **Artwork decode** | `SsArt` | `ArtworkRole::Impl::start()` | 4096 B | 2 | Receives image notifications and calls the decode callback. Hands the server display timestamp off to the main loop, which fires the display callback at the correct time. |
 | **Network** | (library-internal) | IXWebSocket (host) or esp_http_server (ESP) | - | - | WebSocket I/O. Callbacks fire on these threads and must defer work to the main loop. |
 
 On host builds, `platform_configure_thread()` is a no-op; threads use OS defaults. On ESP-IDF it calls `esp_pthread_set_cfg()` to set stack size, priority, name, and optional PSRAM allocation before the `std::thread` is constructed.
@@ -41,11 +41,11 @@ On host builds, `platform_configure_thread()` is a no-op; threads use OS default
 2. The thread blocks on ring buffer receives with a 50 ms timeout.
 3. `VisualizerRole::Impl` destructor sets `COMMAND_STOP` and joins.
 
-**Artwork drain** (`src/artwork_role.cpp`):
+**Artwork decode** (`src/artwork_role.cpp`):
 
-1. `ArtworkRole::Impl::start()` spawns the drain thread.
+1. `ArtworkRole::Impl::start()` spawns the decode thread.
 2. The thread blocks on notification queue receives with a 100 ms timeout.
-3. On notification: calls `on_image_decode()` immediately, then sleeps until the server timestamp to call `on_image_display()`. Sleep is interruptible via `EventFlags`.
+3. On notification: calls `on_image_decode()`, then writes the server display timestamp into a per-slot `ShadowSlot<int64_t>` (`DisplayScheduler::pending[slot]`). The main loop's `ArtworkRole::Impl::drain_events()` fires `on_image_display()` once the timestamp is reached. Latest-wins per slot: if a newer frame's timestamp overwrites the pending one before the main loop takes it, only the newer display fires.
 4. `ArtworkRole::Impl` destructor sets `COMMAND_STOP` and joins.
 
 **Destruction order** matters because external audio callbacks may still reference the sync task. `PlayerRole::Impl`'s destructor resets the sync task first (`sync_task_.reset()`) before tearing down anything else, so the thread is fully joined before any shared state is destroyed.
@@ -69,7 +69,7 @@ TASK_ERROR           (1 << 11)  Allocation or decode failure
 TASK_IDLE            (1 << 12)  Waiting for work
 ```
 
-The sync task, visualizer drain thread, and artwork drain thread all use event flags for command signaling from the main loop and status reporting back. The artwork and visualizer drain threads use a simpler subset: `COMMAND_STOP` and `COMMAND_FLUSH`.
+The sync task, visualizer drain thread, and artwork decode thread all use event flags for command signaling from the main loop and status reporting back. The artwork decode thread and visualizer drain thread use a simpler subset: `COMMAND_STOP` and `COMMAND_FLUSH`.
 
 ### ThreadSafeQueue (`src/platform/thread_safe_queue.h`)
 
@@ -80,7 +80,7 @@ Fixed-depth FIFO queue with timed send/receive. Used to defer events from networ
 | `PlayerRole::Impl::stream_queue` | 8 | `PlayerStreamCallbackType` | Network thread | Main loop (`drain_events`) |
 | `PlayerRole::Impl::state_queue` | 4 | `SendspinClientState` | Sync task thread | Main loop (`drain_events`) |
 | `Client::time_queue` | 16 | `TimeResponseEvent` | Network thread | Main loop (`loop`) |
-| `ArtworkRole::Impl::notify_queue` | 8 | `ArtworkNotification` | Network thread | Artwork drain thread |
+| `ArtworkRole::Impl::notify_queue` | 8 | `ArtworkNotification` | Network thread | Artwork decode thread |
 | `ArtworkRole::Impl::queue` | 8 | `ArtworkEventType` | Network thread | Main loop (`drain_events`) |
 | `VisualizerRole::Impl::queue` | 8 | `VisualizerEventType` | Network thread | Main loop (`drain_events`) |
 
@@ -95,6 +95,7 @@ Single-slot state container with "latest wins" or custom merge semantics. The ne
 | `PlayerRole::Impl::shadow_command` | `ServerCommandMessage` | Field-by-field merge (volume, mute, delay independent) |
 | `ControllerRole::Impl::shadow` | `ServerStateControllerObject` | Latest wins |
 | `MetadataRole::Impl::shadow` | `ServerMetadataStateObject` | Field-by-field delta merge |
+| `ArtworkRole::Impl::display_scheduler->pending[slot]` (×4) | `int64_t` (server display timestamp) | Latest wins |
 | `VisualizerRole::Impl::shadow_config` | `ServerVisualizerStreamObject` | Latest wins |
 | `SyncTask::playback_progress_slot_` | `PlaybackProgress` | Sum `frames_played`, keep latest `finish_timestamp` |
 
@@ -117,7 +118,7 @@ Used for:
 - **`std::atomic<bool/uint8_t/size_t>`** on `VisualizerRole::Impl`: network thread writes stream config atomically; drain thread reads it.
 - **`std::atomic<bool>`** on `ArtworkRole::Impl::stream_active`: guards `handle_binary()` from writing when no stream is active.
 - **`std::atomic<uint8_t>`** on `ArtworkRole::Impl::SlotBuffer::write_idx`: tracks which of two double-buffers the network thread writes to next.
-- **`std::atomic<bool>`** on `ArtworkRole::Impl::SlotBuffer::drain_active`: set by the drain thread while decoding, checked by the network thread to avoid overwriting an in-use buffer.
+- **`std::atomic<bool>`** on `ArtworkRole::Impl::SlotBuffer::drain_active`: set by the decode thread while decoding, checked by the network thread to avoid overwriting an in-use buffer.
 - **`std::atomic<uint8_t>`** on `SendspinClient::high_performance_ref_count_`: ref-counted high-performance networking requests from time sync and playback.
 
 ## Message Flow
@@ -149,7 +150,7 @@ Network thread (IXWebSocket / esp_http_server)
 | `SERVER_STATE` | Writes to `ControllerRole::Impl::shadow` and `MetadataRole::Impl::shadow` |
 | `SERVER_COMMAND` | Merges into `PlayerRole::Impl::shadow_command` |
 | `GROUP_UPDATE` | Merges into `Client::shadow_group` |
-| `STREAM_START` | Writes to `PlayerRole::Impl::shadow_stream_params`, enqueues `STREAM_START` into `stream_queue`. Marks the artwork stream active and flushes the drain thread. Writes to `VisualizerRole::Impl::shadow_config`, enqueues a start event. |
+| `STREAM_START` | Writes to `PlayerRole::Impl::shadow_stream_params`, enqueues `STREAM_START` into `stream_queue`. Marks the artwork stream active, flushes the decode thread's notification queue, and resets any pending per-slot display timestamps. Writes to `VisualizerRole::Impl::shadow_config`, enqueues a start event. |
 | `STREAM_END` | Enqueues `STREAM_END` into player/artwork/visualizer queues, signals sync task `COMMAND_STREAM_END` |
 | `STREAM_CLEAR` | Enqueues `STREAM_CLEAR` into player/artwork/visualizer queues, signals sync task `COMMAND_STREAM_CLEAR` |
 
@@ -160,7 +161,7 @@ Network thread (IXWebSocket / esp_http_server)
 | Binary Type | Handler |
 |-------------|---------|
 | Player audio | `PlayerRole::Impl::handle_binary()`: writes to encoded audio ring buffer |
-| Artwork image | `ArtworkRole::Impl::handle_binary()`: copies image data to a per-slot double buffer and enqueues a notification for the artwork drain thread |
+| Artwork image | `ArtworkRole::Impl::handle_binary()`: copies image data to a per-slot double buffer and enqueues a notification for the artwork decode thread |
 | Visualizer frame/beat | `VisualizerRole::Impl::handle_binary()`: writes to visualizer ring buffer |
 
 ### Main Loop Processing
@@ -232,7 +233,7 @@ The `awaiting_sync_idle_events` list (on `PlayerRole::Impl`) is the key ordering
 
 - **ControllerRole**: Takes from shadow, fires `on_controller_state()`.
 - **MetadataRole**: Takes from shadow when the pending update's `timestamp` has been reached on the synced client clock (or immediately if time sync is not yet ready), applies deltas, fires `on_metadata()`.
-- **ArtworkRole**: Drains event queue for stream end/clear lifecycle events. On `STREAM_END` and `STREAM_CLEAR`, fires `on_image_clear()` for each configured slot. Image data delivery (`on_image_decode` and `on_image_display`) happens on the dedicated artwork drain thread, not here.
+- **ArtworkRole**: Drains event queue for stream end/clear lifecycle events first (resetting all per-slot pending display timestamps and firing `on_image_clear()` for each configured slot). Then iterates the per-slot `DisplayScheduler::pending` shadow slots and fires `on_image_display(slot)` for any slot whose pending timestamp is due on the synced client clock (or immediately if time sync is not yet ready). `on_image_decode` still happens on the dedicated artwork decode thread.
 - **VisualizerRole**: Drains event queue, processes stream start/end/clear with shadow config.
 
 ## Sync Task State Machine

--- a/include/sendspin/artwork_role.h
+++ b/include/sendspin/artwork_role.h
@@ -29,14 +29,14 @@ class SendspinClient;
 
 /// @brief Listener for artwork role events
 ///
-/// THREAD SAFETY: on_image_decode() and on_image_display() fire on a dedicated drain thread.
-/// Implementations must be thread-safe for these two methods. on_image_clear() fires on the
-/// main loop thread.
+/// THREAD SAFETY: on_image_decode() fires on a dedicated decode thread and must be
+/// thread-safe with respect to the other callbacks. on_image_display() and on_image_clear()
+/// fire on the main loop thread.
 class ArtworkRoleListener {
 public:
     virtual ~ArtworkRoleListener() = default;
 
-    /// @brief Called on the drain thread when encoded image data arrives
+    /// @brief Called on the decode thread when encoded image data arrives
     ///
     /// The implementation should decode the image (e.g., JPEG to bitmap) synchronously.
     /// The data pointer is valid for the duration of this call.
@@ -47,10 +47,12 @@ public:
     virtual void on_image_decode(uint8_t /*slot*/, const uint8_t* /*data*/, size_t /*length*/,
                                  SendspinImageFormat /*format*/) {}
 
-    /// @brief Called on the drain thread at the correct timestamp when the decoded image should be
-    /// displayed
+    /// @brief Called on the main loop thread at the correct timestamp when the decoded image
+    /// should be displayed
     ///
-    /// Fires after on_image_decode() once the server timestamp is reached.
+    /// Fires after on_image_decode() once the server timestamp is reached. If a newer frame for
+    /// the same slot finishes decoding before the pending display fires, the older pending
+    /// display is superseded and only the newer one is delivered.
     /// @param slot The artwork slot index.
     virtual void on_image_display(uint8_t /*slot*/) {}
 
@@ -65,11 +67,10 @@ public:
  * @brief Artwork role that receives album art and artist images from the server
  *
  * Receives binary image payloads from the server and delivers them to the platform
- * through ArtworkRoleListener callbacks. A dedicated drain thread handles two-phase
- * delivery: on_image_decode() fires immediately when data arrives for decoding, then
- * on_image_display() fires at the correct timestamp for synchronized display. Lifecycle
- * callbacks fire on the main loop thread. Supports multiple image slots with configurable
- * format and resolution preferences.
+ * through ArtworkRoleListener callbacks. A dedicated decode thread fires on_image_decode()
+ * immediately when data arrives; on_image_display() and on_image_clear() fire on the main
+ * loop thread, with on_image_display() scheduled to the server timestamp. Supports multiple
+ * image slots with configurable format and resolution preferences.
  *
  * Usage:
  * 1. Implement ArtworkRoleListener with on_image_decode() and on_image_display()

--- a/include/sendspin/config.h
+++ b/include/sendspin/config.h
@@ -123,8 +123,8 @@ struct ImageSlotPreference {
 /// @brief Configuration for the artwork role
 struct ArtworkRoleConfig {
     std::vector<ImageSlotPreference> preferred_formats{};
-    bool psram_stack{false};  ///< Allocate drain thread stack in PSRAM (ESP-IDF only)
-    unsigned priority{2};     ///< FreeRTOS priority for the drain thread (ESP-IDF only)
+    bool psram_stack{false};  ///< Allocate decode thread stack in PSRAM (ESP-IDF only)
+    unsigned priority{2};     ///< FreeRTOS priority for the decode thread (ESP-IDF only)
 };
 
 // ============================================================================

--- a/src/artwork_role.cpp
+++ b/src/artwork_role.cpp
@@ -31,10 +31,10 @@ static const char* const TAG = "sendspin.artwork";
 /// @brief Size of the big-endian 64-bit timestamp at the start of artwork binary messages
 static constexpr size_t BINARY_TIMESTAMP_SIZE = 8;
 
-/// @brief Timeout for blocking queue receive in drain thread (allows periodic command checks)
+/// @brief Timeout for blocking queue receive in decode thread (allows periodic command checks)
 static constexpr uint32_t DRAIN_RECEIVE_TIMEOUT_MS = 100U;
 
-// Event flag bits for drain thread signaling
+// Event flag bits for decode thread signaling
 static constexpr uint32_t COMMAND_STOP = (1 << 0);
 static constexpr uint32_t COMMAND_FLUSH = (1 << 1);
 
@@ -61,7 +61,8 @@ ArtworkRole::Impl::Impl(ArtworkRoleConfig config, SendspinClient* client)
     : config(std::move(config)),
       client(client),
       drain_task(std::make_unique<DrainTask>()),
-      event_state(std::make_unique<EventState>()) {
+      event_state(std::make_unique<EventState>()),
+      display_scheduler(std::make_unique<DisplayScheduler>()) {
     for (const auto& pref : this->config.preferred_formats) {
         this->artwork_channels.push_back({pref.source, pref.format, pref.width, pref.height});
     }
@@ -75,7 +76,7 @@ ArtworkRole::Impl::~Impl() {
 
 bool ArtworkRole::Impl::start() {
     if (!this->drain_task) {
-        SS_LOGE(TAG, "Failed to start artwork: drain task not initialized");
+        SS_LOGE(TAG, "Failed to start artwork: decode task not initialized");
         return false;
     }
     if (this->drain_task->drain_thread.joinable()) {
@@ -144,8 +145,8 @@ void ArtworkRole::Impl::handle_binary(uint8_t slot, const uint8_t* data, size_t 
     auto& sb = this->drain_task->slot_buffers[slot];
     uint8_t write_idx = sb.write_idx.load(std::memory_order_acquire);
 
-    // If the drain thread is actively using this buffer, skip to the other one.
-    // If the drain thread is using the other one, this write_idx is already safe.
+    // If the decode thread is actively using this buffer, skip to the other one.
+    // If the decode thread is using the other one, this write_idx is already safe.
     if (sb.drain_active.load(std::memory_order_acquire) && sb.drain_buf_idx == write_idx) {
         write_idx ^= 1;
     }
@@ -165,7 +166,7 @@ void ArtworkRole::Impl::handle_binary(uint8_t slot, const uint8_t* data, size_t 
     // Flip write index so the next network write goes to the other buffer
     sb.write_idx.store(write_idx ^ 1, std::memory_order_release);
 
-    // Signal drain thread with all metadata in the notification
+    // Signal decode thread with all metadata in the notification
     ArtworkNotification notif{slot, write_idx, image_len, timestamp, image_format};
     this->drain_task->notify_queue.send(notif, 0);
 }
@@ -177,9 +178,15 @@ void ArtworkRole::Impl::handle_binary(uint8_t slot, const uint8_t* data, size_t 
 void ArtworkRole::Impl::handle_stream_start() {
     this->stream_active = true;
 
-    // Signal drain thread to flush any stale notifications
+    // Signal decode thread to flush any stale notifications
     if (this->drain_task) {
         this->drain_task->event_flags.set(COMMAND_FLUSH);
+    }
+    // Discard any pending displays from a prior stream
+    if (this->display_scheduler) {
+        for (auto& slot : this->display_scheduler->pending) {
+            slot.reset();
+        }
     }
 }
 
@@ -204,21 +211,50 @@ void ArtworkRole::Impl::handle_stream_clear() {
 }
 
 // ============================================================================
-// Event draining (main thread) - lifecycle events only
+// Event draining (main thread) - lifecycle events and scheduled displays
 // ============================================================================
 
 void ArtworkRole::Impl::drain_events() {
+    // Process stream lifecycle events first so we don't fire a display that was
+    // cancelled by an end/clear in the same tick.
     ArtworkEventType event_type{};
     while (this->event_state->queue.receive(event_type, 0)) {
         switch (event_type) {
             case ArtworkEventType::STREAM_END:
             case ArtworkEventType::STREAM_CLEAR:
+                if (this->display_scheduler) {
+                    for (auto& pending : this->display_scheduler->pending) {
+                        pending.reset();
+                    }
+                }
                 if (this->listener) {
                     for (const auto& pref : this->config.preferred_formats) {
                         this->listener->on_image_clear(pref.slot);
                     }
                 }
                 break;
+        }
+    }
+
+    if (!this->display_scheduler || !this->listener) {
+        return;
+    }
+
+    const int64_t now = platform_time_us();
+    for (uint8_t slot = 0; slot < ARTWORK_MAX_SLOTS; ++slot) {
+        int64_t server_ts = 0;
+        const bool taken = this->display_scheduler->pending[slot].take_if(
+            server_ts, [this, now](const int64_t& pending_ts) {
+                // Fire immediately if time sync isn't ready: holding forever would starve
+                // the listener. Matches the metadata role's behavior.
+                int64_t client_ts = this->client->get_client_time(pending_ts);
+                if (client_ts == 0) {
+                    return true;
+                }
+                return client_ts <= now;
+            });
+        if (taken) {
+            this->listener->on_image_display(slot);
         }
     }
 }
@@ -234,16 +270,22 @@ void ArtworkRole::Impl::cleanup() {
         this->drain_task->event_flags.set(COMMAND_FLUSH);
     }
 
+    if (this->display_scheduler) {
+        for (auto& pending : this->display_scheduler->pending) {
+            pending.reset();
+        }
+    }
+
     this->event_state->queue.reset();
     this->event_state->queue.send(ArtworkEventType::STREAM_END, 0);
 }
 
 // ============================================================================
-// Drain thread
+// Decode thread
 // ============================================================================
 
 void ArtworkRole::Impl::drain_thread_func(ArtworkRole::Impl* self) {
-    SS_LOGD(TAG, "Drain thread started");
+    SS_LOGD(TAG, "Decode thread started");
 
     auto& queue = self->drain_task->notify_queue;
     auto& flags = self->drain_task->event_flags;
@@ -284,49 +326,20 @@ void ArtworkRole::Impl::drain_thread_func(ArtworkRole::Impl* self) {
         sb.drain_buf_idx = buf_idx;
         sb.drain_active.store(true, std::memory_order_release);
 
-        // Phase 1: Decode callback (immediate)
         if (self->listener) {
             self->listener->on_image_decode(slot, buf.data(), notif.data_length, notif.format);
         }
 
-        // Buffer is no longer needed after decode completes
         sb.drain_active.store(false, std::memory_order_release);
 
-        // Wait for time sync before scheduling display
-        if (!self->client->is_time_synced()) {
-            continue;
-        }
-
-        // Phase 2: Wait until display timestamp
-        int64_t client_ts = self->client->get_client_time(notif.timestamp);
-
-        if (client_ts == 0) {
-            continue;
-        }
-
-        int64_t now = platform_time_us();
-        if (client_ts > now) {
-            uint32_t wait_ms = static_cast<uint32_t>((client_ts - now) / US_PER_MS);
-            if (wait_ms > 0) {
-                cmd = flags.wait(COMMAND_STOP | COMMAND_FLUSH, false, true, wait_ms);
-                if (cmd & COMMAND_STOP) {
-                    break;
-                }
-                if (cmd & COMMAND_FLUSH) {
-                    ArtworkNotification dummy2{};
-                    while (queue.receive(dummy2, 0)) {}
-                    continue;
-                }
-            }
-        }
-
-        // Display/swap callback
-        if (self->listener) {
-            self->listener->on_image_display(slot);
+        // Hand off the timestamp to the main loop. Skip if the stream ended while we were
+        // decoding so the main loop doesn't fire a display after on_image_clear.
+        if (self->stream_active.load(std::memory_order_acquire) && self->display_scheduler) {
+            self->display_scheduler->pending[slot].write(notif.timestamp);
         }
     }
 
-    SS_LOGD(TAG, "Drain thread stopped");
+    SS_LOGD(TAG, "Decode thread stopped");
 }
 
 // ============================================================================

--- a/src/artwork_role_impl.h
+++ b/src/artwork_role_impl.h
@@ -19,6 +19,7 @@
 
 #include "platform/event_flags.h"
 #include "platform/memory.h"
+#include "platform/shadow_slot.h"
 #include "platform/thread_safe_queue.h"
 #include "protocol_messages.h"
 #include "sendspin/artwork_role.h"
@@ -48,15 +49,16 @@ static constexpr size_t ARTWORK_MAX_SLOTS = 4;
 struct SlotBuffer {
     PlatformBuffer buffers[2];
     std::atomic<uint8_t> write_idx{0};      ///< Which buffer the network thread writes to next
-    std::atomic<bool> drain_active{false};  ///< True while the drain thread is using a buffer
-    uint8_t drain_buf_idx{0};               ///< Which buffer the drain thread is currently using
+    std::atomic<bool> drain_active{false};  ///< True while the decode thread is using a buffer
+    uint8_t drain_buf_idx{0};               ///< Which buffer the decode thread is currently using
 };
 
-/// @brief Notification sent from the network thread to the drain thread when new image data arrives
+/// @brief Notification sent from the network thread to the decode thread when new image data
+/// arrives
 ///
 /// All metadata is carried in the notification itself (not in SlotBuffer) so that the
 /// ThreadSafeQueue's internal mutex provides the happens-before guarantee between the
-/// network thread's writes and the drain thread's reads.
+/// network thread's writes and the decode thread's reads.
 struct ArtworkNotification {
     uint8_t slot;
     uint8_t buffer_idx;
@@ -74,7 +76,7 @@ struct ArtworkRole::Impl {
     // Nested types
     // ========================================
 
-    /// @brief Persistent drain thread context for artwork image decode and display delivery
+    /// @brief Persistent decode thread context for artwork image decode
     struct DrainTask {
         ThreadSafeQueue<ArtworkNotification> notify_queue;
         EventFlags event_flags;
@@ -85,6 +87,16 @@ struct ArtworkRole::Impl {
     /// @brief Deferred event state for thread-safe artwork stream lifecycle delivery
     struct EventState {
         ThreadSafeQueue<ArtworkEventType> queue;
+    };
+
+    /// @brief Pending display timestamps, one slot per artwork slot
+    ///
+    /// The decode thread writes the server timestamp after on_image_decode() completes; the
+    /// main loop reads the timestamp and fires on_image_display() once it is reached. Latest-
+    /// wins per slot: if a newer frame finishes decoding before the pending display fires,
+    /// the older timestamp is overwritten and only the newer display is delivered.
+    struct DisplayScheduler {
+        ShadowSlot<int64_t> pending[ARTWORK_MAX_SLOTS];
     };
 
     // ========================================
@@ -119,6 +131,7 @@ struct ArtworkRole::Impl {
     SendspinClient* client;
     std::unique_ptr<DrainTask> drain_task;
     std::unique_ptr<EventState> event_state;
+    std::unique_ptr<DisplayScheduler> display_scheduler;
     ArtworkRoleListener* listener{nullptr};
 
     // 8-bit fields


### PR DESCRIPTION
Previously, the artwork thread tried to handle decoding images as well as timing when they should be displayed, which are two different goals.

This PR changes it so that:
- artwork thread only works on decoding images
- ``on_image_decode`` is now fired from the main thread at the correct time via ``loop()``

Marked as a breaking change due to the changed threading contract; ``on_image_decode`` used to be fired from artwork thread, but it is now fired from the main loop.