### PR TITLE
Reduces allocation and memory copies for processing JSON messages

### DIFF
--- a/include/sendspin/client.h
+++ b/include/sendspin/client.h
@@ -21,6 +21,7 @@
 #include "sendspin/types.h"
 
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>

--- a/include/sendspin/client.h
+++ b/include/sendspin/client.h
@@ -409,10 +409,10 @@ private:
 
     /// @brief Processes a JSON message from a connection
     /// @param conn The connection that received the message
-    /// @param message The raw JSON text
+    /// @param data Mutable pointer to the raw JSON text (parsed in place, not null-terminated)
+    /// @param len Length of the JSON text in bytes
     /// @param timestamp Receive timestamp in microseconds
-    void process_json_message(SendspinConnection* conn, const std::string& message,
-                              int64_t timestamp);
+    void process_json_message(SendspinConnection* conn, char* data, size_t len, int64_t timestamp);
 
     /// @brief Processes a binary message from a connection
     /// @param payload Pointer to the raw binary data

--- a/include/sendspin/client.h
+++ b/include/sendspin/client.h
@@ -410,10 +410,12 @@ private:
 
     /// @brief Processes a JSON message from a connection
     /// @param conn The connection that received the message
-    /// @param data Mutable pointer to the raw JSON text (parsed in place, not null-terminated)
+    /// @param data Pointer to the raw JSON text (not null-terminated; valid for the duration of the
+    /// call only)
     /// @param len Length of the JSON text in bytes
     /// @param timestamp Receive timestamp in microseconds
-    void process_json_message(SendspinConnection* conn, char* data, size_t len, int64_t timestamp);
+    void process_json_message(SendspinConnection* conn, const char* data, size_t len,
+                              int64_t timestamp);
 
     /// @brief Processes a binary message from a connection
     /// @param payload Pointer to the raw binary data

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -483,10 +483,16 @@ std::string SendspinClient::build_hello_message() {
 // Message processing
 // ============================================================================
 
-void SendspinClient::process_json_message(SendspinConnection* conn, const std::string& message,
+void SendspinClient::process_json_message(SendspinConnection* conn, char* data, size_t len,
                                           int64_t timestamp) {
     JsonDocument doc = make_json_document();
-    DeserializationError error = deserializeJson(doc, message.c_str(), message.size());
+    // Parse straight out of the connection's reassembly buffer; the old path first copied it into
+    // a std::string. ArduinoJson 7 has no zero-copy mode, so string *values* are still copied into
+    // the document's (PSRAM-backed) pool and the buffer itself is left untouched -- but the
+    // whole-message copy is gone. Safe: the document and everything derived from it stay within
+    // this synchronous call; process_*_message copies any values it keeps into owning types
+    // before returning.
+    DeserializationError error = deserializeJson(doc, data, len);
     if (error || doc.isNull()) {
         SS_LOGW(TAG, "Failed to parse JSON message");
         return;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -483,15 +483,9 @@ std::string SendspinClient::build_hello_message() {
 // Message processing
 // ============================================================================
 
-void SendspinClient::process_json_message(SendspinConnection* conn, char* data, size_t len,
+void SendspinClient::process_json_message(SendspinConnection* conn, const char* data, size_t len,
                                           int64_t timestamp) {
     JsonDocument doc = make_json_document();
-    // Parse straight out of the connection's reassembly buffer; the old path first copied it into
-    // a std::string. ArduinoJson 7 has no zero-copy mode, so string *values* are still copied into
-    // the document's (PSRAM-backed) pool and the buffer itself is left untouched -- but the
-    // whole-message copy is gone. Safe: the document and everything derived from it stay within
-    // this synchronous call; process_*_message copies any values it keeps into owning types
-    // before returning.
     DeserializationError error = deserializeJson(doc, data, len);
     if (error || doc.isNull()) {
         SS_LOGW(TAG, "Failed to parse JSON message");

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -99,10 +99,10 @@ SS_HOT void SendspinConnection::dispatch_completed_message(bool is_text, int64_t
         // Hand the JSON callback a pointer straight into the reassembly buffer instead of copying
         // it into a std::string. The callback parses synchronously; reset_websocket_payload()
         // below makes the buffer reusable as soon as it returns, so the callback must not retain
-        // the pointer. The buffer is mutable (the callback may parse in place) and not
-        // null-terminated; the length is authoritative.
+        // the pointer. Not null-terminated; the length is authoritative.
         if (this->on_json_message_cb) {
-            this->on_json_message_cb(this, reinterpret_cast<char*>(this->websocket_payload_.data()),
+            this->on_json_message_cb(this,
+                                     reinterpret_cast<const char*>(this->websocket_payload_.data()),
                                      this->websocket_write_offset_, receive_time);
         }
     } else {

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -96,13 +96,14 @@ SS_HOT void SendspinConnection::dispatch_completed_message(bool is_text, int64_t
     }
 
     if (is_text) {
-        // Create string from payload for JSON processing
-        const std::string message(this->websocket_payload_.data(),
-                                  this->websocket_payload_.data() + this->websocket_write_offset_);
-
-        // Invoke JSON message callback
+        // Hand the JSON callback a pointer straight into the reassembly buffer instead of copying
+        // it into a std::string. The callback parses synchronously; reset_websocket_payload()
+        // below makes the buffer reusable as soon as it returns, so the callback must not retain
+        // the pointer. The buffer is mutable (the callback may parse in place) and not
+        // null-terminated; the length is authoritative.
         if (this->on_json_message_cb) {
-            this->on_json_message_cb(this, message, receive_time);
+            this->on_json_message_cb(this, reinterpret_cast<char*>(this->websocket_payload_.data()),
+                                     this->websocket_write_offset_, receive_time);
         }
     } else {
         // Binary message - connection retains buffer ownership, callback reads in-place

--- a/src/connection.h
+++ b/src/connection.h
@@ -63,7 +63,7 @@ using SendCompleteCallback = std::function<void(bool)>;
  * // Concrete subclass provided by the platform layer
  * auto conn = std::make_unique<SendspinClientConnection>(url, config);
  * conn->on_connected_cb = [](SendspinConnection* c) { c->send_text_message(hello_json, {}); };
- * conn->on_json_message_cb = [](SendspinConnection* c, char* data, size_t len, int64_t t) { ... };
+ * conn->on_json_message_cb = [](SendspinConnection* c, const char* d, size_t n, int64_t t) {...};
  * conn->on_disconnected_cb = [](SendspinConnection* c) { handle_disconnect(); };
  * conn->start();
  * // Call conn->loop() from a periodic task
@@ -167,11 +167,10 @@ public:
     /// @param conn Pointer to this connection.
     /// @param data Pointer to the message bytes, owned by the connection. Valid only until the
     /// callback returns -- it is reused for the next message immediately afterwards, so the
-    /// callback must not retain it. Mutable, so the callback may parse in place. Not
-    /// null-terminated; use @p len.
+    /// callback must not retain it. Not null-terminated; use @p len.
     /// @param len Length of the message in bytes.
     /// @param timestamp The client timestamp when the message was received.
-    std::function<void(SendspinConnection*, char*, size_t, int64_t)> on_json_message_cb;
+    std::function<void(SendspinConnection*, const char*, size_t, int64_t)> on_json_message_cb;
 
     /// @brief Callback invoked when a binary message is received
     /// @param conn Pointer to this connection.

--- a/src/connection.h
+++ b/src/connection.h
@@ -63,7 +63,7 @@ using SendCompleteCallback = std::function<void(bool)>;
  * // Concrete subclass provided by the platform layer
  * auto conn = std::make_unique<SendspinClientConnection>(url, config);
  * conn->on_connected_cb = [](SendspinConnection* c) { c->send_text_message(hello_json, {}); };
- * conn->on_json_message_cb = [](SendspinConnection* c, const std::string& msg, int64_t t) { ... };
+ * conn->on_json_message_cb = [](SendspinConnection* c, char* data, size_t len, int64_t t) { ... };
  * conn->on_disconnected_cb = [](SendspinConnection* c) { handle_disconnect(); };
  * conn->start();
  * // Call conn->loop() from a periodic task
@@ -165,9 +165,13 @@ public:
 
     /// @brief Callback invoked when a JSON message is received
     /// @param conn Pointer to this connection.
-    /// @param message The JSON message string.
+    /// @param data Pointer to the message bytes, owned by the connection. Valid only until the
+    /// callback returns -- it is reused for the next message immediately afterwards, so the
+    /// callback must not retain it. Mutable, so the callback may parse in place. Not
+    /// null-terminated; use @p len.
+    /// @param len Length of the message in bytes.
     /// @param timestamp The client timestamp when the message was received.
-    std::function<void(SendspinConnection*, const std::string&, int64_t)> on_json_message_cb;
+    std::function<void(SendspinConnection*, char*, size_t, int64_t)> on_json_message_cb;
 
     /// @brief Callback invoked when a binary message is received
     /// @param conn Pointer to this connection.
@@ -321,9 +325,10 @@ protected:
 
     /// @brief Dispatches a fully assembled message to the appropriate callback
     ///
-    /// For text messages: creates a std::string from the buffer, invokes on_json_message_cb,
-    /// deallocates buffer. For binary messages: invokes on_binary_message_cb callback. If the
-    /// buffer is null, does nothing.
+    /// For text messages: invokes on_json_message_cb with a pointer into the reassembly buffer
+    /// (no intermediate std::string). For binary messages: invokes on_binary_message_cb. Either
+    /// way the buffer is retained and only its write offset is reset afterwards. If the buffer is
+    /// null, does nothing.
     ///
     /// @param is_text True if this is a text message, false for binary.
     /// @param receive_time Timestamp when the data was received (microseconds).

--- a/src/connection_manager.cpp
+++ b/src/connection_manager.cpp
@@ -308,9 +308,9 @@ void ConnectionManager::setup_connection_callbacks(SendspinConnection* conn) {
         std::lock_guard<std::mutex> lock(this->conn_mutex_);
         this->pending_connected_events_.push_back(c->shared_from_this());
     };
-    conn->on_json_message_cb = [this](SendspinConnection* c, const std::string& message,
+    conn->on_json_message_cb = [this](SendspinConnection* c, char* data, size_t len,
                                       int64_t timestamp) {
-        this->client_->process_json_message(c, message, timestamp);
+        this->client_->process_json_message(c, data, len, timestamp);
     };
     conn->on_binary_message_cb = [this](SendspinConnection* /*c*/, uint8_t* payload, size_t len) {
         this->client_->process_binary_message(payload, len);

--- a/src/connection_manager.cpp
+++ b/src/connection_manager.cpp
@@ -308,7 +308,7 @@ void ConnectionManager::setup_connection_callbacks(SendspinConnection* conn) {
         std::lock_guard<std::mutex> lock(this->conn_mutex_);
         this->pending_connected_events_.push_back(c->shared_from_this());
     };
-    conn->on_json_message_cb = [this](SendspinConnection* c, char* data, size_t len,
+    conn->on_json_message_cb = [this](SendspinConnection* c, const char* data, size_t len,
                                       int64_t timestamp) {
         this->client_->process_json_message(c, data, len, timestamp);
     };

--- a/src/host/client_connection.h
+++ b/src/host/client_connection.h
@@ -42,8 +42,8 @@ namespace sendspin {
  *
  * @code
  * auto conn = std::make_unique<SendspinClientConnection>("ws://192.168.1.10:8928");
- * conn->on_json_message_cb = [](SendspinConnection*, const std::string& msg, int64_t) {
- * handle(msg);
+ * conn->on_json_message_cb = [](SendspinConnection*, char* data, size_t len, int64_t) {
+ * handle(data, len);
  * }; conn->start();
  * // periodically:
  * conn->loop();

--- a/src/host/client_connection.h
+++ b/src/host/client_connection.h
@@ -42,7 +42,7 @@ namespace sendspin {
  *
  * @code
  * auto conn = std::make_unique<SendspinClientConnection>("ws://192.168.1.10:8928");
- * conn->on_json_message_cb = [](SendspinConnection*, char* data, size_t len, int64_t) {
+ * conn->on_json_message_cb = [](SendspinConnection*, const char* data, size_t len, int64_t) {
  * handle(data, len);
  * }; conn->start();
  * // periodically:


### PR DESCRIPTION
Uses `const char` pointers directly into the websocket payload instead of creating an intermediate string copy that gets passed around.