### PR TITLE
Rebase time filter on upstream reference repo

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -35,10 +35,7 @@ SendspinConnection::~SendspinConnection() = default;
 // ============================================================================
 
 void SendspinConnection::init_time_filter() {
-    this->time_filter_ = std::make_unique<SendspinTimeFilter>(
-        TIME_FILTER_PROCESS_STD_DEV, TIME_FILTER_DRIFT_PROCESS_STD_DEV, TIME_FILTER_FORGET_FACTOR,
-        TIME_FILTER_ADAPTIVE_CUTOFF, TIME_FILTER_MIN_SAMPLES,
-        TIME_FILTER_DRIFT_SIGNIFICANCE_THRESHOLD);
+    this->time_filter_ = std::make_unique<SendspinTimeFilter>(SendspinTimeFilter::Config{});
 }
 
 // ============================================================================

--- a/src/time_burst.cpp
+++ b/src/time_burst.cpp
@@ -93,11 +93,18 @@ TimeBurstResult SendspinTimeBurst::loop(SendspinConnection* conn) {
 
 bool SendspinTimeBurst::on_time_response(SendspinConnection* conn, int64_t offset,
                                          int64_t max_error, int64_t timestamp) {
-    // Track the best (lowest RTT) measurement in this burst
-    if (max_error < this->best_max_error_) {
+    // Track the best (lowest RTT) measurement in this burst.
+    // max_error is half the round-trip delay and must be strictly positive; zero or negative
+    // values arise from clock skew or timestamp quantization in the time message and would
+    // yield zero/negative measurement variance in the Kalman filter (risking divide-by-zero
+    // in the update step), so we skip updating the best_* tracking for those samples.
+    if (max_error > 0 && max_error < this->best_max_error_) {
         this->best_max_error_ = max_error;
         this->best_offset_ = offset;
         this->best_timestamp_ = timestamp;
+    } else if (max_error <= 0) {
+        SS_LOGW(TAG, "Dropping time response with non-positive max_error: %" PRId64 " us",
+                max_error);
     }
 
     conn->set_pending_time_message(false);
@@ -106,7 +113,7 @@ bool SendspinTimeBurst::on_time_response(SendspinConnection* conn, int64_t offse
     // Check if burst is complete
     if (this->burst_index_ >= this->burst_size_) {
         auto* time_filter = conn->get_time_filter();
-        if (time_filter != nullptr) {
+        if (time_filter != nullptr && this->best_max_error_ < std::numeric_limits<int64_t>::max()) {
             time_filter->update(this->best_offset_, this->best_max_error_, this->best_timestamp_);
             SS_LOGV(TAG, "Burst complete, best max_error: %" PRId64 " us", this->best_max_error_);
         }

--- a/src/time_filter.cpp
+++ b/src/time_filter.cpp
@@ -25,16 +25,17 @@ namespace sendspin {
 // Lifecycle
 // ============================================================================
 
-SendspinTimeFilter::SendspinTimeFilter(double process_std_dev, double drift_process_std_dev,
-                                       double forget_factor, double adaptive_cutoff,
-                                       uint8_t min_samples, double drift_significance_threshold)
-    : adaptive_forgetting_cutoff(adaptive_cutoff),
-      drift_process_variance(drift_process_std_dev * drift_process_std_dev),
-      drift_significance_threshold_squared(drift_significance_threshold *
-                                           drift_significance_threshold),
-      forget_variance_factor(forget_factor * forget_factor),
-      process_variance(process_std_dev * process_std_dev),
-      min_samples_for_forgetting(min_samples) {}
+SendspinTimeFilter::SendspinTimeFilter() : SendspinTimeFilter(Config{}) {}
+
+SendspinTimeFilter::SendspinTimeFilter(const Config& config)
+    : adaptive_forgetting_cutoff(config.adaptive_cutoff),
+      drift_process_variance(config.drift_process_std_dev * config.drift_process_std_dev),
+      drift_significance_threshold_squared(config.drift_significance_threshold *
+                                           config.drift_significance_threshold),
+      forget_variance_factor(config.forget_factor * config.forget_factor),
+      max_error_scale(config.max_error_scale),
+      process_variance(config.process_std_dev * config.process_std_dev),
+      min_samples_for_forgetting(config.min_samples) {}
 
 // ============================================================================
 // Core API
@@ -53,7 +54,7 @@ void SendspinTimeFilter::update(int64_t measurement, int64_t max_error, int64_t 
     const double dt_squared = dt * dt;
     this->last_update_ = time_added;
 
-    const double update_std_dev = max_error;
+    const double update_std_dev = max_error * this->max_error_scale;
     const double measurement_variance = update_std_dev * update_std_dev;
 
     // Filter initialization: First measurement establishes offset baseline
@@ -90,8 +91,8 @@ void SendspinTimeFilter::update(int64_t measurement, int64_t max_error, int64_t 
 
     // Process noise for both offset and drift (full random walk model)
     // We assume clock jitter (offset noise) and wander (drift noise) are independent processes
-    const double drift_process_variance = dt * this->drift_process_variance;
-    double new_drift_covariance = this->drift_covariance_ + drift_process_variance;
+    const double drift_process_variance_dt = dt * this->drift_process_variance;
+    double new_drift_covariance = this->drift_covariance_ + drift_process_variance_dt;
 
     double new_offset_drift_covariance =
         this->offset_drift_covariance_ + this->drift_covariance_ * dt;

--- a/src/time_filter.h
+++ b/src/time_filter.h
@@ -39,9 +39,6 @@ namespace sendspin {
 /// All computations use double precision arithmetic to maintain microsecond-level accuracy over
 /// extended periods. Thread-safe access to the current time transformation is provided via
 /// std::mutex.
-/// @brief Default minimum samples before adaptive forgetting is enabled in the time filter.
-static constexpr uint8_t TIME_FILTER_DEFAULT_MIN_SAMPLES = 100U;
-
 class SendspinTimeFilter {
 public:
     /// @brief Configuration parameters for the time synchronization filter.
@@ -62,7 +59,7 @@ public:
         double adaptive_cutoff = 3.0;
         /// Minimum number of samples before adaptive forgetting is enabled.
         /// Building sufficient history before enabling forgetting improves stability.
-        uint8_t min_samples = TIME_FILTER_DEFAULT_MIN_SAMPLES;
+        uint8_t min_samples = 100U;  // NOLINT(readability-magic-numbers)
         /// SNR threshold for applying drift compensation in time conversions.
         /// Drift is only used when drift² > threshold² * drift_covariance, ensuring
         /// the drift estimate is statistically significant before applying corrections.

--- a/src/time_filter.h
+++ b/src/time_filter.h
@@ -24,83 +24,71 @@
 
 namespace sendspin {
 
-// ============================================================================
-// Time filter tuning constants
-// ============================================================================
-static constexpr double TIME_FILTER_PROCESS_STD_DEV = 0.0;
-static constexpr double TIME_FILTER_DRIFT_PROCESS_STD_DEV = 5e-11;
-static constexpr double TIME_FILTER_FORGET_FACTOR = 1.1;
-static constexpr double TIME_FILTER_ADAPTIVE_CUTOFF = 2.0;
-static constexpr uint8_t TIME_FILTER_MIN_SAMPLES = 100U;
-static constexpr double TIME_FILTER_DRIFT_SIGNIFICANCE_THRESHOLD = 2.0;
+/// @brief Two-dimensional Kalman filter for NTP-style time synchronization between client and
+/// server.
+///
+/// This class implements a time synchronization filter that tracks both the timestamp offset and
+/// clock drift rate between a client and server. It processes measurements obtained with NTP-style
+/// time messages that contain round-trip timing information to optimally estimate the time
+/// relationship while accounting for network latency uncertainty.
+///
+/// The filter maintains a 2D state vector [offset, drift] with associated covariance matrix to
+/// track estimation uncertainty. An adaptive forgetting factor helps the filter recover quickly
+/// from network disruptions or server clock adjustments.
+///
+/// All computations use double precision arithmetic to maintain microsecond-level accuracy over
+/// extended periods. Thread-safe access to the current time transformation is provided via
+/// std::mutex.
+/// @brief Default minimum samples before adaptive forgetting is enabled in the time filter.
+static constexpr uint8_t TIME_FILTER_DEFAULT_MIN_SAMPLES = 100U;
 
-/**
- * @brief Two-dimensional Kalman filter for NTP-style time synchronization between client and server
- *
- * Tracks both clock offset and drift rate between a client and server using a 2D state
- * vector [offset, drift] with an associated covariance matrix. Measurements come from
- * NTP-style round-trip exchanges. An adaptive forgetting factor allows the filter to
- * recover from network disruptions or server clock adjustments. All arithmetic is double
- * precision to maintain microsecond accuracy over extended periods. Time conversion
- * methods are thread-safe via an internal mutex.
- *
- * Usage:
- * 1. Construct with tuning parameters (or use the TIME_FILTER_* constants)
- * 2. Call update() each time a time burst measurement arrives
- * 3. Call compute_client_time() or compute_server_time() to convert timestamps
- * 4. Call reset() when the connection drops and a new sync sequence starts
- *
- * @code
- * SendspinTimeFilter filter(
- *     TIME_FILTER_PROCESS_STD_DEV,
- *     TIME_FILTER_DRIFT_PROCESS_STD_DEV,
- *     TIME_FILTER_FORGET_FACTOR);
- *
- * // After receiving an NTP-style time exchange:
- * filter.update(offset_us, max_error_us, client_timestamp_us);
- *
- * int64_t client_now = get_current_time_us();
- * int64_t server_now = filter.compute_server_time(client_now);
- * @endcode
- */
 class SendspinTimeFilter {
 public:
+    /// @brief Configuration parameters for the time synchronization filter.
+    struct Config {
+        /// Diffusion coefficient for offset random walk, in µs / sqrt(µs), modeling clock jitter.
+        /// Offset variance grows by process_std_dev² * dt per µs of elapsed time.
+        double process_std_dev = 0.0;
+        /// Diffusion coefficient for drift random walk, in 1 / sqrt(µs), modeling frequency wander.
+        /// Drift is dimensionless (µs of offset per µs of time), so its variance grows by
+        /// drift_process_std_dev² * dt per µs of elapsed time.
+        double drift_process_std_dev = 1e-11;
+        /// Forgetting factor (>1) applied to covariances when large residuals are detected.
+        /// Higher values enable faster recovery from disruptions but may reduce stability.
+        double forget_factor = 2.0;
+        /// Multiple of max_error that triggers adaptive forgetting.
+        /// When residual > adaptive_cutoff * max_error, forgetting is applied; values > 1 require
+        /// larger residuals.
+        double adaptive_cutoff = 3.0;
+        /// Minimum number of samples before adaptive forgetting is enabled.
+        /// Building sufficient history before enabling forgetting improves stability.
+        uint8_t min_samples = TIME_FILTER_DEFAULT_MIN_SAMPLES;
+        /// SNR threshold for applying drift compensation in time conversions.
+        /// Drift is only used when drift² > threshold² * drift_covariance, ensuring
+        /// the drift estimate is statistically significant before applying corrections.
+        double drift_significance_threshold = 2.0;
+        /// Scale factor applied to max_error before it is used as the measurement standard
+        /// deviation. Values < 1 indicate the round-trip half-delay overestimates true measurement
+        /// noise.
+        double max_error_scale = 0.5;
+    };
+
     // ========================================
     // Lifecycle
     // ========================================
 
-    /// @brief Constructs a Kalman filter for time synchronization
+    /// @brief Constructs a Kalman filter for time synchronization.
     ///
-    /// @param process_std_dev Standard deviation of the offset process noise in microseconds,
-    /// modeling clock jitter.
-    /// @param drift_process_std_dev Standard deviation of the drift process noise in
-    /// microseconds/second, modeling
-    ///                              frequency wander.
-    /// @param forget_factor Forgetting factor (>1) applied to covariances when large residuals are
-    /// detected.
-    ///                      Higher values enable faster recovery from disruptions but may reduce
-    ///                      stability.
-    /// @param adaptive_cutoff Fraction of max_error (0-1) that triggers adaptive forgetting.
-    /// Default 0.75.
-    ///                        When residual > adaptive_cutoff * max_error, forgetting is applied.
-    /// @param min_samples Minimum number of samples before adaptive forgetting is enabled. Default
-    /// 100.
-    ///                    Building sufficient history before enabling forgetting improves
-    ///                    stability.
-    /// @param drift_significance_threshold SNR threshold for applying drift compensation in time
-    /// conversions. Default 2.0.
-    ///                                     Drift is only used when drift² > threshold² *
-    ///                                     drift_covariance, ensuring the drift estimate is
-    ///                                     statistically significant before applying corrections.
-    SendspinTimeFilter(double process_std_dev, double drift_process_std_dev, double forget_factor,
-                       double adaptive_cutoff = 0.75, uint8_t min_samples = TIME_FILTER_MIN_SAMPLES,
-                       double drift_significance_threshold = 2.0);
+    /// @param config Filter configuration parameters. See Config for field documentation and
+    /// defaults.
+    explicit SendspinTimeFilter(const Config& config);
+    SendspinTimeFilter();
 
     // ========================================
     // Core API
     // ========================================
 
-    /// @brief Processes a new time synchronization measurement through the Kalman filter
+    /// @brief Processes a new time synchronization measurement through the Kalman filter.
     ///
     /// Updates the filter's offset and drift estimates using a two-stage Kalman filter algorithm:
     /// predict based on the drift model then correct using the new measurement. The measurement
@@ -114,7 +102,7 @@ public:
     /// @param time_added Client timestamp when this measurement was taken in microseconds.
     void update(int64_t measurement, int64_t max_error, int64_t time_added);
 
-    /// @brief Converts a client timestamp to the equivalent server timestamp
+    /// @brief Converts a client timestamp to the equivalent server timestamp.
     ///
     /// Applies the current offset and drift compensation to transform from client time domain to
     /// server time domain. The transformation accounts for both static offset and dynamic drift
@@ -124,7 +112,7 @@ public:
     /// @return Equivalent server timestamp in microseconds.
     int64_t compute_server_time(int64_t client_time) const;
 
-    /// @brief Converts a server timestamp to the equivalent client timestamp
+    /// @brief Converts a server timestamp to the equivalent client timestamp.
     ///
     /// Inverts the time transformation to convert from server time domain to client time domain.
     /// Accounts for both offset and drift effects in the inverse transformation.
@@ -133,7 +121,7 @@ public:
     /// @return Equivalent client timestamp in microseconds.
     int64_t compute_client_time(int64_t server_time) const;
 
-    /// @brief Resets the filter to its initial uninitialized state
+    /// @brief Resets the filter to its initial uninitialized state.
     ///
     /// Clears all state estimates and resets covariances to initial values. The filter will require
     /// new measurements to re-establish synchronization.
@@ -143,7 +131,7 @@ public:
     // Accessors
     // ========================================
 
-    /// @brief Returns the offset variance in microseconds squared
+    /// @brief Returns the offset variance in microseconds squared.
     ///
     /// Provides the raw variance value from the Kalman filter's covariance matrix. This represents
     /// the statistical uncertainty in the offset estimate.
@@ -151,7 +139,7 @@ public:
     /// @return Variance of the offset estimate in microseconds squared.
     int64_t get_covariance() const;
 
-    /// @brief Returns the estimated standard deviation of the offset in microseconds
+    /// @brief Returns the estimated standard deviation of the offset in microseconds.
     ///
     /// Provides a measure of the current synchronization accuracy by computing the square root of
     /// the offset covariance. Smaller values indicate higher confidence in the time
@@ -160,7 +148,7 @@ public:
     /// @return Standard deviation of the offset estimate in microseconds.
     int64_t get_error() const;
 
-    /// @brief Returns true if the filter has received at least one measurement
+    /// @brief Returns true if the filter has received at least one measurement.
     /// @return True if the filter has been updated with at least one time measurement.
     bool has_update() const;
 
@@ -180,6 +168,7 @@ protected:
     const double drift_significance_threshold_squared;
     const double forget_variance_factor;
     int64_t last_update_{0};
+    const double max_error_scale;
     double offset_{0.0};
     double offset_covariance_{std::numeric_limits<double>::infinity()};
     double offset_drift_covariance_{0.0};


### PR DESCRIPTION
Rebases the time filter code on the latest upstream reference: https://github.com/sendspin/time-filter

Changes the connection code to use a new config struct as well as the new default values.