### PR TITLE
Reduce ambiguity about the metadata's state

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -215,11 +215,14 @@ This method is thread-safe and is expected to be called from an audio callback t
 ```cpp
 struct MyMetadataListener : MetadataRoleListener {
     void on_metadata(const ServerMetadataStateObject& md) override {
-        if (md.title) display_title(*md.title);
-        if (md.artist) display_artist(*md.artist);
-        if (md.album) display_album(*md.album);
+        // Overwrite display state on every call so server clears (nullopt) propagate.
+        display_title(md.title.value_or(""));
+        display_artist(md.artist.value_or(""));
+        display_album(md.album.value_or(""));
         if (md.progress) {
             update_progress_bar(md.progress->track_progress, md.progress->track_duration);
+        } else {
+            clear_progress_bar();
         }
     }
 };

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -241,6 +241,8 @@ The `ServerMetadataStateObject` contains these fields (all optional except `time
 
 `MetadataProgressObject` contains `track_progress` (ms), `track_duration` (ms), and `playback_speed`.
 
+A field is `nullopt` when the server has not provided it or has explicitly cleared it. Listeners that mirror metadata into display state should overwrite the displayed value on every `on_metadata()` call (using e.g. `value_or("")`) so that server clears propagate.
+
 You can also poll track progress at any time:
 
 ```cpp

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -109,7 +109,7 @@ Single-slot state container with "latest wins" or custom merge semantics. The ne
 | `PlayerRole::Impl::shadow_stream_params` | `ServerPlayerStreamObject` | Latest wins |
 | `PlayerRole::Impl::shadow_command` | `ServerCommandMessage` | Field-by-field merge (volume, mute, delay independent) |
 | `ControllerRole::Impl::shadow` | `ServerStateControllerObject` | Latest wins |
-| `MetadataRole::Impl::shadow` | `ServerMetadataStateObject` | Field-by-field delta merge |
+| `MetadataRole::Impl::shadow` | `ServerMetadataStateDelta` | Field-by-field delta merge (preserves pending clears across rapid updates) |
 | `ColorRole::Impl::shadow` | `ServerColorStateDelta` | Field-by-field delta merge (preserves pending clears across rapid updates) |
 | `ArtworkRole::Impl::display_scheduler->pending[slot]` (×4) | `int64_t` (server display timestamp) | Latest wins |
 | `VisualizerRole::Impl::shadow_config` | `ServerVisualizerStreamObject` | Latest wins |
@@ -249,7 +249,7 @@ The `awaiting_sync_idle_events` list (on `PlayerRole::Impl`) is the key ordering
 ### Other Roles
 
 - **ControllerRole**: Takes from shadow, fires `on_controller_state()`.
-- **MetadataRole**: Takes from shadow when the pending update's `timestamp` has been reached on the synced client clock (or immediately if there is no active connection), applies deltas, fires `on_metadata()`.
+- **MetadataRole**: Fires `on_metadata_clear()` first if a `pending_clear` flag is set (deferred from `cleanup()` to avoid invoking the listener while `ConnectionManager` holds `conn_ptr_mutex_`). Then takes from shadow when the pending update's `timestamp` has been reached on the synced client clock (or immediately if there is no active connection), applies deltas, fires `on_metadata()`.
 - **ColorRole**: Fires `on_color_clear()` first if a `pending_clear` flag is set (deferred from `cleanup()` to avoid invoking the listener while `ConnectionManager` holds `conn_ptr_mutex_`). Then takes from shadow when the pending update's `timestamp` has been reached on the synced client clock (or immediately if there is no active connection), applies deltas, fires `on_color()`.
 - **ArtworkRole**: Drains event queue for stream end/clear lifecycle events first (resetting all per-slot pending display timestamps and firing `on_image_clear()` for each configured slot). Then iterates the per-slot `DisplayScheduler::pending` shadow slots and fires `on_image_display(slot)` for any slot whose pending timestamp is due on the synced client clock (or immediately if there is no active connection). `on_image_decode` still happens on the dedicated artwork decode thread.
 - **VisualizerRole**: Drains event queue, processes stream start/end/clear with shadow config.

--- a/examples/tui_client/main.cpp
+++ b/examples/tui_client/main.cpp
@@ -617,15 +617,9 @@ int main(int argc, char* argv[]) {
 
         void on_metadata(const ServerMetadataStateObject& md) override {
             std::lock_guard<std::mutex> lock(state.mutex);
-            if (md.title.has_value()) {
-                state.title = *md.title;
-            }
-            if (md.artist.has_value()) {
-                state.artist = *md.artist;
-            }
-            if (md.album.has_value()) {
-                state.album = *md.album;
-            }
+            state.title = md.title.value_or("");
+            state.artist = md.artist.value_or("");
+            state.album = md.album.value_or("");
         }
     };
 

--- a/src/metadata_role.cpp
+++ b/src/metadata_role.cpp
@@ -98,12 +98,40 @@ void MetadataRole::Impl::build_hello_fields(ClientHelloMessage& msg) {
     msg.supported_roles.push_back(SendspinRole::METADATA);
 }
 
-void MetadataRole::Impl::handle_server_state(ServerMetadataStateObject state) const {
+void MetadataRole::Impl::handle_server_state(ServerMetadataStateDelta delta) const {
+    // Merge incoming wire delta into the accumulated delta in the shadow slot. For each field, an
+    // outer-engaged incoming entry overwrites the accumulated entry verbatim; absent
+    // (outer-nullopt) incoming fields leave the accumulated entry untouched, so pending clears
+    // (inner-nullopt) from earlier deltas survive until drain_events applies them.
     this->event_state->shadow.merge(
-        [](ServerMetadataStateObject& current, ServerMetadataStateObject&& delta) {
-            apply_metadata_state_deltas(&current, delta);
+        [](ServerMetadataStateDelta& current, ServerMetadataStateDelta&& incoming) {
+            current.timestamp = incoming.timestamp;
+            if (incoming.title.has_value()) {
+                current.title = std::move(incoming.title);
+            }
+            if (incoming.artist.has_value()) {
+                current.artist = std::move(incoming.artist);
+            }
+            if (incoming.album_artist.has_value()) {
+                current.album_artist = std::move(incoming.album_artist);
+            }
+            if (incoming.album.has_value()) {
+                current.album = std::move(incoming.album);
+            }
+            if (incoming.artwork_url.has_value()) {
+                current.artwork_url = std::move(incoming.artwork_url);
+            }
+            if (incoming.year.has_value()) {
+                current.year = incoming.year;
+            }
+            if (incoming.track.has_value()) {
+                current.track = incoming.track;
+            }
+            if (incoming.progress.has_value()) {
+                current.progress = incoming.progress;
+            }
         },
-        std::move(state));
+        std::move(delta));
 }
 
 void MetadataRole::Impl::drain_events() {
@@ -116,12 +144,12 @@ void MetadataRole::Impl::drain_events() {
         }
     }
 
-    ServerMetadataStateObject delta{};
+    ServerMetadataStateDelta delta{};
     // Caveat: merged deltas carry only the newest timestamp, so a past-valid field merged
     // under a later future-valid update gets held back until the later deadline. Accepted
     // since overlapping fields are last-writer-wins anyway.
     const bool taken =
-        this->event_state->shadow.take_if(delta, [this](const ServerMetadataStateObject& pending) {
+        this->event_state->shadow.take_if(delta, [this](const ServerMetadataStateDelta& pending) {
             // get_client_time returns 0 when there is no current connection. Without a connection
             // we cannot honor the server-clock deadline, so fire immediately rather than starving
             // the listener.

--- a/src/metadata_role_impl.h
+++ b/src/metadata_role_impl.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "platform/shadow_slot.h"
+#include "protocol_messages.h"
 #include "sendspin/metadata_role.h"
 
 #include <memory>
@@ -37,7 +38,7 @@ struct MetadataRole::Impl {
     // ========================================
 
     struct EventState {
-        ShadowSlot<ServerMetadataStateObject> shadow;
+        ShadowSlot<ServerMetadataStateDelta> shadow;
         bool pending_clear{false};
     };
 
@@ -46,7 +47,7 @@ struct MetadataRole::Impl {
     // ========================================
 
     void build_hello_fields(ClientHelloMessage& msg);
-    void handle_server_state(ServerMetadataStateObject state) const;
+    void handle_server_state(ServerMetadataStateDelta delta) const;
     void drain_events();
     void cleanup();
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -147,9 +147,31 @@ static bool process_server_player_command_object(const JsonObject player_object,
     return true;
 }
 
+// Parses a single string field into a tri-state delta entry. Absent on the wire leaves `out`
+// untouched; explicit `null` writes outer-engaged + inner-`nullopt` (clear); a string writes
+// outer-engaged + inner-engaged.
+static void parse_metadata_string_field(JsonVariantConst var,
+                                        std::optional<std::optional<std::string>>* out) {
+    if (var.is<const char*>()) {
+        *out = var.as<std::string>();
+    } else if (!var.isUnbound() && var.isNull()) {
+        *out = std::optional<std::string>{};
+    }
+}
+
+// Parses a single uint16 field into a tri-state delta entry. Same semantics as above.
+static void parse_metadata_uint16_field(JsonVariantConst var,
+                                        std::optional<std::optional<uint16_t>>* out) {
+    if (var.is<uint16_t>()) {
+        *out = var.as<uint16_t>();
+    } else if (!var.isUnbound() && var.isNull()) {
+        *out = std::optional<uint16_t>{};
+    }
+}
+
 static bool process_server_metadata_state_object(const JsonObject metadata_object,
-                                                 ServerMetadataStateObject* metadata_state) {
-    if (metadata_state == nullptr) {
+                                                 ServerMetadataStateDelta* metadata_delta) {
+    if (metadata_delta == nullptr) {
         return false;
     }
 
@@ -158,55 +180,18 @@ static bool process_server_metadata_state_object(const JsonObject metadata_objec
         SS_LOGE(TAG, "Invalid metadata state object: missing timestamp");
         return false;
     }
-    metadata_state->timestamp = metadata_object["timestamp"].as<int64_t>();
+    metadata_delta->timestamp = metadata_object["timestamp"].as<int64_t>();
 
-    // All other fields are optional - handle both values and null (to clear)
-    // Null is treated as empty string so it gets applied via delta updates
-    // Use isUnbound() to distinguish "key exists with null" from "key doesn't exist"
-    JsonVariantConst title_var = metadata_object["title"];
-    if (title_var.is<const char*>()) {
-        metadata_state->title = title_var.as<std::string>();
-    } else if (!title_var.isUnbound() && title_var.isNull()) {
-        metadata_state->title = "";
-    }
+    parse_metadata_string_field(metadata_object["title"], &metadata_delta->title);
+    parse_metadata_string_field(metadata_object["artist"], &metadata_delta->artist);
+    parse_metadata_string_field(metadata_object["album_artist"], &metadata_delta->album_artist);
+    parse_metadata_string_field(metadata_object["album"], &metadata_delta->album);
+    parse_metadata_string_field(metadata_object["artwork_url"], &metadata_delta->artwork_url);
+    parse_metadata_uint16_field(metadata_object["year"], &metadata_delta->year);
+    parse_metadata_uint16_field(metadata_object["track"], &metadata_delta->track);
 
-    JsonVariantConst artist_var = metadata_object["artist"];
-    if (artist_var.is<const char*>()) {
-        metadata_state->artist = artist_var.as<std::string>();
-    } else if (!artist_var.isUnbound() && artist_var.isNull()) {
-        metadata_state->artist = "";
-    }
-
-    JsonVariantConst album_artist_var = metadata_object["album_artist"];
-    if (album_artist_var.is<const char*>()) {
-        metadata_state->album_artist = album_artist_var.as<std::string>();
-    } else if (!album_artist_var.isUnbound() && album_artist_var.isNull()) {
-        metadata_state->album_artist = "";
-    }
-
-    JsonVariantConst album_var = metadata_object["album"];
-    if (album_var.is<const char*>()) {
-        metadata_state->album = album_var.as<std::string>();
-    } else if (!album_var.isUnbound() && album_var.isNull()) {
-        metadata_state->album = "";
-    }
-
-    JsonVariantConst artwork_url_var = metadata_object["artwork_url"];
-    if (artwork_url_var.is<const char*>()) {
-        metadata_state->artwork_url = artwork_url_var.as<std::string>();
-    } else if (!artwork_url_var.isUnbound() && artwork_url_var.isNull()) {
-        metadata_state->artwork_url = "";
-    }
-
-    if (metadata_object["year"].is<JsonVariant>() && !metadata_object["year"].isNull()) {
-        metadata_state->year = metadata_object["year"].as<uint16_t>();
-    }
-
-    if (metadata_object["track"].is<JsonVariant>() && !metadata_object["track"].isNull()) {
-        metadata_state->track = metadata_object["track"].as<uint16_t>();
-    }
-
-    // Parse progress object - if any progress field is present, create the object
+    // Parse progress object - present object engages inner; explicit null clears; absent leaves
+    // outer nullopt.
     if (metadata_object["progress"].is<JsonObject>()) {
         JsonObject progress_object = metadata_object["progress"];
         MetadataProgressObject progress{};
@@ -219,10 +204,9 @@ static bool process_server_metadata_state_object(const JsonObject metadata_objec
         if (progress_object["playback_speed"].is<JsonVariant>()) {
             progress.playback_speed = progress_object["playback_speed"].as<uint32_t>();
         }
-        metadata_state->progress = progress;
+        metadata_delta->progress = progress;
     } else if (!metadata_object["progress"].isUnbound() && metadata_object["progress"].isNull()) {
-        // Explicit null clears progress
-        metadata_state->progress = std::nullopt;
+        metadata_delta->progress = std::optional<MetadataProgressObject>{};
     }
 
     return true;
@@ -475,9 +459,9 @@ bool process_server_state_message(JsonObject root, ServerStateMessage* state_msg
 
     // Parse optional metadata object
     if (root["payload"]["metadata"].is<JsonObject>()) {
-        ServerMetadataStateObject metadata_state{};
-        if (process_server_metadata_state_object(root["payload"]["metadata"], &metadata_state)) {
-            state_msg->metadata = metadata_state;
+        ServerMetadataStateDelta metadata_delta{};
+        if (process_server_metadata_state_object(root["payload"]["metadata"], &metadata_delta)) {
+            state_msg->metadata = metadata_delta;
         }
     }
 
@@ -672,45 +656,39 @@ bool process_stream_clear_message(JsonObject root, StreamClearMessage* clear_msg
 }
 
 void apply_metadata_state_deltas(ServerMetadataStateObject* current,
-                                 const ServerMetadataStateObject& updates) {
+                                 const ServerMetadataStateDelta& delta) {
     if (current == nullptr) {
         return;
     }
 
-    // timestamp is always updated (not optional)
-    current->timestamp = updates.timestamp;
+    current->timestamp = delta.timestamp;
 
-    // Update optional fields only if they have values
-    if (updates.title.has_value()) {
-        current->title = updates.title;
+    // For each field, an outer-engaged delta entry overwrites the merged optional with the inner
+    // optional verbatim, so an inner-`nullopt` (explicit `null` on the wire) clears the merged
+    // field.
+    if (delta.title.has_value()) {
+        current->title = *delta.title;
     }
-
-    if (updates.artist.has_value()) {
-        current->artist = updates.artist;
+    if (delta.artist.has_value()) {
+        current->artist = *delta.artist;
     }
-
-    if (updates.album_artist.has_value()) {
-        current->album_artist = updates.album_artist;
+    if (delta.album_artist.has_value()) {
+        current->album_artist = *delta.album_artist;
     }
-
-    if (updates.album.has_value()) {
-        current->album = updates.album;
+    if (delta.album.has_value()) {
+        current->album = *delta.album;
     }
-
-    if (updates.artwork_url.has_value()) {
-        current->artwork_url = updates.artwork_url;
+    if (delta.artwork_url.has_value()) {
+        current->artwork_url = *delta.artwork_url;
     }
-
-    if (updates.year.has_value()) {
-        current->year = updates.year;
+    if (delta.year.has_value()) {
+        current->year = *delta.year;
     }
-
-    if (updates.track.has_value()) {
-        current->track = updates.track;
+    if (delta.track.has_value()) {
+        current->track = *delta.track;
     }
-
-    if (updates.progress.has_value()) {
-        current->progress = updates.progress;
+    if (delta.progress.has_value()) {
+        current->progress = *delta.progress;
     }
 }
 

--- a/src/protocol_messages.h
+++ b/src/protocol_messages.h
@@ -513,6 +513,26 @@ inline const char* to_cstr(VisualizerSpectrumScale scale) {
     }
 }
 
+// --- metadata_role.h ---
+
+/// @brief Wire-level delta for the metadata role's server/state object
+///
+/// Each field is a tri-state: outer `nullopt` means the field was absent in the delta and the
+/// merged state should be left alone; outer engaged with inner `nullopt` means the server sent an
+/// explicit `null` and the merged state should clear that field; outer and inner both engaged is a
+/// regular value update.
+struct ServerMetadataStateDelta {
+    int64_t timestamp{};
+    std::optional<std::optional<std::string>> title;
+    std::optional<std::optional<std::string>> artist;
+    std::optional<std::optional<std::string>> album_artist;
+    std::optional<std::optional<std::string>> album;
+    std::optional<std::optional<std::string>> artwork_url;
+    std::optional<std::optional<uint16_t>> year;
+    std::optional<std::optional<uint16_t>> track;
+    std::optional<std::optional<MetadataProgressObject>> progress;
+};
+
 // --- color_role.h ---
 
 /// @brief Wire-level delta for the color role's server/state object
@@ -561,7 +581,7 @@ struct ClientCommandMessage {
 /// @brief Parsed server/state message containing per-role state updates
 struct ServerStateMessage {
     std::optional<ServerStateControllerObject> controller;
-    std::optional<ServerMetadataStateObject> metadata;
+    std::optional<ServerMetadataStateDelta> metadata;
     std::optional<ServerColorStateDelta> color;
 };
 
@@ -666,11 +686,13 @@ bool process_stream_end_message(JsonObject root, StreamEndMessage* end_msg);
 /// @return true if parsing succeeded, false on missing required fields.
 bool process_stream_clear_message(JsonObject root, StreamClearMessage* clear_msg);
 
-/// @brief Merges a ServerMetadataStateObject delta into the current metadata state
+/// @brief Merges a ServerMetadataStateDelta into the current metadata state
 /// @param current [out] Current metadata state to update in place.
-/// @param updates Delta object containing only the fields that changed.
+/// @param delta Wire-level delta containing only the fields that changed; fields with an explicit
+///              `null` on the wire arrive as outer-engaged + inner-`nullopt` and clear the
+///              corresponding merged field.
 void apply_metadata_state_deltas(ServerMetadataStateObject* current,
-                                 const ServerMetadataStateObject& updates);
+                                 const ServerMetadataStateDelta& delta);
 
 /// @brief Merges a ServerColorStateDelta into the current color state
 /// @param current [out] Current color state to update in place.


### PR DESCRIPTION
Replace the metadata role's empty-string approach to clearing old metadata with the new ` ServerMetadataStateDelta` struct to reduce ambiguity for metadata's tri-state absent, null, or value.

This is a behavioral breaking change. The server clears old metadata states with a `nullopt` instead of an empty string. Updating the state where `progress: null` now properly clears the current progress info that before was never actually possible to clear.