### PR TITLE
Set default sync task priority to 18

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -673,7 +673,7 @@ Configuration passed to `client.add_player()`.
 | `fixed_delay_us` | `int32_t` | `0` | Fixed platform-level delay offset in microseconds (e.g., a known I2S pipeline delay). Applied on top of the user-adjustable static delay. |
 | `initial_static_delay_ms` | `uint16_t` | `0` | Initial value for the user-adjustable static delay in milliseconds. Overridden by the persisted value if a `SendspinPersistenceProvider` is set. |
 | `psram_stack` | `bool` | `false` | Allocate sync/decode task stack in PSRAM (ESP-IDF only) |
-| `priority` | `unsigned` | `18` | FreeRTOS priority for the sync/decode task (ESP-IDF only). One above `httpd_priority` so the HTTP server task cannot starve the decoder during the initial burst of encoded audio that fills the buffer at stream start. |
+| `priority` | `unsigned` | `18` | FreeRTOS priority for the sync/decode task (ESP-IDF only). The default value, `18`, is one above the default `httpd_priority` (`17`). If you customize priorities, keep this above `httpd_priority` so the HTTP server task cannot starve the decoder during the initial burst of encoded audio that fills the buffer at stream start. |
 | `interpolation_buffer_location` | `MemoryLocation` | `PREFER_EXTERNAL` | Memory placement preference for the interpolation transfer buffer. `PREFER_EXTERNAL` tries SPIRAM first and falls back to internal RAM; `PREFER_INTERNAL` does the reverse. ESP-IDF only; ignored on host. |
 | `decode_buffer_location` | `MemoryLocation` | `PREFER_EXTERNAL` | Memory placement preference for the decode transfer buffer. Same semantics as `interpolation_buffer_location`. ESP-IDF only; ignored on host. |
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -673,7 +673,7 @@ Configuration passed to `client.add_player()`.
 | `fixed_delay_us` | `int32_t` | `0` | Fixed platform-level delay offset in microseconds (e.g., a known I2S pipeline delay). Applied on top of the user-adjustable static delay. |
 | `initial_static_delay_ms` | `uint16_t` | `0` | Initial value for the user-adjustable static delay in milliseconds. Overridden by the persisted value if a `SendspinPersistenceProvider` is set. |
 | `psram_stack` | `bool` | `false` | Allocate sync/decode task stack in PSRAM (ESP-IDF only) |
-| `priority` | `unsigned` | `2` | FreeRTOS priority for the sync/decode task (ESP-IDF only) |
+| `priority` | `unsigned` | `18` | FreeRTOS priority for the sync/decode task (ESP-IDF only). One above `httpd_priority` so the HTTP server task cannot starve the decoder during the initial burst of encoded audio that fills the buffer at stream start. |
 | `interpolation_buffer_location` | `MemoryLocation` | `PREFER_EXTERNAL` | Memory placement preference for the interpolation transfer buffer. `PREFER_EXTERNAL` tries SPIRAM first and falls back to internal RAM; `PREFER_INTERNAL` does the reverse. ESP-IDF only; ignored on host. |
 | `decode_buffer_location` | `MemoryLocation` | `PREFER_EXTERNAL` | Memory placement preference for the decode transfer buffer. Same semantics as `interpolation_buffer_location`. ESP-IDF only; ignored on host. |
 

--- a/include/sendspin/config.h
+++ b/include/sendspin/config.h
@@ -94,10 +94,11 @@ struct PlayerRoleConfig {
     bool psram_stack{false};  ///< Allocate sync task stack in PSRAM (ESP-IDF only)
 
     /// @brief Default FreeRTOS priority for the sync/decode task (ESP-IDF only).
-    /// Set one above SendspinClientConfig::DEFAULT_HTTPD_PRIORITY so the httpd server task
+    /// One above SendspinClientConfig::DEFAULT_HTTPD_PRIORITY so the httpd server task
     /// cannot starve the decoder during the initial burst of incoming encoded audio that
     /// fills the audio buffer at stream start.
-    static constexpr unsigned DEFAULT_SYNC_TASK_PRIORITY = 18U;
+    static constexpr unsigned DEFAULT_SYNC_TASK_PRIORITY =
+        SendspinClientConfig::DEFAULT_HTTPD_PRIORITY + 1U;
 
     unsigned priority{DEFAULT_SYNC_TASK_PRIORITY};  ///< FreeRTOS priority for the sync/decode
                                                     ///< task (ESP-IDF only)

--- a/include/sendspin/config.h
+++ b/include/sendspin/config.h
@@ -92,7 +92,15 @@ struct PlayerRoleConfig {
     int32_t fixed_delay_us{0};
     uint16_t initial_static_delay_ms{0};
     bool psram_stack{false};  ///< Allocate sync task stack in PSRAM (ESP-IDF only)
-    unsigned priority{2};     ///< FreeRTOS priority for the sync/decode task (ESP-IDF only)
+
+    /// @brief Default FreeRTOS priority for the sync/decode task (ESP-IDF only).
+    /// Set one above SendspinClientConfig::DEFAULT_HTTPD_PRIORITY so the httpd server task
+    /// cannot starve the decoder during the initial burst of incoming encoded audio that
+    /// fills the audio buffer at stream start.
+    static constexpr unsigned DEFAULT_SYNC_TASK_PRIORITY = 18U;
+
+    unsigned priority{DEFAULT_SYNC_TASK_PRIORITY};  ///< FreeRTOS priority for the sync/decode
+                                                    ///< task (ESP-IDF only)
 
     /// @brief Memory placement for the interpolation transfer buffer (ESP-IDF only; ignored on
     /// host). Defaults to PREFER_EXTERNAL (SPIRAM).


### PR DESCRIPTION
When an audio stream initially starts, the Sendspin server sends encoded audio data to fill up the buffer in a very short time frame. On slower devices, like a regular ESP32, this would cause the httpd task to starve the sync task from CPU cycles causing stutters. At task priority 18, the httpd task won't interrupt the sync task causing slow decoding. Since the decoder task waits on the ring buffer being filled by the httpd task, it shouldn't starve that task either.