### PR TITLE
Optimization: mark everything in the httpd->binary chunk path as hot

### DIFF
--- a/src/audio_ring_buffer.cpp
+++ b/src/audio_ring_buffer.cpp
@@ -14,6 +14,7 @@
 
 #include "audio_ring_buffer.h"
 
+#include "platform/compiler.h"
 #include "platform/logging.h"
 
 namespace sendspin {
@@ -47,8 +48,9 @@ SendspinAudioRingBuffer::~SendspinAudioRingBuffer() = default;
 // Public API
 // ============================================================================
 
-bool SendspinAudioRingBuffer::write_chunk(const uint8_t* data, size_t data_size, int64_t timestamp,
-                                          ChunkType chunk_type, uint32_t timeout_ms) {
+SS_HOT bool SendspinAudioRingBuffer::write_chunk(const uint8_t* data, size_t data_size,
+                                                 int64_t timestamp, ChunkType chunk_type,
+                                                 uint32_t timeout_ms) {
     size_t total_size = sizeof(AudioRingBufferEntry) + data_size;
 
     void* acquired_memory = this->ring_buffer_.acquire(total_size, timeout_ms);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -16,6 +16,7 @@
 
 #include "connection.h"
 #include "connection_manager.h"
+#include "platform/compiler.h"
 #include "platform/logging.h"
 #include "platform/memory.h"
 #include "platform/shadow_slot.h"
@@ -657,7 +658,7 @@ void SendspinClient::process_json_message(SendspinConnection* conn, const std::s
     }
 }
 
-void SendspinClient::process_binary_message(const uint8_t* payload, size_t len) {
+SS_HOT void SendspinClient::process_binary_message(const uint8_t* payload, size_t len) {
     if (len < 2) {
         return;
     }

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -14,6 +14,7 @@
 
 #include "connection.h"
 
+#include "platform/compiler.h"
 #include "platform/logging.h"
 #include "time_filter.h"
 
@@ -87,7 +88,7 @@ void SendspinConnection::commit_receive_buffer(size_t data_len) {
     this->websocket_write_offset_ += data_len;
 }
 
-void SendspinConnection::dispatch_completed_message(bool is_text, int64_t receive_time) {
+SS_HOT void SendspinConnection::dispatch_completed_message(bool is_text, int64_t receive_time) {
     if (!this->websocket_payload_) {
         return;
     }

--- a/src/esp/server_connection.cpp
+++ b/src/esp/server_connection.cpp
@@ -15,6 +15,7 @@
 #include "server_connection.h"
 
 #include "lwip/sockets.h"  // for setsockopt, IPPROTO_TCP, NODELAY
+#include "platform/compiler.h"
 #include "platform/logging.h"
 #include "platform/memory.h"
 #include "protocol_messages.h"
@@ -153,7 +154,7 @@ void SendspinServerConnection::trigger_close() {
     }
 }
 
-esp_err_t SendspinServerConnection::handle_data(httpd_req_t* req, int64_t receive_time) {
+SS_HOT esp_err_t SendspinServerConnection::handle_data(httpd_req_t* req, int64_t receive_time) {
     httpd_ws_frame_t ws_pkt;
     memset(&ws_pkt, 0, sizeof(httpd_ws_frame_t));
 

--- a/src/esp/ws_server.cpp
+++ b/src/esp/ws_server.cpp
@@ -16,6 +16,7 @@
 
 #include "connection.h"
 #include "lwip/sockets.h"  // for close()
+#include "platform/compiler.h"
 #include "platform/logging.h"
 #include "server_connection.h"
 #include <esp_timer.h>
@@ -155,7 +156,7 @@ void SendspinWsServer::close_callback(httpd_handle_t handle, int sockfd) {
     close(sockfd);
 }
 
-esp_err_t SendspinWsServer::websocket_handler(httpd_req_t* req) {
+SS_HOT esp_err_t SendspinWsServer::websocket_handler(httpd_req_t* req) {
     // Capture timestamp immediately for accurate time synchronization
     int64_t receive_time = esp_timer_get_time();
 

--- a/src/platform/compiler.h
+++ b/src/platform/compiler.h
@@ -1,0 +1,28 @@
+// Copyright 2026 Sendspin Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @file compiler.h
+/// @brief Compiler hints and platform-specific macros
+
+#pragma once
+
+// Mark a function as hot. The compiler places hot functions in a dedicated
+// .text.hot section for better i-cache locality and optimizes them more
+// aggressively. Use on per-packet / per-frame functions on the audio receive
+// and decode path.
+#if defined(__GNUC__) || defined(__clang__)
+#define SS_HOT __attribute__((hot))
+#else
+#define SS_HOT
+#endif

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -14,6 +14,7 @@
 
 #include "audio_types.h"
 #include "platform/base64.h"
+#include "platform/compiler.h"
 #include "platform/logging.h"
 #include "player_role_impl.h"
 #include "protocol_messages.h"
@@ -220,7 +221,7 @@ void PlayerRole::Impl::build_state_fields(ClientStateMessage& msg) const {
     msg.player = player_state;
 }
 
-void PlayerRole::Impl::handle_binary(const uint8_t* data, size_t len) const {
+SS_HOT void PlayerRole::Impl::handle_binary(const uint8_t* data, size_t len) const {
     if (this->config.audio_formats.empty()) {
         return;
     }


### PR DESCRIPTION
This gives better cache locality improving CPU usage on slower cache limited devices like an ESP32. This is especially helpful when playback initially starts, as the Sendspin server sends enough audio data to fill the buffer almost immediately, and it causes a lot of CPU contention which results in some initial stuttering.

Adds a new compiler.h file to get a new ``SS_HOT`` macro so that we maintain compatibility across compilers.