### PR TITLE
Allow player transfer buffers to prefer internal or external memory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ examples/tui_client/        - Terminal UI host example with PortAudio audio outp
 Headers in `src/platform/` use `#ifdef ESP_PLATFORM` to provide unified APIs across platforms:
 
 - `logging.h`: `SS_LOGE`/`SS_LOGW`/`SS_LOGI`/`SS_LOGD`/`SS_LOGV` macros (ESP: `esp_log.h`, host: `printf`-based)
-- `memory.h`: `platform_malloc`/`platform_realloc`/`platform_free` (ESP: SPIRAM-preferring `heap_caps_malloc`, host: standard `malloc`)
+- `memory.h`: `platform_malloc`/`platform_realloc`/`platform_malloc_internal`/`platform_realloc_internal`/`platform_free` (ESP: SPIRAM-preferring or internal-RAM-preferring `heap_caps_malloc_prefer`, host: standard `malloc`). `PlatformBuffer` accepts a `MemoryLocation` (defined in `include/sendspin/types.h`) to select the preference.
 - `thread.h`: threading utilities
 - `time.h`: time utilities
 - `base64.h`: base64 encoding/decoding
@@ -117,7 +117,7 @@ Core source files in `src/` have no `#ifdef ESP_PLATFORM` guards; all platform d
 - C++20 (`gnu++20` on ESP, `cxx_std_20` on host)
 - Namespace: `sendspin`
 - Logging: Platform macros `SS_LOGE`, `SS_LOGW`, `SS_LOGI`, `SS_LOGD`, `SS_LOGV` (not raw `ESP_LOG*`)
-- Memory: `platform_malloc`/`platform_realloc`/`platform_free` from `platform/memory.h` (not raw `heap_caps_malloc`)
+- Memory: `platform_malloc`/`platform_realloc`/`platform_malloc_internal`/`platform_realloc_internal`/`platform_free` from `platform/memory.h` (not raw `heap_caps_malloc`). The `_internal` variants prefer internal RAM with SPIRAM fallback; the unsuffixed variants do the reverse. `PlatformBuffer` and `TransferBuffer` accept a `MemoryLocation` argument to select the preference.
 - Threading: `std::mutex`, `std::thread` (via pthreads on both platforms). ESP build also uses FreeRTOS primitives (`xRingbuffer`, queues, event groups) for performance via the platform abstraction layer.
 - Role composition: Roles are added at runtime via `add_player()`, `add_metadata()`, etc. Roles can be disabled at compile time via `SENDSPIN_ENABLE_*` cmake options / Kconfig entries. Audio codec dependencies (micro-flac, micro-opus) are only linked when the player role is enabled.
 - Apache 2.0 license headers on all files

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -674,6 +674,8 @@ Configuration passed to `client.add_player()`.
 | `initial_static_delay_ms` | `uint16_t` | `0` | Initial value for the user-adjustable static delay in milliseconds. Overridden by the persisted value if a `SendspinPersistenceProvider` is set. |
 | `psram_stack` | `bool` | `false` | Allocate sync/decode task stack in PSRAM (ESP-IDF only) |
 | `priority` | `unsigned` | `2` | FreeRTOS priority for the sync/decode task (ESP-IDF only) |
+| `interpolation_buffer_location` | `MemoryLocation` | `PREFER_EXTERNAL` | Memory placement preference for the interpolation transfer buffer. `PREFER_EXTERNAL` tries SPIRAM first and falls back to internal RAM; `PREFER_INTERNAL` does the reverse. ESP-IDF only; ignored on host. |
+| `decode_buffer_location` | `MemoryLocation` | `PREFER_EXTERNAL` | Memory placement preference for the decode transfer buffer. Same semantics as `interpolation_buffer_location`. ESP-IDF only; ignored on host. |
 
 Each entry in `audio_formats` is an `AudioSupportedFormatObject`:
 
@@ -855,3 +857,12 @@ These represent commands the server can send to the player. The player advertise
 | `VERBOSE` | All messages |
 
 Set with `SendspinClient::set_log_level()`. Only affects host builds; ESP-IDF builds use the ESP log level system.
+
+### MemoryLocation
+
+| Value | Description |
+|---|---|
+| `PREFER_EXTERNAL` | Prefer SPIRAM, fall back to internal RAM (ESP-IDF only) |
+| `PREFER_INTERNAL` | Prefer internal RAM, fall back to SPIRAM (ESP-IDF only) |
+
+Used by `PlayerRoleConfig::interpolation_buffer_location` and `decode_buffer_location` to control where the player's transfer buffers are allocated. Ignored on host platforms (no internal/external distinction).

--- a/include/sendspin/config.h
+++ b/include/sendspin/config.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "sendspin/types.h"
+
 #include <cstddef>
 #include <cstdint>
 #include <optional>
@@ -91,6 +93,14 @@ struct PlayerRoleConfig {
     uint16_t initial_static_delay_ms{0};
     bool psram_stack{false};  ///< Allocate sync task stack in PSRAM (ESP-IDF only)
     unsigned priority{2};     ///< FreeRTOS priority for the sync/decode task (ESP-IDF only)
+
+    /// @brief Memory placement for the interpolation transfer buffer (ESP-IDF only; ignored on
+    /// host). Defaults to PREFER_EXTERNAL (SPIRAM).
+    MemoryLocation interpolation_buffer_location{MemoryLocation::PREFER_EXTERNAL};
+
+    /// @brief Memory placement for the decode transfer buffer (ESP-IDF only; ignored on host).
+    /// Defaults to PREFER_EXTERNAL (SPIRAM).
+    MemoryLocation decode_buffer_location{MemoryLocation::PREFER_EXTERNAL};
 };
 
 // ============================================================================

--- a/include/sendspin/types.h
+++ b/include/sendspin/types.h
@@ -61,4 +61,12 @@ struct GroupUpdateObject {
     std::optional<std::string> group_name{};
 };
 
+/// @brief Memory placement preference for platform allocations
+/// On ESP-IDF, controls whether SPIRAM or internal RAM is tried first; the other is the
+/// fallback. Ignored on host platforms (no internal/external distinction).
+enum class MemoryLocation : uint8_t {
+    PREFER_EXTERNAL,  // Prefer SPIRAM, fall back to internal RAM
+    PREFER_INTERNAL,  // Prefer internal RAM, fall back to SPIRAM
+};
+
 }  // namespace sendspin

--- a/src/platform/memory.h
+++ b/src/platform/memory.h
@@ -13,11 +13,12 @@
 // limitations under the License.
 
 /// @file memory.h
-/// @brief Platform-abstracted memory allocation preferring SPIRAM on ESP, plus RAII buffer and
-/// ArduinoJson allocator helpers
+/// @brief Platform-abstracted memory allocation with selectable SPIRAM-vs-internal preference on
+/// ESP, plus RAII buffer and ArduinoJson allocator helpers
 
 #pragma once
 
+#include "sendspin/types.h"
 #include <ArduinoJson.h>
 
 #include <cstddef>
@@ -46,7 +47,24 @@ inline void* platform_realloc(void* ptr, size_t size) {
                                     MALLOC_CAP_INTERNAL);
 }
 
-/// @brief Frees memory allocated by platform_malloc or platform_realloc
+/// @brief Allocates memory, preferring internal RAM on ESP-IDF. Falls back to SPIRAM
+/// @param size Number of bytes to allocate.
+/// @return Pointer to the allocated memory, or nullptr on failure.
+inline void* platform_malloc_internal(size_t size) {
+    return heap_caps_malloc_prefer(size, 2, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT,
+                                   MALLOC_CAP_SPIRAM);
+}
+
+/// @brief Reallocates memory, preferring internal RAM on ESP-IDF. Falls back to SPIRAM
+/// @param ptr Pointer to the block to reallocate, or nullptr to allocate a new block.
+/// @param size New size in bytes.
+/// @return Pointer to the reallocated memory, or nullptr on failure.
+inline void* platform_realloc_internal(void* ptr, size_t size) {
+    return heap_caps_realloc_prefer(ptr, size, 2, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT,
+                                    MALLOC_CAP_SPIRAM);
+}
+
+/// @brief Frees memory allocated by any platform_malloc[_internal] or platform_realloc[_internal]
 /// @param ptr Pointer to the block to free, or nullptr.
 inline void platform_free(void* ptr) {
     heap_caps_free(ptr);
@@ -73,7 +91,23 @@ inline void* platform_realloc(void* ptr, size_t size) {
     return realloc(ptr, size);
 }
 
-/// @brief Frees memory allocated by platform_malloc or platform_realloc
+/// @brief Allocates a block of memory (host has no internal/external distinction)
+/// @param size Number of bytes to allocate.
+/// @return Pointer to the allocated memory, or nullptr on failure.
+inline void* platform_malloc_internal(size_t size) {
+    return malloc(size);
+}
+
+/// @brief Reallocates a previously allocated block of memory (host has no internal/external
+/// distinction)
+/// @param ptr Pointer to the block to reallocate, or nullptr to allocate a new block.
+/// @param size New size in bytes.
+/// @return Pointer to the reallocated memory, or nullptr on failure.
+inline void* platform_realloc_internal(void* ptr, size_t size) {
+    return realloc(ptr, size);
+}
+
+/// @brief Frees memory allocated by any platform_malloc[_internal] or platform_realloc[_internal]
 /// @param ptr Pointer to the block to free, or nullptr.
 inline void platform_free(void* ptr) {
     free(ptr);
@@ -88,23 +122,29 @@ namespace sendspin {
 /**
  * @brief RAII wrapper for platform-allocated memory buffers
  *
- * Owns a block of memory obtained via platform_malloc. Automatically frees on destruction.
- * Supports reallocation and move semantics. Not copyable.
+ * Owns a block of memory obtained via platform_malloc / platform_malloc_internal. Automatically
+ * frees on destruction. Supports reallocation and move semantics. Not copyable.
+ *
+ * The MemoryLocation passed to allocate() is stored on the buffer and reused by subsequent
+ * realloc() calls, so the placement preference is preserved across resizes. The location also
+ * carries through move construction and move assignment.
  *
  * Usage:
- * 1. Default-construct a PlatformBuffer, then call allocate() with the desired size
+ * 1. Default-construct a PlatformBuffer, then call allocate() with the desired size and (on ESP)
+ *    optional MemoryLocation preference (defaults to PREFER_EXTERNAL / SPIRAM-first)
  * 2. Access the raw memory with data() or via the typed as<T>() accessor
- * 3. Optionally grow the buffer in-place with realloc()
+ * 3. Optionally grow the buffer in-place with realloc(), which keeps the original location
+ *    preference
  * 4. Memory is freed automatically on destruction, or explicitly via reset()
  *
  * @code
  * PlatformBuffer buf;
- * buf.allocate(1024);
+ * buf.allocate(1024, MemoryLocation::PREFER_INTERNAL);
  *
  * auto* header = buf.as<MyHeader>();
  * header->magic = 0xDEAD;
  *
- * buf.realloc(2048);
+ * buf.realloc(2048);  // also prefers internal RAM
  * @endcode
  */
 class PlatformBuffer {
@@ -118,7 +158,8 @@ public:
     }
 
     // Move-only
-    PlatformBuffer(PlatformBuffer&& other) noexcept : ptr_(other.ptr_), size_(other.size_) {
+    PlatformBuffer(PlatformBuffer&& other) noexcept
+        : ptr_(other.ptr_), size_(other.size_), location_(other.location_) {
         other.ptr_ = nullptr;
         other.size_ = 0;
     }
@@ -130,6 +171,7 @@ public:
             }
             this->ptr_ = other.ptr_;
             this->size_ = other.size_;
+            this->location_ = other.location_;
             other.ptr_ = nullptr;
             other.size_ = 0;
         }
@@ -140,27 +182,41 @@ public:
     PlatformBuffer& operator=(const PlatformBuffer&) = delete;
 
     /// @brief Allocates a new buffer. Any previously held memory is freed
+    /// The location preference is remembered and reused by subsequent realloc() calls.
     /// @return true if allocation succeeded.
-    bool allocate(size_t size) {
+    bool allocate(size_t size, MemoryLocation location = MemoryLocation::PREFER_EXTERNAL) {
         if (this->ptr_ != nullptr) {
             platform_free(this->ptr_);
         }
-        this->ptr_ = static_cast<uint8_t*>(platform_malloc(size));
+        this->location_ = location;
+        this->ptr_ = static_cast<uint8_t*>((location == MemoryLocation::PREFER_INTERNAL)
+                                               ? platform_malloc_internal(size)
+                                               : platform_malloc(size));
         this->size_ = (this->ptr_ != nullptr) ? size : 0;
         return this->ptr_ != nullptr;
     }
 
     /// @brief Reallocates the buffer to a new size, preserving existing data
-    /// On failure, the original buffer remains valid.
+    /// Uses the location preference passed to the most recent allocate() call. On failure, the
+    /// original buffer remains valid.
     /// @return true if reallocation succeeded.
     bool realloc(size_t new_size) {
-        uint8_t* new_ptr = static_cast<uint8_t*>(platform_realloc(this->ptr_, new_size));
+        uint8_t* new_ptr =
+            static_cast<uint8_t*>((this->location_ == MemoryLocation::PREFER_INTERNAL)
+                                      ? platform_realloc_internal(this->ptr_, new_size)
+                                      : platform_realloc(this->ptr_, new_size));
         if (new_ptr == nullptr) {
             return false;
         }
         this->ptr_ = new_ptr;
         this->size_ = new_size;
         return true;
+    }
+
+    /// @brief Returns the location preference last passed to allocate()
+    /// @return The current location preference.
+    MemoryLocation location() const {
+        return this->location_;
     }
 
     /// @brief Frees the held memory
@@ -215,6 +271,9 @@ private:
 
     // size_t fields
     size_t size_{0};
+
+    // Enum fields
+    MemoryLocation location_{MemoryLocation::PREFER_EXTERNAL};
 };
 
 /// @brief ArduinoJson allocator that routes through platform_malloc/platform_realloc/platform_free

--- a/src/platform/memory.h
+++ b/src/platform/memory.h
@@ -35,7 +35,7 @@ namespace sendspin {
 /// @return Pointer to the allocated memory, or nullptr on failure.
 inline void* platform_malloc(size_t size) {
     return heap_caps_malloc_prefer(size, 2, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT,
-                                   MALLOC_CAP_INTERNAL);
+                                   MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
 }
 
 /// @brief Reallocates memory, preferring SPIRAM on ESP-IDF. Falls back to internal RAM
@@ -44,7 +44,7 @@ inline void* platform_malloc(size_t size) {
 /// @return Pointer to the reallocated memory, or nullptr on failure.
 inline void* platform_realloc(void* ptr, size_t size) {
     return heap_caps_realloc_prefer(ptr, size, 2, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT,
-                                    MALLOC_CAP_INTERNAL);
+                                    MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
 }
 
 /// @brief Allocates memory, preferring internal RAM on ESP-IDF. Falls back to SPIRAM
@@ -52,7 +52,7 @@ inline void* platform_realloc(void* ptr, size_t size) {
 /// @return Pointer to the allocated memory, or nullptr on failure.
 inline void* platform_malloc_internal(size_t size) {
     return heap_caps_malloc_prefer(size, 2, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT,
-                                   MALLOC_CAP_SPIRAM);
+                                   MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
 }
 
 /// @brief Reallocates memory, preferring internal RAM on ESP-IDF. Falls back to SPIRAM
@@ -61,7 +61,7 @@ inline void* platform_malloc_internal(size_t size) {
 /// @return Pointer to the reallocated memory, or nullptr on failure.
 inline void* platform_realloc_internal(void* ptr, size_t size) {
     return heap_caps_realloc_prefer(ptr, size, 2, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT,
-                                    MALLOC_CAP_SPIRAM);
+                                    MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
 }
 
 /// @brief Frees memory allocated by any platform_malloc[_internal] or platform_realloc[_internal]

--- a/src/sync_task.cpp
+++ b/src/sync_task.cpp
@@ -449,7 +449,8 @@ DecodeResult SyncTask::decode_chunk(SyncContext& sync_context) {
             // Create or resize the decode buffer now that we know the maximum decoded size
             size_t needed = sync_context.decoder->get_maximum_decoded_size();
             if (sync_context.decode_buffer == nullptr) {
-                sync_context.decode_buffer = TransferBuffer::create(needed);
+                sync_context.decode_buffer = TransferBuffer::create(
+                    needed, this->player_impl_->config.decode_buffer_location);
                 if (sync_context.decode_buffer == nullptr) {
                     SS_LOGE(TAG, "Failed to allocate decode buffer");
                     this->encoded_ring_buffer_->return_chunk(sync_context.encoded_entry);
@@ -625,7 +626,8 @@ void SyncTask::thread_entry(void* params) {
     sync_context.bytes_per_frame = sync_context.current_stream_info.frames_to_bytes(1);
 
     sync_context.interpolation_transfer_buffer = TransferBuffer::create(
-        sync_context.current_stream_info.ms_to_bytes(INITIAL_SYNC_ZEROS_DURATION_MS));
+        sync_context.current_stream_info.ms_to_bytes(INITIAL_SYNC_ZEROS_DURATION_MS),
+        this_task->player_impl_->config.interpolation_buffer_location);
     if (sync_context.interpolation_transfer_buffer == nullptr) {
         SS_LOGE(TAG, "Failed to allocate interpolation transfer buffer");
         this_task->event_flags_.set(EventGroupBits::TASK_ERROR | EventGroupBits::TASK_STOPPED);

--- a/src/transfer_buffer.cpp
+++ b/src/transfer_buffer.cpp
@@ -28,10 +28,11 @@ TransferBuffer::~TransferBuffer() {
     this->deallocate_buffer();
 }
 
-std::unique_ptr<TransferBuffer> TransferBuffer::create(size_t buffer_size) {
+std::unique_ptr<TransferBuffer> TransferBuffer::create(size_t buffer_size,
+                                                       MemoryLocation location) {
     std::unique_ptr<TransferBuffer> buffer(new TransferBuffer());
 
-    if (!buffer->allocate_buffer(buffer_size)) {
+    if (!buffer->allocate_buffer(buffer_size, location)) {
         return nullptr;
     }
 
@@ -75,10 +76,6 @@ void TransferBuffer::increase_buffer_length(size_t bytes) {
 }
 
 bool TransferBuffer::reallocate(size_t new_buffer_size) {
-    if (!this->buffer_) {
-        return this->allocate_buffer(new_buffer_size);
-    }
-
     if (new_buffer_size < this->buffer_length_) {
         return false;
     }
@@ -101,8 +98,8 @@ bool TransferBuffer::reallocate(size_t new_buffer_size) {
 // Private helpers
 // ============================================================================
 
-bool TransferBuffer::allocate_buffer(size_t buffer_size) {
-    if (!this->buffer_.allocate(buffer_size)) {
+bool TransferBuffer::allocate_buffer(size_t buffer_size, MemoryLocation location) {
+    if (!this->buffer_.allocate(buffer_size, location)) {
         return false;
     }
 

--- a/src/transfer_buffer.h
+++ b/src/transfer_buffer.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "platform/memory.h"
+#include "sendspin/types.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -56,8 +57,11 @@ public:
 
     /// @brief Creates a new transfer buffer.
     /// @param buffer_size Size of the buffer in bytes.
+    /// @param location Memory placement preference for the backing allocation. Subsequent
+    /// reallocate() calls reuse this preference.
     /// @return unique_ptr if successfully allocated, nullptr otherwise.
-    static std::unique_ptr<TransferBuffer> create(size_t buffer_size);
+    static std::unique_ptr<TransferBuffer> create(
+        size_t buffer_size, MemoryLocation location = MemoryLocation::PREFER_EXTERNAL);
 
     /// @brief Writes buffered data to the sink.
     /// @param timeout_ms Milliseconds to block while waiting for the sink (UINT32_MAX = wait
@@ -117,7 +121,8 @@ protected:
 
     /// @brief Allocates the backing buffer and resets tracking state.
     /// @return True if allocation succeeded, false otherwise.
-    bool allocate_buffer(size_t buffer_size);
+    bool allocate_buffer(size_t buffer_size,
+                         MemoryLocation location = MemoryLocation::PREFER_EXTERNAL);
     /// @brief Releases the backing buffer and resets all tracking state.
     void deallocate_buffer();
 


### PR DESCRIPTION
Add two configuration options to the player role that dictate memory preferences (internal/external) for the two transfer buffers. Updates `memory.h` to support specifying memory location preferences.