### PR TITLE
Configurable memory location for websocket payload

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -659,6 +659,7 @@ Main client configuration passed to the `SendspinClient` constructor.
 | `time_burst_size` | `uint8_t` | `8` | Number of messages per time sync burst |
 | `time_burst_interval_ms` | `int64_t` | `10000` | Milliseconds between time sync bursts |
 | `time_burst_response_timeout_ms` | `int64_t` | `10000` | Milliseconds before a burst message times out |
+| `websocket_payload_location` | `MemoryLocation` | `PREFER_EXTERNAL` | Memory placement for the per-connection WebSocket payload reassembly buffer (sized to the largest incoming frame, holds raw audio chunks delivered by httpd). `PREFER_EXTERNAL` tries SPIRAM first and falls back to internal RAM; `PREFER_INTERNAL` does the reverse. Use `PREFER_INTERNAL` on devices with slow PSRAM (e.g., plain ESP32) to avoid stuttering. ESP-IDF only; ignored on host. |
 
 ---
 
@@ -865,4 +866,4 @@ Set with `SendspinClient::set_log_level()`. Only affects host builds; ESP-IDF bu
 | `PREFER_EXTERNAL` | Prefer SPIRAM, fall back to internal RAM (ESP-IDF only) |
 | `PREFER_INTERNAL` | Prefer internal RAM, fall back to SPIRAM (ESP-IDF only) |
 
-Used by `PlayerRoleConfig::interpolation_buffer_location` and `decode_buffer_location` to control where the player's transfer buffers are allocated. Ignored on host platforms (no internal/external distinction).
+Used by `SendspinClientConfig::websocket_payload_location` to control where the per-connection WebSocket payload reassembly buffer is allocated, and by `PlayerRoleConfig::interpolation_buffer_location` and `decode_buffer_location` to control where the player's transfer buffers are allocated. Ignored on host platforms (no internal/external distinction).

--- a/include/sendspin/config.h
+++ b/include/sendspin/config.h
@@ -62,6 +62,10 @@ struct SendspinClientConfig {
     int64_t time_burst_interval_ms{DEFAULT_BURST_INTERVAL_MS};  ///< Milliseconds between bursts
     int64_t time_burst_response_timeout_ms{
         DEFAULT_BURST_TIMEOUT_MS};  ///< Milliseconds before a burst message times out
+
+    /// @brief Memory placement for the per-connection WebSocket payload reassembly buffer
+    /// (ESP-IDF only; ignored on host). Defaults to PREFER_EXTERNAL (SPIRAM).
+    MemoryLocation websocket_payload_location{MemoryLocation::PREFER_EXTERNAL};
 };
 
 // ============================================================================

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -66,7 +66,7 @@ void SendspinConnection::reset_websocket_payload() {
 uint8_t* SendspinConnection::prepare_receive_buffer(size_t data_len) {
     if (!this->websocket_payload_) {
         // First fragment - allocate new buffer
-        if (!this->websocket_payload_.allocate(data_len)) {
+        if (!this->websocket_payload_.allocate(data_len, this->websocket_payload_location_)) {
             SS_LOGE(TAG, "Failed to allocate %zu bytes for websocket payload", data_len);
             return nullptr;
         }

--- a/src/connection.h
+++ b/src/connection.h
@@ -286,6 +286,17 @@ public:
         this->pending_time_message_ = pending;
     }
 
+    // ========================================
+    // Initialization setters (called by hub before start)
+    // ========================================
+
+    /// @brief Sets the memory location preference for the websocket payload reassembly buffer
+    /// @param location PREFER_EXTERNAL (SPIRAM-first) or PREFER_INTERNAL (internal-RAM-first).
+    /// @note Must be called before the first received frame; takes effect on the next allocation.
+    void set_websocket_payload_location(MemoryLocation location) {
+        this->websocket_payload_location_ = location;
+    }
+
 protected:
     /// @brief Deallocates the websocket payload buffer if allocated
     void deallocate_websocket_payload();
@@ -361,6 +372,9 @@ protected:
     /// Time message state.
     bool pending_time_message_{false};
     bool server_hello_received_{false};
+
+    /// Memory placement preference for `websocket_payload_` allocations (ESP-IDF only).
+    MemoryLocation websocket_payload_location_{MemoryLocation::PREFER_EXTERNAL};
 };
 
 }  // namespace sendspin

--- a/src/connection_manager.cpp
+++ b/src/connection_manager.cpp
@@ -58,6 +58,7 @@ void ConnectionManager::connect_to(const std::string& url) {
     auto client_conn = std::make_unique<SendspinClientConnection>(url);
     client_conn->set_auto_reconnect(false);
     client_conn->set_task_config(this->client_->config_.websocket_priority);
+    client_conn->set_websocket_payload_location(this->client_->config_.websocket_payload_location);
 
     this->setup_connection_callbacks(client_conn.get());
     client_conn->on_disconnected_cb = [this](SendspinConnection* conn) {
@@ -324,6 +325,7 @@ void ConnectionManager::on_new_connection(std::unique_ptr<SendspinServerConnecti
     // because the httpd find_connection_callback needs to locate this connection immediately
     // for subsequent message routing on the same thread.
     conn->init_time_filter();
+    conn->set_websocket_payload_location(this->client_->config_.websocket_payload_location);
 
     this->setup_connection_callbacks(conn.get());
     conn->on_disconnected_cb = [](SendspinConnection* /*c*/) {

--- a/src/transfer_buffer.h
+++ b/src/transfer_buffer.h
@@ -44,7 +44,7 @@ class PlayerRoleListener;
  *   4. Call transfer_data_to_sink() to flush buffered data to the listener.
  *
  * @code
- * auto buf = TransferBuffer::create(4096);
+ * auto buf = TransferBuffer::create(4096, MemoryLocation::PREFER_EXTERNAL);
  * buf->set_listener(&my_player_listener);
  * // ... write decoded audio into buf->get_buffer_end() ...
  * buf->increase_buffer_length(bytes_written);
@@ -60,8 +60,7 @@ public:
     /// @param location Memory placement preference for the backing allocation. Subsequent
     /// reallocate() calls reuse this preference.
     /// @return unique_ptr if successfully allocated, nullptr otherwise.
-    static std::unique_ptr<TransferBuffer> create(
-        size_t buffer_size, MemoryLocation location = MemoryLocation::PREFER_EXTERNAL);
+    static std::unique_ptr<TransferBuffer> create(size_t buffer_size, MemoryLocation location);
 
     /// @brief Writes buffered data to the sink.
     /// @param timeout_ms Milliseconds to block while waiting for the sink (UINT32_MAX = wait
@@ -121,8 +120,7 @@ protected:
 
     /// @brief Allocates the backing buffer and resets tracking state.
     /// @return True if allocation succeeded, false otherwise.
-    bool allocate_buffer(size_t buffer_size,
-                         MemoryLocation location = MemoryLocation::PREFER_EXTERNAL);
+    bool allocate_buffer(size_t buffer_size, MemoryLocation location);
     /// @brief Releases the backing buffer and resets all tracking state.
     void deallocate_buffer();
 


### PR DESCRIPTION
Adds a configuration option to control the location (psram or internal) for the websocket payload. No-op on host builds. This is beneficial for plain ESP32 platforms where PSRAM is slow/has smaller data caches.