### PR TITLE
Handle stream/clear internally

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -176,11 +176,6 @@ struct MyPlayerListener : PlayerRoleListener {
         my_audio_output.clear();
     }
 
-    // Optional: Called when the audio stream is cleared (e.g., track skip).
-    void on_stream_clear() override {
-        my_audio_output.clear();
-    }
-
     // Optional: Called when the server changes the volume.
     void on_volume_changed(uint8_t volume) override {
         my_audio_output.set_volume(volume);

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -76,7 +76,7 @@ Atomic bit flags with blocking wait. Used for thread lifecycle control:
 ```api
 COMMAND_STOP         (1 << 0)   Stop the thread
 COMMAND_STREAM_END   (1 << 1)   End current stream
-COMMAND_STREAM_CLEAR (1 << 2)   Clear all buffered audio
+COMMAND_STREAM_CLEAR (1 << 2)   Seek: discard buffered audio up to the stream/clear marker
 COMMAND_START        (1 << 3)   Main loop acknowledged stream start
 TASK_RUNNING         (1 << 8)   Actively decoding
 TASK_STOPPED         (1 << 10)  Thread has exited
@@ -168,7 +168,7 @@ Network thread (IXWebSocket / esp_http_server)
 | `GROUP_UPDATE` | Merges into `Client::shadow_group` |
 | `STREAM_START` | Writes to `PlayerRole::Impl::shadow_stream_params`, enqueues `STREAM_START` into `stream_queue`. Marks the artwork stream active, flushes the decode thread's notification queue, and resets any pending per-slot display timestamps. Writes to `VisualizerRole::Impl::shadow_config`, enqueues a start event. |
 | `STREAM_END` | Enqueues `STREAM_END` into player/artwork/visualizer queues, signals sync task `COMMAND_STREAM_END` |
-| `STREAM_CLEAR` | Enqueues `STREAM_CLEAR` into player/artwork/visualizer queues, signals sync task `COMMAND_STREAM_CLEAR` |
+| `STREAM_CLEAR` | Enqueues `STREAM_CLEAR` into artwork/visualizer queues; for the player, signals sync task `COMMAND_STREAM_CLEAR` and enqueues a `CHUNK_TYPE_STREAM_CLEAR_MARKER` chunk into the encoded ring buffer (no player listener callback — a seek is not a stream lifecycle event) |
 
 #### JSON parse arena (`src/platform/json_arena.h`)
 
@@ -240,9 +240,9 @@ stream_queue → awaiting_sync_idle_events_ list
                        │
                        ▼
          For each event in order:
-           ├─ STREAM_END or STREAM_CLEAR:
-           │    If sync task is still running → STOP, wait for next tick
-           │    If sync task is idle → fire callback, continue
+           ├─ STREAM_END:
+           │    If sync task is still running → wait for next tick
+           │    If sync task is idle → fire on_stream_end(), continue
            │
            └─ STREAM_START:
                 Take shadow_stream_params
@@ -250,7 +250,7 @@ stream_queue → awaiting_sync_idle_events_ list
                 Signal sync task COMMAND_START
 ```
 
-The `awaiting_sync_idle_events` list (on `PlayerRole::Impl`) is the key ordering mechanism. STREAM_END/CLEAR callbacks are held until the sync task has reached its IDLE state, preventing the main loop from processing a new STREAM_START before the sync task has finished with the old stream. Events ahead of the blocked event also wait, preserving FIFO order.
+The `awaiting_sync_idle_events` list (on `PlayerRole::Impl`) is the key ordering mechanism. STREAM_END callbacks are held until the sync task has reached its IDLE state, preventing the main loop from processing a new STREAM_START before the sync task has finished with the old stream. Events ahead of the blocked event also wait, preserving FIFO order. (`stream/clear` is not queued here — it is handled synchronously in `handle_stream_clear()` by signaling the sync task and enqueuing a marker chunk.)
 
 ### Other Roles
 

--- a/examples/basic_client/main.cpp
+++ b/examples/basic_client/main.cpp
@@ -256,13 +256,6 @@ int main(int argc, char* argv[]) {
 #endif
         }
 
-        void on_stream_clear() override {
-            fprintf(stderr, ">>> Stream clear\n");
-#ifdef SENDSPIN_HAS_PORTAUDIO
-            sink.clear();
-#endif
-        }
-
 #ifdef SENDSPIN_HAS_PORTAUDIO
         void on_volume_changed(uint8_t vol) override { sink.set_volume(vol); }
         void on_mute_changed(bool muted) override { sink.set_muted(muted); }

--- a/examples/tui_client/main.cpp
+++ b/examples/tui_client/main.cpp
@@ -579,12 +579,6 @@ int main(int argc, char* argv[]) {
 #endif
         }
 
-        void on_stream_clear() override {
-#ifdef SENDSPIN_HAS_PORTAUDIO
-            sink.clear();
-#endif
-        }
-
         void on_volume_changed(uint8_t vol) override {
             {
                 std::lock_guard<std::mutex> lock(state.mutex);

--- a/include/sendspin/player_role.h
+++ b/include/sendspin/player_role.h
@@ -73,7 +73,7 @@ struct ServerCommandMessage {
 ///
 /// THREAD SAFETY: on_audio_write() fires on the sync task's background thread.
 /// Implementations must be thread-safe for this method. on_stream_start(), on_stream_end(),
-/// on_stream_clear(), on_volume_changed(), on_mute_changed(), and on_static_delay_changed()
+/// on_volume_changed(), on_mute_changed(), and on_static_delay_changed()
 /// fire on the main loop thread via drain_events(). The listener must outlive the role.
 class PlayerRoleListener {
 public:
@@ -93,9 +93,6 @@ public:
 
     /// @brief Called when the audio stream ends. Fires on the main loop thread
     virtual void on_stream_end() {}
-
-    /// @brief Called when the audio stream is cleared. Fires on the main loop thread
-    virtual void on_stream_clear() {}
 
     /// @brief Called when the volume is changed by the server. Fires on the main loop thread
     virtual void on_volume_changed(uint8_t /*volume*/) {}

--- a/src/audio_types.h
+++ b/src/audio_types.h
@@ -25,11 +25,12 @@ namespace sendspin {
 ///
 /// Not part of the protocol specification.
 enum ChunkType : uint8_t {
-    CHUNK_TYPE_ENCODED_AUDIO = 0,  // Raw encoded audio data
-    CHUNK_TYPE_DECODED_AUDIO,      // Already-decoded PCM frames
-    CHUNK_TYPE_PCM_DUMMY_HEADER,   // Synthetic header for PCM streams
-    CHUNK_TYPE_OPUS_DUMMY_HEADER,  // Synthetic header for Opus streams
-    CHUNK_TYPE_FLAC_HEADER,        // FLAC stream header block
+    CHUNK_TYPE_ENCODED_AUDIO = 0,    // Raw encoded audio data
+    CHUNK_TYPE_DECODED_AUDIO,        // Already-decoded PCM frames
+    CHUNK_TYPE_PCM_DUMMY_HEADER,     // Synthetic header for PCM streams
+    CHUNK_TYPE_OPUS_DUMMY_HEADER,    // Synthetic header for Opus streams
+    CHUNK_TYPE_FLAC_HEADER,          // FLAC stream header block
+    CHUNK_TYPE_STREAM_CLEAR_MARKER,  // Boundary marker: discard everything before it (stream/clear)
 };
 
 /// @brief Synthetic codec header for PCM and Opus streams that lack a real header block

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -411,9 +411,7 @@ void PlayerRole::Impl::drain_events() {
         size_t processed = 0;
 
         for (auto& event : this->awaiting_sync_idle_events) {
-            if ((event == PlayerStreamCallbackType::STREAM_END ||
-                 event == PlayerStreamCallbackType::STREAM_CLEAR) &&
-                !sync_idle) {
+            if (event == PlayerStreamCallbackType::STREAM_END && !sync_idle) {
                 break;  // Wait for sync task to go idle before firing this and anything after it
             }
 
@@ -425,11 +423,6 @@ void PlayerRole::Impl::drain_events() {
                     if (this->high_performance_requested_for_playback) {
                         this->client->release_high_performance();
                         this->high_performance_requested_for_playback = false;
-                    }
-                    break;
-                case PlayerStreamCallbackType::STREAM_CLEAR:
-                    if (this->listener) {
-                        this->listener->on_stream_clear();
                     }
                     break;
                 case PlayerStreamCallbackType::STREAM_START: {

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -314,8 +314,13 @@ void PlayerRole::Impl::handle_stream_clear() const {
     // so the sync task starts draining (freeing ring-buffer space) before we write the marker.
     // No listener callback: a seek is not a stream lifecycle event for the consumer.
     this->sync_task->signal_stream_clear();
-    this->sync_task->write_audio_chunk(nullptr, 0, 0, CHUNK_TYPE_STREAM_CLEAR_MARKER,
-                                       HEADER_SEND_TIMEOUT_MS);
+    if (!this->sync_task->write_audio_chunk(nullptr, 0, 0, CHUNK_TYPE_STREAM_CLEAR_MARKER,
+                                            HEADER_SEND_TIMEOUT_MS)) {
+        // The marker couldn't be enqueued (ring buffer full). The sync task will still drain to
+        // empty and apply the clear, but the pre-seek/post-seek boundary is lost, so new audio
+        // may be discarded along with the old.
+        SS_LOGW(TAG, "Failed to enqueue stream/clear marker; seek boundary may be imprecise");
+    }
 }
 
 void PlayerRole::Impl::handle_server_command(const ServerCommandMessage& cmd) const {

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -307,8 +307,15 @@ void PlayerRole::Impl::handle_stream_end() const {
 }
 
 void PlayerRole::Impl::handle_stream_clear() const {
+    // stream/clear is a seek within the active stream: the server flushes our buffered audio and
+    // immediately resumes sending new audio with the same codec/params (no new stream/start). Tell
+    // the sync task to discard buffered audio, then enqueue a marker so it knows exactly where the
+    // discarded (pre-seek) audio ends and the new audio begins. The flag is set before the marker
+    // so the sync task starts draining (freeing ring-buffer space) before we write the marker.
+    // No listener callback: a seek is not a stream lifecycle event for the consumer.
     this->sync_task->signal_stream_clear();
-    this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_CLEAR, 0);
+    this->sync_task->write_audio_chunk(nullptr, 0, 0, CHUNK_TYPE_STREAM_CLEAR_MARKER,
+                                       HEADER_SEND_TIMEOUT_MS);
 }
 
 void PlayerRole::Impl::handle_server_command(const ServerCommandMessage& cmd) const {
@@ -444,8 +451,9 @@ void PlayerRole::Impl::drain_events() {
 }
 
 void PlayerRole::Impl::cleanup() {
-    // Clear all buffered audio immediately
-    this->sync_task->signal_stream_clear();
+    // End the current stream: the sync task drains and returns to idle. (Not signal_stream_clear():
+    // that path is a seek within a live stream and expects a marker to follow.)
+    this->sync_task->signal_stream_end();
 
     // Discard stale events from the dead connection
     this->event_state->stream_queue.reset();

--- a/src/player_role_impl.h
+++ b/src/player_role_impl.h
@@ -37,7 +37,6 @@ struct ClientStateMessage;
 enum class PlayerStreamCallbackType : uint8_t {
     STREAM_START,  // New stream is starting
     STREAM_END,    // Stream ended normally
-    STREAM_CLEAR,  // Stream cleared immediately
 };
 
 /// @brief Private implementation of the player role

--- a/src/sync_task.cpp
+++ b/src/sync_task.cpp
@@ -609,12 +609,16 @@ void SyncTask::drain_ring_buffer(SyncContext& sync_context) {
 
 void SyncTask::apply_stream_clear(SyncContext& sync_context) {
     // Drop in-flight decoded audio (it carries the pre-seek timestamp; appending post-seek audio to
-    // it would mis-stamp the buffer) and any pending priming/gap-fill silence. Codec/decoder state,
-    // buffered_frames and new_audio_client_playtime are deliberately left intact: the audio already
-    // handed to the sink keeps draining, and the next chunk's server timestamp lets the existing
-    // sync logic re-align (hard sync) on its own.
+    // it would mis-stamp the buffer) and any pending hard-sync gap-fill silence. Codec/decoder
+    // state, buffered_frames and new_audio_client_playtime are deliberately left intact: the audio
+    // already handed to the sink keeps draining, and the next chunk's server timestamp lets the
+    // sync logic re-align on its own. Force hard_syncing on so that re-alignment uses the tight
+    // settle threshold (the post-seek timestamp jump would trigger it anyway, but this is
+    // explicit). initial_decode is left as-is: if priming has not finished the caller resumes it
+    // via the INITIAL_SYNC state; if it has, we must not re-prime an already-running sink.
     sync_context.silence_remaining = 0;
     sync_context.release_chunk = false;
+    sync_context.hard_syncing = true;
     if (sync_context.decode_buffer != nullptr) {
         sync_context.decode_buffer->decrease_buffer_length(sync_context.decode_buffer->available());
     }
@@ -810,8 +814,10 @@ void SyncTask::thread_entry(void* params) {
             if (flags & COMMAND_STREAM_CLEAR) {
                 // Seek within the current stream: discard buffered audio up to the marker, keep the
                 // codec/decoder and playtime accounting, and continue decoding the new audio.
+                // Re-enter at INITIAL_SYNC: if priming had not finished it resumes there; otherwise
+                // handle_initial_sync() falls straight through to LOAD_CHUNK on the next tick.
                 this_task->discard_to_clear_marker(sync_context);
-                sync_state = SyncTaskState::LOAD_CHUNK;
+                sync_state = SyncTaskState::INITIAL_SYNC;
                 continue;
             }
 

--- a/src/sync_task.cpp
+++ b/src/sync_task.cpp
@@ -451,6 +451,16 @@ int32_t SyncTask::soft_sync_insert_frame(SyncContext& sync_context) {
 }
 
 DecodeResult SyncTask::decode_chunk(SyncContext& sync_context) {
+    if (sync_context.encoded_entry != nullptr &&
+        sync_context.encoded_entry->chunk_type == CHUNK_TYPE_STREAM_CLEAR_MARKER) {
+        // Reached the stream/clear marker before the inner loop noticed COMMAND_STREAM_CLEAR
+        // (the marker was at the front of an otherwise-empty ring buffer). Apply the clear here.
+        this->encoded_ring_buffer_->return_chunk(sync_context.encoded_entry);
+        sync_context.encoded_entry = nullptr;
+        this->apply_stream_clear(sync_context);
+        return DecodeResult::SKIPPED;
+    }
+
     if (sync_context.decode_buffer != nullptr && sync_context.decode_buffer->available() > 0) {
         // Already have decoded audio
         return DecodeResult::SUCCESS;
@@ -565,12 +575,13 @@ bool SyncTask::wait_for_codec_header(SyncContext& sync_context) {
             continue;  // Timed out; check flags and try again
         }
         if (entry->chunk_type != CHUNK_TYPE_ENCODED_AUDIO &&
-            entry->chunk_type != CHUNK_TYPE_DECODED_AUDIO) {
+            entry->chunk_type != CHUNK_TYPE_DECODED_AUDIO &&
+            entry->chunk_type != CHUNK_TYPE_STREAM_CLEAR_MARKER) {
             // Found a codec header
             sync_context.encoded_entry = entry;
             return true;
         }
-        // Stale audio data from a previous stream, discard it
+        // Stale audio data (or a leftover stream/clear marker) from a previous stream, discard it
         this->encoded_ring_buffer_->return_chunk(entry);
     }
     return false;
@@ -586,13 +597,55 @@ void SyncTask::drain_ring_buffer(SyncContext& sync_context) {
             break;
         }
         if (entry->chunk_type != CHUNK_TYPE_ENCODED_AUDIO &&
-            entry->chunk_type != CHUNK_TYPE_DECODED_AUDIO) {
+            entry->chunk_type != CHUNK_TYPE_DECODED_AUDIO &&
+            entry->chunk_type != CHUNK_TYPE_STREAM_CLEAR_MARKER) {
             // Codec header for the next stream; hold onto it
             sync_context.encoded_entry = entry;
             break;
         }
         this->encoded_ring_buffer_->return_chunk(entry);
     }
+}
+
+void SyncTask::apply_stream_clear(SyncContext& sync_context) {
+    // Drop in-flight decoded audio (it carries the pre-seek timestamp; appending post-seek audio to
+    // it would mis-stamp the buffer) and any pending priming/gap-fill silence. Codec/decoder state,
+    // buffered_frames and new_audio_client_playtime are deliberately left intact: the audio already
+    // handed to the sink keeps draining, and the next chunk's server timestamp lets the existing
+    // sync logic re-align (hard sync) on its own.
+    sync_context.silence_remaining = 0;
+    sync_context.release_chunk = false;
+    if (sync_context.decode_buffer != nullptr) {
+        sync_context.decode_buffer->decrease_buffer_length(sync_context.decode_buffer->available());
+    }
+    this->event_flags_.clear(EventGroupBits::COMMAND_STREAM_CLEAR);
+}
+
+void SyncTask::discard_to_clear_marker(SyncContext& sync_context) {
+    // A stream/clear arrived: discard buffered audio up to the marker the client enqueued right
+    // after signaling.
+    if (sync_context.encoded_entry != nullptr) {
+        bool is_marker = sync_context.encoded_entry->chunk_type == CHUNK_TYPE_STREAM_CLEAR_MARKER;
+        this->encoded_ring_buffer_->return_chunk(sync_context.encoded_entry);
+        sync_context.encoded_entry = nullptr;
+        if (is_marker) {
+            this->apply_stream_clear(sync_context);
+            return;
+        }
+    }
+
+    while (!(this->event_flags_.get() & COMMAND_STOP)) {
+        auto* entry = this->encoded_ring_buffer_->receive_chunk(0);
+        if (entry == nullptr) {
+            break;
+        }
+        ChunkType type = entry->chunk_type;
+        this->encoded_ring_buffer_->return_chunk(entry);
+        if (type == CHUNK_TYPE_STREAM_CLEAR_MARKER) {
+            break;
+        }
+    }
+    this->apply_stream_clear(sync_context);
 }
 
 void SyncTask::reset_context(SyncContext& sync_context) {
@@ -751,8 +804,15 @@ void SyncTask::thread_entry(void* params) {
         // === INNER LOOP: state machine for active stream ===
         while (true) {
             uint32_t flags = this_task->event_flags_.get();
-            if (flags & (COMMAND_STOP | COMMAND_STREAM_END | COMMAND_STREAM_CLEAR)) {
+            if (flags & (COMMAND_STOP | COMMAND_STREAM_END)) {
                 break;
+            }
+            if (flags & COMMAND_STREAM_CLEAR) {
+                // Seek within the current stream: discard buffered audio up to the marker, keep the
+                // codec/decoder and playtime accounting, and continue decoding the new audio.
+                this_task->discard_to_clear_marker(sync_context);
+                sync_state = SyncTaskState::LOAD_CHUNK;
+                continue;
             }
 
             this_task->process_playback_progress(sync_context);

--- a/src/sync_task.h
+++ b/src/sync_task.h
@@ -232,9 +232,11 @@ protected:
     /// up to (and including) the CHUNK_TYPE_STREAM_CLEAR_MARKER, then applies apply_stream_clear()
     void discard_to_clear_marker(SyncContext& sync_context);
 
-    /// @brief Drops in-flight decoded audio and pending silence (they carry the pre-seek timeline)
-    /// and clears COMMAND_STREAM_CLEAR. Codec/decoder state and playtime accounting are left
-    /// intact; the next chunk's server timestamp lets the existing sync logic re-align on its own.
+    /// @brief Drops in-flight decoded audio and pending silence (they carry the pre-seek timeline),
+    /// forces hard_syncing on, and clears COMMAND_STREAM_CLEAR. Codec/decoder state, playtime
+    /// accounting, and initial_decode are left intact; the next chunk's server timestamp lets the
+    /// sync logic re-align on its own. The caller re-enters the loop at INITIAL_SYNC so unfinished
+    /// priming resumes.
     void apply_stream_clear(SyncContext& sync_context);
 
     /// @brief Resets SyncContext between streams without deallocating buffers

--- a/src/sync_task.h
+++ b/src/sync_task.h
@@ -90,7 +90,7 @@ struct SyncContext {
 enum EventGroupBits : uint16_t {
     COMMAND_STOP = (1 << 0),          // Signal task to stop
     COMMAND_STREAM_END = (1 << 1),    // Signal end of current stream
-    COMMAND_STREAM_CLEAR = (1 << 2),  // Signal immediate buffer clear
+    COMMAND_STREAM_CLEAR = (1 << 2),  // Seek: discard buffered audio up to the clear marker
     COMMAND_START = (1 << 3),         // Signal stream start acknowledged
     TASK_RUNNING = (1 << 8),          // Task is actively processing a stream
     TASK_STOPPED = (1 << 10),         // Task thread has exited
@@ -143,8 +143,10 @@ public:
     /// Thread-safe: may be called from any context.
     void signal_stream_end();
 
-    /// @brief Signals the sync task to clear all buffered audio. Non-blocking
-    /// The task immediately drains the ring buffer and returns to idle.
+    /// @brief Signals the sync task that a stream/clear (seek) occurred. Non-blocking
+    /// The task discards buffered audio up to the CHUNK_TYPE_STREAM_CLEAR_MARKER that the caller
+    /// must enqueue immediately after this call, then keeps processing the same stream with its
+    /// existing codec, decoder, and playtime accounting intact. It does not return to idle.
     /// Thread-safe: may be called from any context.
     void signal_stream_clear();
 
@@ -225,6 +227,15 @@ protected:
 
     /// @brief Non-blocking drain of audio data from the ring buffer, preserving codec headers
     void drain_ring_buffer(SyncContext& sync_context);
+
+    /// @brief Handles a stream/clear (seek) while a stream is active: discards ring-buffer chunks
+    /// up to (and including) the CHUNK_TYPE_STREAM_CLEAR_MARKER, then applies apply_stream_clear()
+    void discard_to_clear_marker(SyncContext& sync_context);
+
+    /// @brief Drops in-flight decoded audio and pending silence (they carry the pre-seek timeline)
+    /// and clears COMMAND_STREAM_CLEAR. Codec/decoder state and playtime accounting are left
+    /// intact; the next chunk's server timestamp lets the existing sync logic re-align on its own.
+    void apply_stream_clear(SyncContext& sync_context);
 
     /// @brief Resets SyncContext between streams without deallocating buffers
     void reset_context(SyncContext& sync_context);


### PR DESCRIPTION
Fixes a bug where `stream/clear` always assumed a `stream/start` message would follow. `stream/clear` messages are now handled internally by the player role. It adds a marker to the ring buffer queue, and then the sync task clears all chunks up to that marker. It does not break out of the inner loop, so the next new chunk will get synchronized using the current sync algorithm (with the hard_sync flag automatically set so it uses a stricter bound for correction).

There is one flaw with this design: it does not clear data already written out to the user provided buffer, so any pending audio will still play before starting with the new audio. This requires exposing more details to the library user, as the library itself has no control over that buffer. I have a longer-term plan to introduce this to the library. Note that in ESPHome, this is also the current behavior when stream/clear and stream/end are paired together, as the current `speaker_source` media player always waits until all data is played before, so this is not a regression on that platform. I'm tracking this in #55 

This is a breaking change, because this PR removes the `on_stream_clear` function from the `PlayerRoleListener` class.

