### PR TITLE
Bugfix: static delay no longer applied when not adjustable

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -486,7 +486,8 @@ player.update_volume(75);
 player.update_muted(false);
 player.update_static_delay(50);  // User-adjustable delay in ms
 
-// Enable/disable static delay adjustment by the server
+// Enable/disable static delay adjustment by the server. When disabled, the stored delay
+// is not applied to sync timing and is reported as 0 in client state.
 player.set_static_delay_adjustable(true);
 ```
 

--- a/include/sendspin/player_role.h
+++ b/include/sendspin/player_role.h
@@ -171,11 +171,20 @@ public:
     /// @param muted true to mute, false to unmute
     void update_muted(bool muted);
 
-    /// @brief Updates the static delay and publishes client state to the server.
+    /// @brief Updates the stored static delay preference and publishes client state to the server.
+    ///
+    /// The value is always persisted (if a persistence provider is set), independent of
+    /// adjustability. If adjustability is currently disabled, the stored value has no
+    /// effect on sync timing until adjustability is re-enabled.
     /// @param delay_ms Static delay in milliseconds
     void update_static_delay(uint16_t delay_ms);
 
     /// @brief Enables or disables the static delay adjustment command.
+    ///
+    /// When disabled, the stored delay is not applied to audio sync timing and is reported
+    /// as 0 in client state, per the Sendspin spec (a delay that is not exposed as a knob
+    /// must not be applied). The stored value is preserved and takes effect again if
+    /// adjustability is re-enabled.
     /// @param adjustable true if the delay can be adjusted at runtime
     void set_static_delay_adjustable(bool adjustable);
 
@@ -195,8 +204,8 @@ public:
     /// @return true if muted, false otherwise.
     bool get_muted() const;
 
-    /// @brief Returns the current static delay in milliseconds
-    /// @return Static playback delay in milliseconds.
+    /// @brief Returns the effective static delay in milliseconds
+    /// @return Static playback delay in milliseconds, or 0 if the delay is not adjustable.
     uint16_t get_static_delay_ms() const;
 
     /// @brief Returns the current volume level

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -116,7 +116,7 @@ void PlayerRole::update_static_delay(uint16_t delay_ms) {
 }
 
 void PlayerRole::set_static_delay_adjustable(bool adjustable) {
-    this->impl_->static_delay_adjustable = adjustable;
+    this->impl_->static_delay_adjustable.store(adjustable, std::memory_order_relaxed);
     this->impl_->client->publish_state();
 }
 
@@ -158,7 +158,7 @@ void PlayerRole::Impl::update_static_delay(uint16_t delay_ms) {
     if (delay_ms > MAX_STATIC_DELAY_MS) {
         delay_ms = MAX_STATIC_DELAY_MS;
     }
-    this->static_delay_ms = delay_ms;
+    this->static_delay_ms.store(delay_ms, std::memory_order_relaxed);
     this->persist_static_delay();
     this->client->publish_state();
 }
@@ -211,8 +211,9 @@ void PlayerRole::Impl::build_state_fields(ClientStateMessage& msg) const {
     ClientPlayerStateObject player_state{};
     player_state.volume = this->volume;
     player_state.muted = this->muted;
-    bool adjustable = this->static_delay_adjustable.load();
-    player_state.static_delay_ms = adjustable ? this->static_delay_ms.load() : 0;
+    bool adjustable = this->static_delay_adjustable.load(std::memory_order_relaxed);
+    player_state.static_delay_ms =
+        adjustable ? this->static_delay_ms.load(std::memory_order_relaxed) : 0;
     if (adjustable) {
         player_state.supported_commands = {SendspinPlayerCommand::SET_STATIC_DELAY};
     }
@@ -378,7 +379,8 @@ void PlayerRole::Impl::drain_events() {
             if (player_cmd.static_delay_ms.has_value()) {
                 this->update_static_delay(player_cmd.static_delay_ms.value());
                 if (this->listener) {
-                    this->listener->on_static_delay_changed(this->static_delay_ms.load());
+                    this->listener->on_static_delay_changed(
+                        this->static_delay_ms.load(std::memory_order_relaxed));
                 }
             }
         }
@@ -485,9 +487,10 @@ void PlayerRole::Impl::load_static_delay() {
     if (!this->persistence) {
         // No persistence provider - use initial value from config
         if (this->config.initial_static_delay_ms > 0) {
-            this->static_delay_ms = this->config.initial_static_delay_ms;
+            this->static_delay_ms.store(this->config.initial_static_delay_ms,
+                                        std::memory_order_relaxed);
             SS_LOGI(TAG, "Using initial static delay from config: %u ms",
-                    this->static_delay_ms.load());
+                    this->config.initial_static_delay_ms);
         }
         return;
     }
@@ -495,24 +498,28 @@ void PlayerRole::Impl::load_static_delay() {
     auto delay = this->persistence->load_static_delay();
     if (delay.has_value()) {
         if (delay.value() <= MAX_STATIC_DELAY_MS) {
-            this->static_delay_ms = delay.value();
-            SS_LOGI(TAG, "Loaded static delay: %u ms", this->static_delay_ms.load());
+            this->static_delay_ms.store(delay.value(), std::memory_order_relaxed);
+            SS_LOGI(TAG, "Loaded static delay: %u ms", delay.value());
         } else {
             SS_LOGW(TAG, "Persisted static delay out of range (%u), ignoring", delay.value());
         }
     } else if (this->config.initial_static_delay_ms > 0) {
-        this->static_delay_ms = this->config.initial_static_delay_ms;
-        SS_LOGI(TAG, "Using initial static delay from config: %u ms", this->static_delay_ms.load());
+        this->static_delay_ms.store(this->config.initial_static_delay_ms,
+                                    std::memory_order_relaxed);
+        SS_LOGI(TAG, "Using initial static delay from config: %u ms",
+                this->config.initial_static_delay_ms);
     }
 }
 
 uint16_t PlayerRole::Impl::get_effective_static_delay_ms() const {
-    return this->static_delay_adjustable ? this->static_delay_ms.load() : 0;
+    return this->static_delay_adjustable.load(std::memory_order_relaxed)
+               ? this->static_delay_ms.load(std::memory_order_relaxed)
+               : 0;
 }
 
 void PlayerRole::Impl::persist_static_delay() const {
     if (this->persistence) {
-        uint16_t delay = this->static_delay_ms.load();
+        uint16_t delay = this->static_delay_ms.load(std::memory_order_relaxed);
         if (this->persistence->save_static_delay(delay)) {
             SS_LOGD(TAG, "Persisted static delay: %u ms", delay);
         } else {

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -377,7 +377,7 @@ void PlayerRole::Impl::drain_events() {
             if (player_cmd.static_delay_ms.has_value()) {
                 this->update_static_delay(player_cmd.static_delay_ms.value());
                 if (this->listener) {
-                    this->listener->on_static_delay_changed(this->static_delay_ms);
+                    this->listener->on_static_delay_changed(this->static_delay_ms.load());
                 }
             }
         }
@@ -485,7 +485,8 @@ void PlayerRole::Impl::load_static_delay() {
         // No persistence provider - use initial value from config
         if (this->config.initial_static_delay_ms > 0) {
             this->static_delay_ms = this->config.initial_static_delay_ms;
-            SS_LOGI(TAG, "Using initial static delay from config: %u ms", this->static_delay_ms);
+            SS_LOGI(TAG, "Using initial static delay from config: %u ms",
+                    this->static_delay_ms.load());
         }
         return;
     }
@@ -494,24 +495,25 @@ void PlayerRole::Impl::load_static_delay() {
     if (delay.has_value()) {
         if (delay.value() <= MAX_STATIC_DELAY_MS) {
             this->static_delay_ms = delay.value();
-            SS_LOGI(TAG, "Loaded static delay: %u ms", this->static_delay_ms);
+            SS_LOGI(TAG, "Loaded static delay: %u ms", this->static_delay_ms.load());
         } else {
             SS_LOGW(TAG, "Persisted static delay out of range (%u), ignoring", delay.value());
         }
     } else if (this->config.initial_static_delay_ms > 0) {
         this->static_delay_ms = this->config.initial_static_delay_ms;
-        SS_LOGI(TAG, "Using initial static delay from config: %u ms", this->static_delay_ms);
+        SS_LOGI(TAG, "Using initial static delay from config: %u ms", this->static_delay_ms.load());
     }
 }
 
 uint16_t PlayerRole::Impl::get_effective_static_delay_ms() const {
-    return this->static_delay_adjustable ? this->static_delay_ms : 0;
+    return this->static_delay_adjustable ? this->static_delay_ms.load() : 0;
 }
 
 void PlayerRole::Impl::persist_static_delay() const {
     if (this->persistence) {
-        if (this->persistence->save_static_delay(this->static_delay_ms)) {
-            SS_LOGD(TAG, "Persisted static delay: %u ms", this->static_delay_ms);
+        uint16_t delay = this->static_delay_ms.load();
+        if (this->persistence->save_static_delay(delay)) {
+            SS_LOGD(TAG, "Persisted static delay: %u ms", delay);
         } else {
             SS_LOGW(TAG, "Failed to persist static delay");
         }

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -133,7 +133,7 @@ bool PlayerRole::get_muted() const {
 }
 
 uint16_t PlayerRole::get_static_delay_ms() const {
-    return this->impl_->static_delay_ms;
+    return this->impl_->get_effective_static_delay_ms();
 }
 
 uint8_t PlayerRole::get_volume() const {
@@ -211,7 +211,7 @@ void PlayerRole::Impl::build_state_fields(ClientStateMessage& msg) const {
     ClientPlayerStateObject player_state{};
     player_state.volume = this->volume;
     player_state.muted = this->muted;
-    player_state.static_delay_ms = this->static_delay_ms;
+    player_state.static_delay_ms = this->get_effective_static_delay_ms();
     if (this->static_delay_adjustable) {
         player_state.supported_commands = {SendspinPlayerCommand::SET_STATIC_DELAY};
     }
@@ -502,6 +502,10 @@ void PlayerRole::Impl::load_static_delay() {
         this->static_delay_ms = this->config.initial_static_delay_ms;
         SS_LOGI(TAG, "Using initial static delay from config: %u ms", this->static_delay_ms);
     }
+}
+
+uint16_t PlayerRole::Impl::get_effective_static_delay_ms() const {
+    return this->static_delay_adjustable ? this->static_delay_ms : 0;
 }
 
 void PlayerRole::Impl::persist_static_delay() const {

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -211,8 +211,9 @@ void PlayerRole::Impl::build_state_fields(ClientStateMessage& msg) const {
     ClientPlayerStateObject player_state{};
     player_state.volume = this->volume;
     player_state.muted = this->muted;
-    player_state.static_delay_ms = this->get_effective_static_delay_ms();
-    if (this->static_delay_adjustable) {
+    bool adjustable = this->static_delay_adjustable.load();
+    player_state.static_delay_ms = adjustable ? this->static_delay_ms.load() : 0;
+    if (adjustable) {
         player_state.supported_commands = {SendspinPlayerCommand::SET_STATIC_DELAY};
     }
     msg.player = player_state;

--- a/src/player_role_impl.h
+++ b/src/player_role_impl.h
@@ -22,6 +22,7 @@
 #include "sendspin/player_role.h"
 #include "sync_task.h"
 
+#include <atomic>
 #include <memory>
 #include <vector>
 
@@ -87,6 +88,7 @@ struct PlayerRole::Impl {
     void enqueue_state_update(SendspinClientState state) const;
     void load_static_delay();
     void persist_static_delay() const;
+    uint16_t get_effective_static_delay_ms() const;
 
     // ========================================
     // Fields
@@ -110,7 +112,7 @@ struct PlayerRole::Impl {
     // 8-bit fields
     bool high_performance_requested_for_playback{false};
     bool muted{false};
-    bool static_delay_adjustable{false};
+    std::atomic<bool> static_delay_adjustable{false};
     uint8_t volume{0};
 };
 

--- a/src/player_role_impl.h
+++ b/src/player_role_impl.h
@@ -107,7 +107,7 @@ struct PlayerRole::Impl {
     std::unique_ptr<SyncTask> sync_task;
 
     // 16-bit fields
-    uint16_t static_delay_ms{0};
+    std::atomic<uint16_t> static_delay_ms{0};
 
     // 8-bit fields
     bool high_performance_requested_for_playback{false};

--- a/src/sync_task.cpp
+++ b/src/sync_task.cpp
@@ -472,7 +472,7 @@ DecodeResult SyncTask::decode_chunk(SyncContext& sync_context) {
                (sync_context.encoded_entry->chunk_type == CHUNK_TYPE_ENCODED_AUDIO)) {
         int64_t client_timestamp =
             this->client_->get_client_time(sync_context.encoded_entry->timestamp) -
-            static_cast<int64_t>(this->player_impl_->static_delay_ms) * US_PER_MS -
+            static_cast<int64_t>(this->player_impl_->get_effective_static_delay_ms()) * US_PER_MS -
             this->player_impl_->config.fixed_delay_us;
 
         if (client_timestamp < sync_context.new_audio_client_playtime - HARD_SYNC_THRESHOLD_US) {


### PR DESCRIPTION
- Fixes a bug where the stored static delay was always applied even if it was disabled by the user
- Adds a new helper to get the effective static delay that returns 0 whenever adjustment is disabled and returns the actual value whenever the adjustment is enabled

Fixes #28 