### PR TITLE
Move repeat and shuffle status from metadata to controller state

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -88,7 +88,7 @@ Call `is_complete()` on the object to check if all fields have values.
 
 ### Controller Role (Playback Commands)
 
-Lets your application send transport commands (play, pause, next, etc.) and receive the server's controller state (volume, mute, supported commands).
+Lets your application send transport commands (play, pause, next, etc.) and receive the server's controller state (volume, mute, repeat, shuffle, supported commands).
 
 ```cpp
 auto& controller = client.add_controller();
@@ -212,8 +212,6 @@ struct MyMetadataListener : MetadataRoleListener {
         if (md.progress) {
             update_progress_bar(md.progress->track_progress, md.progress->track_duration);
         }
-        if (md.repeat) update_repeat_icon(*md.repeat);
-        if (md.shuffle) update_shuffle_icon(*md.shuffle);
     }
 };
 ```
@@ -231,8 +229,6 @@ The `ServerMetadataStateObject` contains these fields (all optional except `time
 | `year` | `std::optional<uint16_t>` | Release year |
 | `track` | `std::optional<uint16_t>` | Track number |
 | `progress` | `std::optional<MetadataProgressObject>` | Playback progress (see below) |
-| `repeat` | `std::optional<SendspinRepeatMode>` | Repeat mode |
-| `shuffle` | `std::optional<bool>` | Shuffle state |
 
 `MetadataProgressObject` contains `track_progress` (ms), `track_duration` (ms), and `playback_speed`.
 
@@ -248,9 +244,11 @@ uint32_t duration_ms = metadata.get_track_duration_ms();   // 0 = unknown/live
 ```cpp
 struct MyControllerListener : ControllerRoleListener {
     void on_controller_state(const ServerStateControllerObject& state) override {
-        // Update UI with server-side volume and mute state
+        // Update UI with server-side volume, mute, repeat, and shuffle state
         update_volume_slider(state.volume);
         update_mute_button(state.muted);
+        update_repeat_icon(state.repeat);
+        update_shuffle_icon(state.shuffle);
         // Enable/disable buttons based on supported commands
         enable_buttons(state.supported_commands);
     }
@@ -519,7 +517,7 @@ int32_t fixed = player.get_fixed_delay_us();
 auto& stream = player.get_current_stream_params();
 
 // Controller state
-auto& ctrl = controller.get_controller_state();  // volume, muted, supported_commands
+auto& ctrl = controller.get_controller_state();  // volume, muted, repeat, shuffle, supported_commands
 
 // Metadata
 uint32_t progress = metadata.get_track_progress_ms();  // Interpolated

--- a/examples/tui_client/main.cpp
+++ b/examples/tui_client/main.cpp
@@ -626,12 +626,6 @@ int main(int argc, char* argv[]) {
             if (md.album.has_value()) {
                 state.album = *md.album;
             }
-            if (md.repeat.has_value()) {
-                state.repeat_mode = *md.repeat;
-            }
-            if (md.shuffle.has_value()) {
-                state.shuffle = *md.shuffle;
-            }
         }
     };
 

--- a/examples/tui_client/tui.cpp
+++ b/examples/tui_client/tui.cpp
@@ -944,6 +944,8 @@ void update_polled_state(TuiState& state, SendspinClient& client) {
         auto& cs = client.controller()->get_controller_state();
         state.group_volume = cs.volume;
         state.group_muted = cs.muted;
+        state.repeat_mode = cs.repeat;
+        state.shuffle = cs.shuffle;
     }
 }
 

--- a/include/sendspin/controller_role.h
+++ b/include/sendspin/controller_role.h
@@ -48,11 +48,20 @@ enum class SendspinControllerCommand : uint8_t {
     SWITCH,      // Switch playback source
 };
 
+/// @brief Repeat mode for playback
+enum class SendspinRepeatMode : uint8_t {
+    OFF,  // No repeat
+    ONE,  // Repeat current track
+    ALL,  // Repeat entire queue
+};
+
 /// @brief Controller state received from the server in server/state messages
 struct ServerStateControllerObject {
     std::vector<SendspinControllerCommand> supported_commands{};
     uint8_t volume{};
     bool muted{};
+    SendspinRepeatMode repeat{SendspinRepeatMode::OFF};
+    bool shuffle{};
 };
 
 /// @brief Listener for controller role events. All methods fire on the main loop thread.
@@ -66,17 +75,18 @@ public:
     /// @brief Called when the connection to the server is lost and cached controller state is
     /// dropped
     ///
-    /// Implementations should clear any displayed controller state (volume, mute, supported
-    /// commands) since the previous server's state is no longer valid.
+    /// Implementations should clear any displayed controller state (volume, mute, repeat,
+    /// shuffle, supported commands) since the previous server's state is no longer valid.
     virtual void on_controller_state_clear() {}
 };
 
 /**
  * @brief Playback controller role that sends commands to and receives state from the server
  *
- * Maintains a local copy of the server's controller state (volume, mute, supported commands)
- * and provides a send_command() method for dispatching playback control messages. State
- * updates from the server are queued and delivered to the listener on the main loop thread.
+ * Maintains a local copy of the server's controller state (volume, mute, repeat, shuffle,
+ * supported commands) and provides a send_command() method for dispatching playback control
+ * messages. State updates from the server are queued and delivered to the listener on the
+ * main loop thread.
  *
  * Usage:
  * 1. Implement ControllerRoleListener to receive server state updates
@@ -88,6 +98,8 @@ public:
  * struct MyControllerListener : ControllerRoleListener {
  *     void on_controller_state(const ServerStateControllerObject& state) override {
  *         update_volume_ui(state.volume, state.muted);
+ *         update_repeat_ui(state.repeat);
+ *         update_shuffle_ui(state.shuffle);
  *     }
  * };
  *

--- a/include/sendspin/metadata_role.h
+++ b/include/sendspin/metadata_role.h
@@ -37,13 +37,6 @@ struct MetadataProgressObject {
     uint32_t playback_speed;
 };
 
-/// @brief Repeat mode for playback
-enum class SendspinRepeatMode : uint8_t {
-    OFF,  // No repeat
-    ONE,  // Repeat current track
-    ALL,  // Repeat entire queue
-};
-
 /// @brief Track metadata and playback state received from the server
 struct ServerMetadataStateObject {
     int64_t timestamp{};
@@ -55,8 +48,6 @@ struct ServerMetadataStateObject {
     std::optional<uint16_t> year;
     std::optional<uint16_t> track;
     std::optional<MetadataProgressObject> progress;
-    std::optional<SendspinRepeatMode> repeat;
-    std::optional<bool> shuffle;
 };
 
 /// @brief Listener for metadata role events. All methods fire on the main loop thread.
@@ -78,7 +69,7 @@ public:
  * @brief Metadata role that receives track metadata and playback progress from the server
  *
  * Maintains a local shadow of the server's metadata state, including track title, artist,
- * album, artwork URL, repeat/shuffle mode, and playback progress. Incoming metadata deltas
+ * album, artwork URL, and playback progress. Incoming metadata deltas
  * are merged into the shadow and delivered to the listener on the main loop thread once the
  * synchronized client clock reaches the update's `timestamp` (or immediately if time sync is
  * not yet ready). Progress is interpolated locally using the server timestamp so callers

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -225,15 +225,6 @@ static bool process_server_metadata_state_object(const JsonObject metadata_objec
         metadata_state->progress = std::nullopt;
     }
 
-    if (metadata_object["repeat"].is<const char*>()) {
-        std::string repeat_str = metadata_object["repeat"].as<std::string>();
-        metadata_state->repeat = repeat_mode_from_string(repeat_str);
-    }
-
-    if (metadata_object["shuffle"].is<JsonVariant>() && !metadata_object["shuffle"].isNull()) {
-        metadata_state->shuffle = metadata_object["shuffle"].as<bool>();
-    }
-
     return true;
 }
 
@@ -460,6 +451,20 @@ bool process_server_state_message(JsonObject root, ServerStateMessage* state_msg
             controller_state.muted = controller_object["muted"].as<bool>();
         }
 
+        // Parse repeat
+        if (controller_object["repeat"].is<const char*>()) {
+            std::string repeat_str = controller_object["repeat"].as<std::string>();
+            auto repeat = repeat_mode_from_string(repeat_str);
+            if (repeat.has_value()) {
+                controller_state.repeat = repeat.value();
+            }
+        }
+
+        // Parse shuffle
+        if (controller_object["shuffle"].is<JsonVariant>()) {
+            controller_state.shuffle = controller_object["shuffle"].as<bool>();
+        }
+
         state_msg->controller = controller_state;
     }
 
@@ -639,14 +644,6 @@ void apply_metadata_state_deltas(ServerMetadataStateObject* current,
 
     if (updates.progress.has_value()) {
         current->progress = updates.progress;
-    }
-
-    if (updates.repeat.has_value()) {
-        current->repeat = updates.repeat;
-    }
-
-    if (updates.shuffle.has_value()) {
-        current->shuffle = updates.shuffle;
     }
 }
 

--- a/src/protocol_messages.h
+++ b/src/protocol_messages.h
@@ -353,15 +353,6 @@ inline std::optional<SendspinControllerCommand> controller_command_from_string(
     return std::nullopt;
 }
 
-/// @brief A playback command sent from the client to the server via client/command messages
-struct ClientCommandControllerObject {
-    SendspinControllerCommand command{};
-    std::optional<uint8_t> volume;
-    std::optional<bool> mute;
-};
-
-// --- metadata_role.h ---
-
 inline const char* to_cstr(SendspinRepeatMode mode) {
     switch (mode) {
         case SendspinRepeatMode::OFF:
@@ -387,6 +378,13 @@ inline std::optional<SendspinRepeatMode> repeat_mode_from_string(const std::stri
     }
     return std::nullopt;
 }
+
+/// @brief A playback command sent from the client to the server via client/command messages
+struct ClientCommandControllerObject {
+    SendspinControllerCommand command{};
+    std::optional<uint8_t> volume;
+    std::optional<bool> mute;
+};
 
 // --- artwork_role.h ---
 


### PR DESCRIPTION
Breaking change!

Moves repeat and shuffle status from the metadata state to the controller state to match the latest spec: https://github.com/Sendspin/spec/pull/81