### PR TITLE
Fix release drafter action labels

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,7 +2,7 @@ name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 categories:
   - title: "Breaking Changes"
-    label: "breaking-change"
+    label: "breaking change"
   - title: "Dependencies"
     collapse-after: 1
     labels:
@@ -12,17 +12,17 @@ version-resolver:
   major:
     labels:
       - "major"
-      - "breaking-change"
   minor:
     labels:
+      - "breaking change"
       - "minor"
-      - "new-feature"
+      - "enhancement"
   patch:
     labels:
+      - "bug"
       - "bugfix"
       - "dependencies"
       - "documentation"
-      - "enhancement"
   default: patch
 
 template: |


### PR DESCRIPTION
Moves breaking change to just be a minor bump. This is temporary. Once we hit v1.0.0 and have a more stable API, change it back.