### PR TITLE
Fix ESP-IDF server-initiated discovery

### DIFF
--- a/include/sendspin/config.h
+++ b/include/sendspin/config.h
@@ -34,7 +34,9 @@ namespace sendspin {
 /// @brief Configuration for a SendspinClient instance
 /// Filled in by the platform (e.g., ESPHome) before calling start_server()
 struct SendspinClientConfig {
-    std::string client_id;  ///< Unique client identifier (e.g., MAC address)
+    /// Unique client identifier. When left empty, the library falls back to the detected local
+    /// network interface MAC address (the same value used for device_info.mac_address).
+    std::string client_id;
     std::string name;       ///< Friendly display name
 
     std::optional<std::string> product_name{};  ///< Device product name (optional)

--- a/include/sendspin/config.h
+++ b/include/sendspin/config.h
@@ -37,7 +37,7 @@ struct SendspinClientConfig {
     /// Unique client identifier. When left empty, the library falls back to the detected local
     /// network interface MAC address (the same value used for device_info.mac_address).
     std::string client_id;
-    std::string name;       ///< Friendly display name
+    std::string name;  ///< Friendly display name
 
     std::optional<std::string> product_name{};  ///< Device product name (optional)
     std::optional<std::string> manufacturer{};  ///< Manufacturer name, e.g., "ESPHome" (optional)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -438,17 +438,26 @@ void SendspinClient::cleanup_connection_state() {
 
 std::string SendspinClient::build_hello_message() {
     ClientHelloMessage msg;
-    msg.client_id = this->config_.client_id;
     msg.name = this->config_.name;
+
+    // Use the explicitly configured MAC when provided; otherwise fall back to platform detection
+    // (reliable on ESP, best-effort on host). Leaves the field absent if neither is available.
+    const std::optional<std::string> interface_mac =
+        this->config_.mac_address ? this->config_.mac_address : platform_get_interface_mac();
+
+    // Some integrations use the network MAC as the Sendspin client_id. If they leave it empty,
+    // default to the same active-interface MAC advertised in device_info instead of forcing them
+    // to duplicate platform-specific MAC detection.
+    msg.client_id = this->config_.client_id;
+    if (msg.client_id.empty() && interface_mac.has_value()) {
+        msg.client_id = interface_mac.value();
+    }
 
     DeviceInfoObject device_info{};
     device_info.product_name = this->config_.product_name;
     device_info.manufacturer = this->config_.manufacturer;
     device_info.software_version = this->config_.software_version;
-    // Use the explicitly configured MAC when provided; otherwise fall back to platform detection
-    // (reliable on ESP, best-effort on host). Leaves the field absent if neither is available.
-    device_info.mac_address =
-        this->config_.mac_address ? this->config_.mac_address : platform_get_interface_mac();
+    device_info.mac_address = interface_mac;
     msg.device_info = device_info;
 
     msg.version = 1;

--- a/src/connection_manager.cpp
+++ b/src/connection_manager.cpp
@@ -337,9 +337,11 @@ void ConnectionManager::on_new_connection(std::shared_ptr<SendspinServerConnecti
     };
 
     std::lock_guard<std::mutex> lock(this->conn_ptr_mutex_);
+    SendspinConnection* accepted_conn = nullptr;
     if (this->current_connection_ == nullptr) {
         SS_LOGD(TAG, "No existing connection, accepting as current");
         this->current_connection_ = std::move(conn);
+        accepted_conn = this->current_connection_.get();
     } else {
         SS_LOGD(TAG, "Existing connection present, setting as pending for handoff");
         if (this->pending_connection_ != nullptr) {
@@ -348,6 +350,15 @@ void ConnectionManager::on_new_connection(std::shared_ptr<SendspinServerConnecti
             return;
         }
         this->pending_connection_ = std::move(conn);
+        accepted_conn = this->pending_connection_.get();
+    }
+
+    // Some ESP-IDF/httpd versions complete the WebSocket upgrade without dispatching the initial
+    // HTTP_GET request to websocket_handler(). Arm the hello retry from the accept path as well so
+    // server-initiated connections always receive client/hello. If the GET callback arrives later,
+    // initiate_hello() only re-arms the existing per-connection retry entry.
+    if (accepted_conn != nullptr) {
+        this->initiate_hello(accepted_conn);
     }
 }
 


### PR DESCRIPTION
﻿## Summary

Fixes two closely related discovery/connection problems seen with an ESP32-P4 ESP-IDF 6.0.1 device using Sendspin as an ESPHome component.

- Server-initiated WebSocket connections now arm `client/hello` from the accepted-connection path, not only from the later HTTP GET callback.
- If an integration leaves `SendspinClientConfig::client_id` empty, the client now falls back to the detected local network interface MAC address, matching the value advertised in `device_info.mac_address`.

## Root cause

On ESP-IDF HTTPD, the WebSocket upgrade can complete and the connection can be accepted before the initial HTTP GET path reliably drives the existing `on_connected_cb` path. In that state the server gets a valid WebSocket connection, but no `client/hello`, so discovery appears flaky or the speaker appears only transiently.

For ESP32-P4 boards using hosted Wi-Fi, the active network interface MAC can also differ from the chip base MAC. Using the active interface MAC as the fallback client identity avoids requiring each integration to duplicate platform-specific MAC detection.

## Validation

Tested on an ESP32-P4 ESPHome device with ESP-IDF 6.0.1:

- Verified inbound `ws://device:8928/sendspin` returns `client/hello` immediately after WebSocket upgrade.
- Verified `client_id` and `device_info.mac_address` use the hosted Wi-Fi STA MAC.
- Verified Music Assistant discovers the player and playback no longer drops after starting a stream.

Host CMake tests were not run locally because this Windows environment does not have a host C++ compiler on PATH. The available ESPHome firmware build using this branch compiled and ran on-device.

## Documentation

No docs change: this is a transport/identity fallback fix and does not add a user-facing configuration option.
