### PR TITLE
Reduce httpd task priority to 5

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -696,7 +696,7 @@ Main client configuration passed to the `SendspinClient` constructor.
 | `manufacturer` | `std::string` | — | Manufacturer name (e.g., `"ESPHome"`) |
 | `software_version` | `std::string` | — | Software version string |
 | `httpd_psram_stack` | `bool` | `false` | Allocate HTTP server task stack in PSRAM (ESP-IDF only) |
-| `httpd_priority` | `unsigned` | `17` | FreeRTOS priority for the HTTP server task (ESP-IDF only) |
+| `httpd_priority` | `unsigned` | `5` | FreeRTOS priority for the HTTP server task (ESP-IDF only) |
 | `websocket_priority` | `unsigned` | `5` | FreeRTOS priority for the WebSocket client task (ESP-IDF only) |
 | `server_port` | `uint16_t` | `8928` | WebSocket server port |
 | `server_max_connections` | `uint8_t` | `2` | Maximum simultaneous WebSocket connections (default supports the handoff protocol) |
@@ -720,7 +720,7 @@ Configuration passed to `client.add_player()`.
 | `fixed_delay_us` | `int32_t` | `0` | Fixed platform-level delay offset in microseconds (e.g., a known I2S pipeline delay). Applied on top of the user-adjustable static delay. |
 | `initial_static_delay_ms` | `uint16_t` | `0` | Initial value for the user-adjustable static delay in milliseconds. Overridden by the persisted value if a `SendspinPersistenceProvider` is set. |
 | `psram_stack` | `bool` | `false` | Allocate sync/decode task stack in PSRAM (ESP-IDF only) |
-| `priority` | `unsigned` | `18` | FreeRTOS priority for the sync/decode task (ESP-IDF only). The default value, `18`, is one above the default `httpd_priority` (`17`). If you customize priorities, keep this above `httpd_priority` so the HTTP server task cannot starve the decoder during the initial burst of encoded audio that fills the buffer at stream start. |
+| `priority` | `unsigned` | `6` | FreeRTOS priority for the sync/decode task (ESP-IDF only). The default value, `6`, is one above the default `httpd_priority` (`5`). If you customize priorities, keep this above `httpd_priority` so the HTTP server task cannot starve the decoder during the initial burst of encoded audio that fills the buffer at stream start. |
 | `decode_buffer_location` | `MemoryLocation` | `PREFER_EXTERNAL` | Memory placement preference for the decode transfer buffer. `PREFER_EXTERNAL` tries SPIRAM first and falls back to internal RAM; `PREFER_INTERNAL` does the reverse. ESP-IDF only; ignored on host. |
 
 Each entry in `audio_formats` is an `AudioSupportedFormatObject`:

--- a/include/sendspin/config.h
+++ b/include/sendspin/config.h
@@ -43,7 +43,7 @@ struct SendspinClientConfig {
     bool httpd_psram_stack{false};  ///< Allocate httpd task stack in PSRAM (ESP-IDF only)
 
     /// @brief Default FreeRTOS priority for the HTTP server task (ESP-IDF only)
-    static constexpr unsigned DEFAULT_HTTPD_PRIORITY = 17U;
+    static constexpr unsigned DEFAULT_HTTPD_PRIORITY = 5U;
 
     unsigned httpd_priority{DEFAULT_HTTPD_PRIORITY};  ///< FreeRTOS priority for the HTTP server
                                                       ///< task (ESP-IDF only)


### PR DESCRIPTION
- The lower priority doesn't seem to cause a measurable increase in time message round trip times
- Could be beneficial for ESP32 (plain variant) with ethernet. It's a lower priority than the ethernet task so httpd can't potentially starve it