### PR TITLE
Clears all states on a server disconnect to avoid exposing stale values

### DIFF
--- a/include/sendspin/controller_role.h
+++ b/include/sendspin/controller_role.h
@@ -62,6 +62,13 @@ public:
 
     /// @brief Called when the server sends updated controller state
     virtual void on_controller_state(const ServerStateControllerObject& /*state*/) {}
+
+    /// @brief Called when the connection to the server is lost and cached controller state is
+    /// dropped
+    ///
+    /// Implementations should clear any displayed controller state (volume, mute, supported
+    /// commands) since the previous server's state is no longer valid.
+    virtual void on_controller_state_clear() {}
 };
 
 /**

--- a/include/sendspin/metadata_role.h
+++ b/include/sendspin/metadata_role.h
@@ -66,6 +66,12 @@ public:
 
     /// @brief Called when metadata is updated by the server
     virtual void on_metadata(const ServerMetadataStateObject& /*metadata*/) {}
+
+    /// @brief Called when the connection to the server is lost and cached metadata is dropped
+    ///
+    /// Implementations should clear any displayed track metadata (title, artist, artwork URL,
+    /// progress, etc.) since the previous server's state is no longer valid.
+    virtual void on_metadata_clear() {}
 };
 
 /**

--- a/src/controller_role.cpp
+++ b/src/controller_role.cpp
@@ -66,6 +66,15 @@ void ControllerRole::Impl::handle_server_state(ServerStateControllerObject state
 }
 
 void ControllerRole::Impl::drain_events() {
+    // Deferred from cleanup() to avoid invoking the listener while ConnectionManager holds
+    // conn_ptr_mutex_; a listener that calls back into the client would otherwise deadlock.
+    if (this->event_state->pending_clear) {
+        this->event_state->pending_clear = false;
+        if (this->listener) {
+            this->listener->on_controller_state_clear();
+        }
+    }
+
     ServerStateControllerObject state;
     if (this->event_state->shadow.take(state)) {
         this->controller_state = std::move(state);
@@ -78,9 +87,7 @@ void ControllerRole::Impl::drain_events() {
 void ControllerRole::Impl::cleanup() {
     this->event_state->shadow.reset();
     this->controller_state = {};
-    if (this->listener) {
-        this->listener->on_controller_state_clear();
-    }
+    this->event_state->pending_clear = true;
 }
 
 }  // namespace sendspin

--- a/src/controller_role.cpp
+++ b/src/controller_role.cpp
@@ -78,6 +78,9 @@ void ControllerRole::Impl::drain_events() {
 void ControllerRole::Impl::cleanup() {
     this->event_state->shadow.reset();
     this->controller_state = {};
+    if (this->listener) {
+        this->listener->on_controller_state_clear();
+    }
 }
 
 }  // namespace sendspin

--- a/src/controller_role_impl.h
+++ b/src/controller_role_impl.h
@@ -38,6 +38,7 @@ struct ControllerRole::Impl {
 
     struct EventState {
         ShadowSlot<ServerStateControllerObject> shadow;
+        bool pending_clear{false};
     };
 
     // ========================================

--- a/src/metadata_role.cpp
+++ b/src/metadata_role.cpp
@@ -133,6 +133,9 @@ void MetadataRole::Impl::drain_events() {
 void MetadataRole::Impl::cleanup() {
     this->event_state->shadow.reset();
     this->metadata = {};
+    if (this->listener) {
+        this->listener->on_metadata_clear();
+    }
 }
 
 }  // namespace sendspin

--- a/src/metadata_role.cpp
+++ b/src/metadata_role.cpp
@@ -107,6 +107,15 @@ void MetadataRole::Impl::handle_server_state(ServerMetadataStateObject state) co
 }
 
 void MetadataRole::Impl::drain_events() {
+    // Deferred from cleanup() to avoid invoking the listener while ConnectionManager holds
+    // conn_ptr_mutex_; a listener that calls back into the client would otherwise deadlock.
+    if (this->event_state->pending_clear) {
+        this->event_state->pending_clear = false;
+        if (this->listener) {
+            this->listener->on_metadata_clear();
+        }
+    }
+
     ServerMetadataStateObject delta{};
     // Caveat: merged deltas carry only the newest timestamp, so a past-valid field merged
     // under a later future-valid update gets held back until the later deadline. Accepted
@@ -133,9 +142,7 @@ void MetadataRole::Impl::drain_events() {
 void MetadataRole::Impl::cleanup() {
     this->event_state->shadow.reset();
     this->metadata = {};
-    if (this->listener) {
-        this->listener->on_metadata_clear();
-    }
+    this->event_state->pending_clear = true;
 }
 
 }  // namespace sendspin

--- a/src/metadata_role_impl.h
+++ b/src/metadata_role_impl.h
@@ -38,6 +38,7 @@ struct MetadataRole::Impl {
 
     struct EventState {
         ShadowSlot<ServerMetadataStateObject> shadow;
+        bool pending_clear{false};
     };
 
     // ========================================


### PR DESCRIPTION
When a server disconnects, the artwork, controller, and metadata roles still have stale data. This PR clears those states.