### PR TITLE
Refactor stream start handlers

### DIFF
--- a/src/artwork_role.cpp
+++ b/src/artwork_role.cpp
@@ -20,6 +20,7 @@
 #include "protocol_messages.h"
 #include "sendspin/client.h"
 
+#include <algorithm>
 #include <cstring>
 
 static const char* const TAG = "sendspin.artwork";
@@ -175,7 +176,34 @@ void ArtworkRole::Impl::handle_binary(uint8_t slot, const uint8_t* data, size_t 
 // Stream lifecycle (network thread)
 // ============================================================================
 
-void ArtworkRole::Impl::handle_stream_start() {
+void ArtworkRole::Impl::handle_stream_start(const ServerArtworkStreamObject& stream) {
+    if (stream.channels.has_value()) {
+        const auto& server_channels = stream.channels.value();
+        if (server_channels.size() != this->artwork_channels.size()) {
+            SS_LOGW(TAG, "Artwork channel count mismatch: server sent %zu, expected %zu",
+                    server_channels.size(), this->artwork_channels.size());
+        }
+        size_t n = std::min(server_channels.size(), this->artwork_channels.size());
+        for (size_t i = 0; i < n; ++i) {
+            const auto& srv = server_channels[i];
+            const auto& req = this->artwork_channels[i];
+            if (srv.source.has_value() && srv.source.value() != req.source) {
+                SS_LOGW(TAG, "Artwork channel %zu source mismatch", i);
+            }
+            if (srv.format.has_value() && srv.format.value() != req.format) {
+                SS_LOGW(TAG, "Artwork channel %zu format mismatch", i);
+            }
+            if (srv.width.has_value() && srv.width.value() != req.media_width) {
+                SS_LOGW(TAG, "Artwork channel %zu width mismatch: server %u, expected %u", i,
+                        srv.width.value(), req.media_width);
+            }
+            if (srv.height.has_value() && srv.height.value() != req.media_height) {
+                SS_LOGW(TAG, "Artwork channel %zu height mismatch: server %u, expected %u", i,
+                        srv.height.value(), req.media_height);
+            }
+        }
+    }
+
     this->stream_active = true;
 
     // Signal decode thread to flush any stale notifications

--- a/src/artwork_role.cpp
+++ b/src/artwork_role.cpp
@@ -194,12 +194,15 @@ void ArtworkRole::Impl::handle_stream_start(const ServerArtworkStreamObject& str
                 SS_LOGW(TAG, "Artwork channel %zu format mismatch", i);
             }
             if (srv.width.has_value() && srv.width.value() != req.media_width) {
-                SS_LOGW(TAG, "Artwork channel %zu width mismatch: server %u, expected %u", i,
-                        srv.width.value(), req.media_width);
+                SS_LOGW(TAG,
+                        "Artwork channel %zu width mismatch: server %" PRIu16 ", expected %" PRIu16,
+                        i, srv.width.value(), req.media_width);
             }
             if (srv.height.has_value() && srv.height.value() != req.media_height) {
-                SS_LOGW(TAG, "Artwork channel %zu height mismatch: server %u, expected %u", i,
-                        srv.height.value(), req.media_height);
+                SS_LOGW(TAG,
+                        "Artwork channel %zu height mismatch: server %" PRIu16
+                        ", expected %" PRIu16,
+                        i, srv.height.value(), req.media_height);
             }
         }
     }

--- a/src/artwork_role_impl.h
+++ b/src/artwork_role_impl.h
@@ -106,7 +106,7 @@ struct ArtworkRole::Impl {
     bool start();
     void build_hello_fields(ClientHelloMessage& msg) const;
     void handle_binary(uint8_t slot, const uint8_t* data, size_t len);
-    void handle_stream_start();
+    void handle_stream_start(const ServerArtworkStreamObject& stream);
     void handle_stream_end();
     void handle_stream_clear();
     void drain_events();

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -484,7 +484,7 @@ void SendspinClient::process_json_message(SendspinConnection* conn, const std::s
 
 #ifdef SENDSPIN_ENABLE_ARTWORK
             if (this->artwork_ && stream_msg.artwork.has_value()) {
-                this->artwork_->impl_->handle_stream_start();
+                this->artwork_->impl_->handle_stream_start(stream_msg.artwork.value());
             }
 #endif
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -477,7 +477,7 @@ void SendspinClient::process_json_message(SendspinConnection* conn, const std::s
             }
 
 #ifdef SENDSPIN_ENABLE_PLAYER
-            if (this->player_) {
+            if (this->player_ && stream_msg.player.has_value()) {
                 this->player_->impl_->handle_stream_start(stream_msg);
             }
 #endif

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -478,7 +478,7 @@ void SendspinClient::process_json_message(SendspinConnection* conn, const std::s
 
 #ifdef SENDSPIN_ENABLE_PLAYER
             if (this->player_ && stream_msg.player.has_value()) {
-                this->player_->impl_->handle_stream_start(stream_msg);
+                this->player_->impl_->handle_stream_start(stream_msg.player.value());
             }
 #endif
 

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -233,7 +233,7 @@ void PlayerRole::Impl::handle_binary(const uint8_t* data, size_t len) const {
     }
 }
 
-void PlayerRole::Impl::handle_stream_start(const StreamStartMessage& stream_msg) {
+void PlayerRole::Impl::handle_stream_start(const ServerPlayerStreamObject& player_obj) {
     if (this->config.audio_formats.empty()) {
         // No audio formats, just defer stream start callback
         this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_START, 0);
@@ -246,55 +246,47 @@ void PlayerRole::Impl::handle_stream_start(const StreamStartMessage& stream_msg)
         this->high_performance_requested_for_playback = true;
     }
 
-    if (stream_msg.player.has_value()) {
-        const ServerPlayerStreamObject& player_obj = stream_msg.player.value();
-
-        if (!player_obj.bit_depth.has_value() || !player_obj.channels.has_value() ||
-            !player_obj.sample_rate.has_value() || !player_obj.codec.has_value()) {
-            SS_LOGE(TAG, "Stream start message missing required audio parameters");
-            return;
-        }
-
-        auto codec = player_obj.codec.value();
-        bool header_sent = false;
-
-        if ((codec == SendspinCodecFormat::PCM) || (codec == SendspinCodecFormat::OPUS)) {
-            DummyHeader header{};
-            header.sample_rate = player_obj.sample_rate.value();
-            header.bits_per_sample = player_obj.bit_depth.value();
-            header.channels = player_obj.channels.value();
-
-            ChunkType chunk_type = (codec == SendspinCodecFormat::PCM)
-                                       ? CHUNK_TYPE_PCM_DUMMY_HEADER
-                                       : CHUNK_TYPE_OPUS_DUMMY_HEADER;
-
-            header_sent =
-                this->send_audio_chunk(reinterpret_cast<const uint8_t*>(&header),
-                                       sizeof(DummyHeader), 0, chunk_type, HEADER_SEND_TIMEOUT_MS);
-        } else if (codec == SendspinCodecFormat::FLAC) {
-            if (!player_obj.codec_header.has_value()) {
-                SS_LOGE(TAG, "FLAC codec header missing");
-                return;
-            }
-            std::vector<uint8_t> flac_header = base64_decode(player_obj.codec_header.value());
-            header_sent = this->send_audio_chunk(flac_header.data(), flac_header.size(), 0,
-                                                 CHUNK_TYPE_FLAC_HEADER, HEADER_SEND_TIMEOUT_MS);
-        }
-
-        if (!header_sent) {
-            SS_LOGE(TAG, "Failed to send codec header");
-            this->sync_task->signal_stream_end();
-            this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_END, 0);
-            return;
-        }
-
-        // Shadow stream params for main thread, then signal
-        this->event_state->shadow_stream_params.write(player_obj);
-        this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_START, 0);
-    } else {
-        // No player in stream start -- sync task is already running (idle)
-        this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_START, 0);
+    if (!player_obj.bit_depth.has_value() || !player_obj.channels.has_value() ||
+        !player_obj.sample_rate.has_value() || !player_obj.codec.has_value()) {
+        SS_LOGE(TAG, "Stream start message missing required audio parameters");
+        return;
     }
+
+    auto codec = player_obj.codec.value();
+    bool header_sent = false;
+
+    if ((codec == SendspinCodecFormat::PCM) || (codec == SendspinCodecFormat::OPUS)) {
+        DummyHeader header{};
+        header.sample_rate = player_obj.sample_rate.value();
+        header.bits_per_sample = player_obj.bit_depth.value();
+        header.channels = player_obj.channels.value();
+
+        ChunkType chunk_type = (codec == SendspinCodecFormat::PCM) ? CHUNK_TYPE_PCM_DUMMY_HEADER
+                                                                   : CHUNK_TYPE_OPUS_DUMMY_HEADER;
+
+        header_sent =
+            this->send_audio_chunk(reinterpret_cast<const uint8_t*>(&header), sizeof(DummyHeader),
+                                   0, chunk_type, HEADER_SEND_TIMEOUT_MS);
+    } else if (codec == SendspinCodecFormat::FLAC) {
+        if (!player_obj.codec_header.has_value()) {
+            SS_LOGE(TAG, "FLAC codec header missing");
+            return;
+        }
+        std::vector<uint8_t> flac_header = base64_decode(player_obj.codec_header.value());
+        header_sent = this->send_audio_chunk(flac_header.data(), flac_header.size(), 0,
+                                             CHUNK_TYPE_FLAC_HEADER, HEADER_SEND_TIMEOUT_MS);
+    }
+
+    if (!header_sent) {
+        SS_LOGE(TAG, "Failed to send codec header");
+        this->sync_task->signal_stream_end();
+        this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_END, 0);
+        return;
+    }
+
+    // Shadow stream params for main thread, then signal
+    this->event_state->shadow_stream_params.write(player_obj);
+    this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_START, 0);
 }
 
 void PlayerRole::Impl::handle_stream_end() const {

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -240,12 +240,6 @@ void PlayerRole::Impl::handle_stream_start(const ServerPlayerStreamObject& playe
         return;
     }
 
-    // Request high-performance networking for playback
-    if (!this->high_performance_requested_for_playback) {
-        this->client->acquire_high_performance();
-        this->high_performance_requested_for_playback = true;
-    }
-
     if (!player_obj.bit_depth.has_value() || !player_obj.channels.has_value() ||
         !player_obj.sample_rate.has_value() || !player_obj.codec.has_value()) {
         SS_LOGE(TAG, "Stream start message missing required audio parameters");
@@ -282,6 +276,12 @@ void PlayerRole::Impl::handle_stream_start(const ServerPlayerStreamObject& playe
         this->sync_task->signal_stream_end();
         this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_END, 0);
         return;
+    }
+
+    // Request high-performance networking for playback
+    if (!this->high_performance_requested_for_playback) {
+        this->client->acquire_high_performance();
+        this->high_performance_requested_for_playback = true;
     }
 
     // Shadow stream params for main thread, then signal

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -240,39 +240,48 @@ void PlayerRole::Impl::handle_stream_start(const ServerPlayerStreamObject& playe
         return;
     }
 
+    bool header_sent = false;
+
     if (!player_obj.bit_depth.has_value() || !player_obj.channels.has_value() ||
         !player_obj.sample_rate.has_value() || !player_obj.codec.has_value()) {
         SS_LOGE(TAG, "Stream start message missing required audio parameters");
-        return;
-    }
+    } else {
+        auto codec = player_obj.codec.value();
 
-    auto codec = player_obj.codec.value();
-    bool header_sent = false;
+        if ((codec == SendspinCodecFormat::PCM) || (codec == SendspinCodecFormat::OPUS)) {
+            DummyHeader header{};
+            header.sample_rate = player_obj.sample_rate.value();
+            header.bits_per_sample = player_obj.bit_depth.value();
+            header.channels = player_obj.channels.value();
 
-    if ((codec == SendspinCodecFormat::PCM) || (codec == SendspinCodecFormat::OPUS)) {
-        DummyHeader header{};
-        header.sample_rate = player_obj.sample_rate.value();
-        header.bits_per_sample = player_obj.bit_depth.value();
-        header.channels = player_obj.channels.value();
+            ChunkType chunk_type = (codec == SendspinCodecFormat::PCM)
+                                       ? CHUNK_TYPE_PCM_DUMMY_HEADER
+                                       : CHUNK_TYPE_OPUS_DUMMY_HEADER;
 
-        ChunkType chunk_type = (codec == SendspinCodecFormat::PCM) ? CHUNK_TYPE_PCM_DUMMY_HEADER
-                                                                   : CHUNK_TYPE_OPUS_DUMMY_HEADER;
-
-        header_sent =
-            this->send_audio_chunk(reinterpret_cast<const uint8_t*>(&header), sizeof(DummyHeader),
-                                   0, chunk_type, HEADER_SEND_TIMEOUT_MS);
-    } else if (codec == SendspinCodecFormat::FLAC) {
-        if (!player_obj.codec_header.has_value()) {
-            SS_LOGE(TAG, "FLAC codec header missing");
-            return;
+            header_sent =
+                this->send_audio_chunk(reinterpret_cast<const uint8_t*>(&header),
+                                       sizeof(DummyHeader), 0, chunk_type, HEADER_SEND_TIMEOUT_MS);
+            if (!header_sent) {
+                SS_LOGE(TAG, "Failed to send codec header");
+            }
+        } else if (codec == SendspinCodecFormat::FLAC) {
+            if (!player_obj.codec_header.has_value()) {
+                SS_LOGE(TAG, "FLAC codec header missing");
+            } else {
+                std::vector<uint8_t> flac_header = base64_decode(player_obj.codec_header.value());
+                header_sent =
+                    this->send_audio_chunk(flac_header.data(), flac_header.size(), 0,
+                                           CHUNK_TYPE_FLAC_HEADER, HEADER_SEND_TIMEOUT_MS);
+                if (!header_sent) {
+                    SS_LOGE(TAG, "Failed to send codec header");
+                }
+            }
+        } else {
+            SS_LOGE(TAG, "Unsupported codec: %d", static_cast<int>(codec));
         }
-        std::vector<uint8_t> flac_header = base64_decode(player_obj.codec_header.value());
-        header_sent = this->send_audio_chunk(flac_header.data(), flac_header.size(), 0,
-                                             CHUNK_TYPE_FLAC_HEADER, HEADER_SEND_TIMEOUT_MS);
     }
 
     if (!header_sent) {
-        SS_LOGE(TAG, "Failed to send codec header");
         this->sync_task->signal_stream_end();
         this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_END, 0);
         return;

--- a/src/player_role_impl.h
+++ b/src/player_role_impl.h
@@ -31,7 +31,6 @@ class SendspinClient;
 class SendspinPersistenceProvider;
 struct ClientHelloMessage;
 struct ClientStateMessage;
-struct StreamStartMessage;
 
 /// @brief Deferred stream lifecycle callback types queued from the network thread
 enum class PlayerStreamCallbackType : uint8_t {
@@ -64,7 +63,7 @@ struct PlayerRole::Impl {
     void build_hello_fields(ClientHelloMessage& msg);
     void build_state_fields(ClientStateMessage& msg) const;
     void handle_binary(const uint8_t* data, size_t len) const;
-    void handle_stream_start(const StreamStartMessage& stream_msg);
+    void handle_stream_start(const ServerPlayerStreamObject& player_obj);
     void handle_stream_end() const;
     void handle_stream_clear() const;
     void handle_server_command(const ServerCommandMessage& cmd) const;


### PR DESCRIPTION
Makes all three binary roles follow the same pattern on stream start: validate that the message includes information for the role, then pass that information to the stream start handler.

- Fixes a bug where the player's stream start handler would fire even if only other role's had actual info in the message
- Refactors player role's start streaming handling to make the failure path unified
- Artwork now validates the settings match what we expect