### PR TITLE
Fix artwork/visualizer role races

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -111,11 +111,13 @@ Receives album artwork images from the server. Requires a configuration struct d
 ```cpp
 ArtworkRoleConfig artwork_config;
 artwork_config.preferred_formats = {
-    {0, SendspinImageSource::ALBUM, SendspinImageFormat::JPEG, 300, 300},
+    {SendspinImageSource::ALBUM, SendspinImageFormat::JPEG, 300, 300},
 };
 
 auto& artwork = client.add_artwork(std::move(artwork_config));
 ```
+
+The slot/channel number for each entry is its position (index) in `preferred_formats`; the first entry is slot 0, the second slot 1, and so on. Up to `ARTWORK_MAX_SLOTS` (4) entries are supported.
 
 ### Visualizer Role (Audio Visualization)
 
@@ -743,15 +745,14 @@ Configuration passed to `client.add_artwork()`.
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `preferred_formats` | `std::vector<ImageSlotPreference>` | `{}` | Image slot preferences advertised to the server during the hello handshake. Each entry declares a slot index, image source, format, and resolution. |
+| `preferred_formats` | `std::vector<ImageSlotPreference>` | `{}` | Image slot preferences advertised to the server during the hello handshake. Each entry declares an image source, format, and resolution; the slot/channel number is the entry's index in this vector. |
 | `psram_stack` | `bool` | `false` | Allocate decode thread stack in PSRAM (ESP-IDF only) |
 | `priority` | `unsigned` | `2` | FreeRTOS priority for the decode thread (ESP-IDF only) |
 
-Each entry in `preferred_formats` is an `ImageSlotPreference`:
+Each entry in `preferred_formats` is an `ImageSlotPreference`. The slot/channel number is the entry's index in `preferred_formats` (first entry is slot 0), so entries are declared in slot order:
 
 | Field | Type | Description |
 |---|---|---|
-| `slot` | `uint8_t` | Artwork slot index (0–3) |
 | `source` | `SendspinImageSource` | Image source (`ALBUM` or `ARTIST`) |
 | `format` | `SendspinImageFormat` | Image format (`JPEG`, `PNG`, or `BMP`) |
 | `width` | `uint16_t` | Desired image width in pixels |

--- a/include/sendspin/artwork_role.h
+++ b/include/sendspin/artwork_role.h
@@ -94,8 +94,8 @@ public:
  *
  * MyArtworkListener listener;
  * ArtworkRoleConfig config;
- * config.preferred_formats = {{0, SendspinImageSource::ALBUM,
- *                               SendspinImageFormat::JPEG, 240, 240}};
+ * config.preferred_formats = {{SendspinImageSource::ALBUM,
+ *                            SendspinImageFormat::JPEG, 240, 240}};
  * auto& artwork = client.add_artwork(config);
  * artwork.set_listener(&listener);
  * @endcode

--- a/include/sendspin/config.h
+++ b/include/sendspin/config.h
@@ -167,10 +167,6 @@ enum class SendspinImageSource : uint8_t {
 
 /// @brief Preference for an image slot's format and resolution
 struct ImageSlotPreference {
-    /// @brief Deprecated and ignored. The channel/slot number is determined by this entry's
-    /// position (index) in ArtworkRoleConfig::preferred_formats, not by this field. Kept only
-    /// for API compatibility.
-    uint8_t slot{};
     SendspinImageSource source{};
     SendspinImageFormat format{};
     uint16_t width{};
@@ -179,10 +175,10 @@ struct ImageSlotPreference {
 
 /// @brief Configuration for the artwork role
 struct ArtworkRoleConfig {
-    /// @brief Slot/channel preferences in order. The array index is the authoritative channel
-    /// slot number (matched against the binary message slot byte and advertised to the server
-    /// in that order); ImageSlotPreference::slot is ignored. Limited to ARTWORK_MAX_SLOTS (4)
-    /// entries; extra entries are truncated with a warning.
+    /// @brief Slot/channel preferences in order. The array index is the channel slot number
+    /// (matched against the binary message slot byte and advertised to the server in that
+    /// order). Limited to ARTWORK_MAX_SLOTS (4) entries; extra entries are truncated with a
+    /// warning.
     std::vector<ImageSlotPreference> preferred_formats{};
     bool psram_stack{false};  ///< Allocate decode thread stack in PSRAM (ESP-IDF only)
     unsigned priority{2};     ///< FreeRTOS priority for the decode thread (ESP-IDF only)

--- a/include/sendspin/config.h
+++ b/include/sendspin/config.h
@@ -167,6 +167,9 @@ enum class SendspinImageSource : uint8_t {
 
 /// @brief Preference for an image slot's format and resolution
 struct ImageSlotPreference {
+    /// @brief Deprecated and ignored. The channel/slot number is determined by this entry's
+    /// position (index) in ArtworkRoleConfig::preferred_formats, not by this field. Kept only
+    /// for API compatibility.
     uint8_t slot{};
     SendspinImageSource source{};
     SendspinImageFormat format{};
@@ -176,6 +179,10 @@ struct ImageSlotPreference {
 
 /// @brief Configuration for the artwork role
 struct ArtworkRoleConfig {
+    /// @brief Slot/channel preferences in order. The array index is the authoritative channel
+    /// slot number (matched against the binary message slot byte and advertised to the server
+    /// in that order); ImageSlotPreference::slot is ignored. Limited to ARTWORK_MAX_SLOTS (4)
+    /// entries; extra entries are truncated with a warning.
     std::vector<ImageSlotPreference> preferred_formats{};
     bool psram_stack{false};  ///< Allocate decode thread stack in PSRAM (ESP-IDF only)
     unsigned priority{2};     ///< FreeRTOS priority for the decode thread (ESP-IDF only)
@@ -211,6 +218,10 @@ struct VisualizerSpectrumConfig {
 
 /// @brief Visualizer capabilities advertised to the server during the hello handshake
 struct VisualizerSupportObject {
+    /// @brief Data types the client wants to receive.
+    /// The order here does not need to match the wire order: VisualizerRole normalizes this
+    /// list internally to LOUDNESS, F_PEAK, SPECTRUM, then BEAT (duplicates removed) before it
+    /// is sent, so the server always packs per-frame fields in the order the client parses them.
     std::vector<VisualizerDataType> types{};
     size_t buffer_capacity{};
     uint8_t batch_max{};

--- a/src/artwork_role.cpp
+++ b/src/artwork_role.cpp
@@ -169,7 +169,9 @@ void ArtworkRole::Impl::handle_binary(uint8_t slot, const uint8_t* data, size_t 
 
     // Signal decode thread with all metadata in the notification
     ArtworkNotification notif{slot, write_idx, image_len, timestamp, image_format};
-    this->drain_task->notify_queue.send(notif, 0);
+    if (!this->drain_task->notify_queue.send(notif, 0)) {
+        SS_LOGW(TAG, "Artwork notify queue full; dropping image for slot %u", slot);
+    }
 }
 
 // ============================================================================
@@ -228,7 +230,9 @@ void ArtworkRole::Impl::handle_stream_end() {
         this->drain_task->event_flags.set(COMMAND_FLUSH);
     }
 
-    this->event_state->queue.send(ArtworkEventType::STREAM_END, 0);
+    if (!this->event_state->queue.send(ArtworkEventType::STREAM_END, 0)) {
+        SS_LOGW(TAG, "Artwork event queue full; dropping STREAM_END");
+    }
 }
 
 void ArtworkRole::Impl::handle_stream_clear() {
@@ -238,7 +242,9 @@ void ArtworkRole::Impl::handle_stream_clear() {
         this->drain_task->event_flags.set(COMMAND_FLUSH);
     }
 
-    this->event_state->queue.send(ArtworkEventType::STREAM_CLEAR, 0);
+    if (!this->event_state->queue.send(ArtworkEventType::STREAM_CLEAR, 0)) {
+        SS_LOGW(TAG, "Artwork event queue full; dropping STREAM_CLEAR");
+    }
 }
 
 // ============================================================================

--- a/src/artwork_role.cpp
+++ b/src/artwork_role.cpp
@@ -37,7 +37,6 @@ static constexpr uint32_t DRAIN_RECEIVE_TIMEOUT_MS = 100U;
 
 // Event flag bits for decode thread signaling
 static constexpr uint32_t COMMAND_STOP = (1 << 0);
-static constexpr uint32_t COMMAND_FLUSH = (1 << 1);
 
 // ============================================================================
 // Big-endian helpers
@@ -64,7 +63,23 @@ ArtworkRole::Impl::Impl(ArtworkRoleConfig config, SendspinClient* client)
       drain_task(std::make_unique<DrainTask>()),
       event_state(std::make_unique<EventState>()),
       display_scheduler(std::make_unique<DisplayScheduler>()) {
-    for (const auto& pref : this->config.preferred_formats) {
+    // The array index (not the `slot` field) is authoritative for channel/slot mapping: the
+    // hello advertises channels in this->artwork_channels order, and handle_binary looks up
+    // this->config.preferred_formats by index to match. The `slot` field is kept for API
+    // compatibility but is otherwise ignored, so warn once if a caller's config disagrees.
+    if (this->config.preferred_formats.size() > ARTWORK_MAX_SLOTS) {
+        SS_LOGW(TAG, "Artwork configured with %zu channels, truncating to %zu",
+                this->config.preferred_formats.size(), ARTWORK_MAX_SLOTS);
+        this->config.preferred_formats.resize(ARTWORK_MAX_SLOTS);
+    }
+    for (size_t i = 0; i < this->config.preferred_formats.size(); ++i) {
+        const auto& pref = this->config.preferred_formats[i];
+        if (pref.slot != i) {
+            SS_LOGW(TAG,
+                    "Artwork channel at index %zu has slot field %u; the slot field is ignored, "
+                    "array index order is authoritative",
+                    i, pref.slot);
+        }
         this->artwork_channels.push_back({pref.source, pref.format, pref.width, pref.height});
     }
     this->event_state->queue.create(8);
@@ -133,42 +148,54 @@ void ArtworkRole::Impl::handle_binary(uint8_t slot, const uint8_t* data, size_t 
     const uint8_t* image_data = data + BINARY_TIMESTAMP_SIZE;
     size_t image_len = len - BINARY_TIMESTAMP_SIZE;
 
-    // Look up format for this slot
+    // Look up format by array index (authoritative), not by matching the deprecated `slot`
+    // field. See the Impl constructor comment for why the index is authoritative.
     SendspinImageFormat image_format = SendspinImageFormat::JPEG;
-    for (const auto& pref : this->config.preferred_formats) {
-        if (pref.slot == slot) {
-            image_format = pref.format;
-            break;
+    if (slot < this->config.preferred_formats.size()) {
+        image_format = this->config.preferred_formats[slot].format;
+    }
+
+    uint32_t generation = 0;
+    uint8_t write_idx = 0;
+    {
+        // Hold the slot mutex across the read-modify-write of write_idx/drain_active/
+        // write_generation and the memcpy itself, so the decode thread can never observe a
+        // buffer mid-write (torn image) and can never have a buffer stolen out from under it
+        // while it still owns the notification for that generation.
+        std::lock_guard<std::mutex> lock(this->drain_task->slot_mutex);
+        auto& sb = this->drain_task->slot_buffers[slot];
+        write_idx = sb.write_idx;
+
+        // If the decode thread is actively using this buffer, skip to the other one.
+        // If the decode thread is using the other one, this write_idx is already safe.
+        if (sb.drain_active && sb.drain_buf_idx == write_idx) {
+            write_idx ^= 1;
         }
-    }
 
-    // Copy into the back buffer for this slot (grow-only)
-    auto& sb = this->drain_task->slot_buffers[slot];
-    uint8_t write_idx = sb.write_idx.load(std::memory_order_acquire);
+        auto& buf = sb.buffers[write_idx];
 
-    // If the decode thread is actively using this buffer, skip to the other one.
-    // If the decode thread is using the other one, this write_idx is already safe.
-    if (sb.drain_active.load(std::memory_order_acquire) && sb.drain_buf_idx == write_idx) {
-        write_idx ^= 1;
-    }
-
-    auto& buf = sb.buffers[write_idx];
-
-    if (buf.size() < image_len) {
-        if (!buf.realloc(image_len)) {
-            SS_LOGE(TAG, "Failed to allocate artwork buffer for slot %d (%zu bytes)", slot,
-                    image_len);
-            return;
+        if (buf.size() < image_len) {
+            if (!buf.realloc(image_len)) {
+                SS_LOGE(TAG, "Failed to allocate artwork buffer for slot %d (%zu bytes)", slot,
+                        image_len);
+                return;
+            }
         }
+
+        std::memcpy(buf.data(), image_data, image_len);
+
+        // Bump this buffer's generation so the decode thread can detect if it gets
+        // overwritten again before being claimed, then flip write_idx so the next network
+        // write goes to the other buffer.
+        sb.write_generation[write_idx]++;
+        generation = sb.write_generation[write_idx];
+        sb.write_idx = write_idx ^ 1;
     }
-
-    std::memcpy(buf.data(), image_data, image_len);
-
-    // Flip write index so the next network write goes to the other buffer
-    sb.write_idx.store(write_idx ^ 1, std::memory_order_release);
 
     // Signal decode thread with all metadata in the notification
-    ArtworkNotification notif{slot, write_idx, image_len, timestamp, image_format};
+    uint32_t epoch = this->stream_epoch.load(std::memory_order_relaxed);
+    ArtworkNotification notif{slot,         write_idx,  image_len, timestamp,
+                              image_format, generation, epoch};
     if (!this->drain_task->notify_queue.send(notif, 0)) {
         SS_LOGW(TAG, "Artwork notify queue full; dropping image for slot %u", slot);
     }
@@ -211,10 +238,12 @@ void ArtworkRole::Impl::handle_stream_start(const ServerArtworkStreamObject& str
 
     this->stream_active = true;
 
-    // Signal decode thread to flush any stale notifications
-    if (this->drain_task) {
-        this->drain_task->event_flags.set(COMMAND_FLUSH);
-    }
+    // Bump the stream epoch so any notification still in the queue from a prior stream is
+    // recognized as stale by the decode thread and skipped, rather than draining the whole
+    // notify queue here (which could wrongly discard this new stream's first image if it was
+    // already queued before this handler ran).
+    this->stream_epoch.fetch_add(1, std::memory_order_relaxed);
+
     // Discard any pending displays from a prior stream
     if (this->display_scheduler) {
         for (auto& slot : this->display_scheduler->pending) {
@@ -225,10 +254,7 @@ void ArtworkRole::Impl::handle_stream_start(const ServerArtworkStreamObject& str
 
 void ArtworkRole::Impl::handle_stream_end() {
     this->stream_active = false;
-
-    if (this->drain_task) {
-        this->drain_task->event_flags.set(COMMAND_FLUSH);
-    }
+    this->stream_epoch.fetch_add(1, std::memory_order_relaxed);
 
     if (!this->event_state->queue.send(ArtworkEventType::STREAM_END, 0)) {
         SS_LOGW(TAG, "Artwork event queue full; dropping STREAM_END");
@@ -237,10 +263,7 @@ void ArtworkRole::Impl::handle_stream_end() {
 
 void ArtworkRole::Impl::handle_stream_clear() {
     this->stream_active = false;
-
-    if (this->drain_task) {
-        this->drain_task->event_flags.set(COMMAND_FLUSH);
-    }
+    this->stream_epoch.fetch_add(1, std::memory_order_relaxed);
 
     if (!this->event_state->queue.send(ArtworkEventType::STREAM_CLEAR, 0)) {
         SS_LOGW(TAG, "Artwork event queue full; dropping STREAM_CLEAR");
@@ -265,8 +288,9 @@ void ArtworkRole::Impl::drain_events() {
                     }
                 }
                 if (this->listener) {
-                    for (const auto& pref : this->config.preferred_formats) {
-                        this->listener->on_image_clear(pref.slot);
+                    // Array index is the authoritative slot number; see the Impl constructor.
+                    for (size_t i = 0; i < this->config.preferred_formats.size(); ++i) {
+                        this->listener->on_image_clear(static_cast<uint8_t>(i));
                     }
                 }
                 break;
@@ -303,10 +327,7 @@ void ArtworkRole::Impl::drain_events() {
 
 void ArtworkRole::Impl::cleanup() {
     this->stream_active = false;
-
-    if (this->drain_task) {
-        this->drain_task->event_flags.set(COMMAND_FLUSH);
-    }
+    this->stream_epoch.fetch_add(1, std::memory_order_relaxed);
 
     if (this->display_scheduler) {
         for (auto& pending : this->display_scheduler->pending) {
@@ -330,15 +351,9 @@ void ArtworkRole::Impl::drain_thread_func(ArtworkRole::Impl* self) {
 
     while (true) {
         // Non-blocking check for commands
-        uint32_t cmd = flags.wait(COMMAND_STOP | COMMAND_FLUSH, false, true, 0);
+        uint32_t cmd = flags.wait(COMMAND_STOP, false, true, 0);
         if (cmd & COMMAND_STOP) {
             break;
-        }
-        if (cmd & COMMAND_FLUSH) {
-            // Drain all pending notifications without processing
-            ArtworkNotification dummy{};
-            while (queue.receive(dummy, 0)) {}
-            continue;
         }
 
         // Blocking receive with 100ms timeout (allows periodic command checks)
@@ -353,22 +368,45 @@ void ArtworkRole::Impl::drain_thread_func(ArtworkRole::Impl* self) {
             continue;
         }
 
-        auto& sb = self->drain_task->slot_buffers[slot];
-        auto& buf = sb.buffers[buf_idx];
+        uint8_t* decode_data = nullptr;
+        size_t decode_length = 0;
+        {
+            // Validate the notification is still current before touching the buffer: a newer
+            // stream (stream_epoch changed) or a newer write to the same buffer (write_generation
+            // changed) means this notification is stale and the bytes it names may have already
+            // been overwritten by the network thread, or are about to be. Skip it instead of
+            // risking a torn read; a fresher notification for the same slot is already queued or
+            // on its way.
+            std::lock_guard<std::mutex> lock(self->drain_task->slot_mutex);
+            auto& sb = self->drain_task->slot_buffers[slot];
 
-        if (notif.data_length == 0 || buf.data() == nullptr) {
-            continue;
+            if (notif.stream_epoch != self->stream_epoch.load(std::memory_order_relaxed)) {
+                continue;
+            }
+            if (notif.generation != sb.write_generation[buf_idx]) {
+                continue;
+            }
+
+            auto& buf = sb.buffers[buf_idx];
+            if (notif.data_length == 0 || buf.data() == nullptr) {
+                continue;
+            }
+
+            // Mark this buffer as in-use so the network thread avoids it while we decode.
+            sb.drain_buf_idx = buf_idx;
+            sb.drain_active = true;
+            decode_data = buf.data();
+            decode_length = notif.data_length;
         }
-
-        // Mark this buffer as in-use so the network thread avoids it
-        sb.drain_buf_idx = buf_idx;
-        sb.drain_active.store(true, std::memory_order_release);
 
         if (self->listener) {
-            self->listener->on_image_decode(slot, buf.data(), notif.data_length, notif.format);
+            self->listener->on_image_decode(slot, decode_data, decode_length, notif.format);
         }
 
-        sb.drain_active.store(false, std::memory_order_release);
+        {
+            std::lock_guard<std::mutex> lock(self->drain_task->slot_mutex);
+            self->drain_task->slot_buffers[slot].drain_active = false;
+        }
 
         // Hand off the timestamp to the main loop. Skip if the stream ended while we were
         // decoding so the main loop doesn't fire a display after on_image_clear.

--- a/src/artwork_role.cpp
+++ b/src/artwork_role.cpp
@@ -63,23 +63,15 @@ ArtworkRole::Impl::Impl(ArtworkRoleConfig config, SendspinClient* client)
       drain_task(std::make_unique<DrainTask>()),
       event_state(std::make_unique<EventState>()),
       display_scheduler(std::make_unique<DisplayScheduler>()) {
-    // The array index (not the `slot` field) is authoritative for channel/slot mapping: the
-    // hello advertises channels in this->artwork_channels order, and handle_binary looks up
-    // this->config.preferred_formats by index to match. The `slot` field is kept for API
-    // compatibility but is otherwise ignored, so warn once if a caller's config disagrees.
+    // The array index is authoritative for channel/slot mapping: the hello advertises channels
+    // in this->artwork_channels order, and handle_binary looks up this->config.preferred_formats
+    // by index to match.
     if (this->config.preferred_formats.size() > ARTWORK_MAX_SLOTS) {
         SS_LOGW(TAG, "Artwork configured with %zu channels, truncating to %zu",
                 this->config.preferred_formats.size(), ARTWORK_MAX_SLOTS);
         this->config.preferred_formats.resize(ARTWORK_MAX_SLOTS);
     }
-    for (size_t i = 0; i < this->config.preferred_formats.size(); ++i) {
-        const auto& pref = this->config.preferred_formats[i];
-        if (pref.slot != i) {
-            SS_LOGW(TAG,
-                    "Artwork channel at index %zu has slot field %u; the slot field is ignored, "
-                    "array index order is authoritative",
-                    i, pref.slot);
-        }
+    for (const auto& pref : this->config.preferred_formats) {
         this->artwork_channels.push_back({pref.source, pref.format, pref.width, pref.height});
     }
     this->event_state->queue.create(8);
@@ -148,8 +140,8 @@ void ArtworkRole::Impl::handle_binary(uint8_t slot, const uint8_t* data, size_t 
     const uint8_t* image_data = data + BINARY_TIMESTAMP_SIZE;
     size_t image_len = len - BINARY_TIMESTAMP_SIZE;
 
-    // Look up format by array index (authoritative), not by matching the deprecated `slot`
-    // field. See the Impl constructor comment for why the index is authoritative.
+    // Look up format by array index. See the Impl constructor comment for why the index is
+    // authoritative for slot mapping.
     SendspinImageFormat image_format = SendspinImageFormat::JPEG;
     if (slot < this->config.preferred_formats.size()) {
         image_format = this->config.preferred_formats[slot].format;

--- a/src/artwork_role_impl.h
+++ b/src/artwork_role_impl.h
@@ -28,6 +28,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <thread>
 #include <vector>
 
@@ -46,11 +47,21 @@ enum class ArtworkEventType : uint8_t {
 static constexpr size_t ARTWORK_MAX_SLOTS = 4;
 
 /// @brief Double-buffered image storage for a single artwork slot
+///
+/// All fields here are guarded by DrainTask::slot_mutex (shared across all slots; artwork is
+/// not a hot path so contention is negligible). The network thread and decode thread both read
+/// and write these fields, so they must never be touched outside that lock:
+///  - write_idx: which buffer the network thread writes to next.
+///  - drain_active / drain_buf_idx: which buffer the decode thread is currently decoding.
+///  - write_generation[i]: bumped every time buffers[i] is overwritten by the network thread.
+///    The decode thread compares this against the generation stamped on the notification it
+///    dequeued to detect whether the buffer was overwritten again before it could be claimed.
 struct SlotBuffer {
     PlatformBuffer buffers[2];
-    std::atomic<uint8_t> write_idx{0};      ///< Which buffer the network thread writes to next
-    std::atomic<bool> drain_active{false};  ///< True while the decode thread is using a buffer
-    uint8_t drain_buf_idx{0};               ///< Which buffer the decode thread is currently using
+    uint8_t write_idx{0};
+    bool drain_active{false};
+    uint8_t drain_buf_idx{0};
+    uint32_t write_generation[2]{0, 0};
 };
 
 /// @brief Notification sent from the network thread to the decode thread when new image data
@@ -59,12 +70,19 @@ struct SlotBuffer {
 /// All metadata is carried in the notification itself (not in SlotBuffer) so that the
 /// ThreadSafeQueue's internal mutex provides the happens-before guarantee between the
 /// network thread's writes and the decode thread's reads.
+///
+/// `generation` and `stream_epoch` let the decode thread detect a stale notification: if the
+/// buffer it names has since been overwritten (generation mismatch) or the stream has moved on
+/// (stream_epoch mismatch), the notification is skipped rather than decoding torn or
+/// superseded data. See ArtworkRole::Impl::drain_thread_func.
 struct ArtworkNotification {
     uint8_t slot;
     uint8_t buffer_idx;
     size_t data_length;
     int64_t timestamp;
     SendspinImageFormat format;
+    uint32_t generation;
+    uint32_t stream_epoch;
 };
 
 /// @brief Private implementation of the artwork role
@@ -82,6 +100,9 @@ struct ArtworkRole::Impl {
         EventFlags event_flags;
         std::thread drain_thread;
         SlotBuffer slot_buffers[ARTWORK_MAX_SLOTS];
+        /// @brief Guards every field of every entry in slot_buffers. One mutex for all slots
+        /// is intentional: artwork is not a hot path, so cross-slot contention is negligible.
+        std::mutex slot_mutex;
     };
 
     /// @brief Deferred event state for thread-safe artwork stream lifecycle delivery
@@ -136,6 +157,12 @@ struct ArtworkRole::Impl {
 
     // 8-bit fields
     std::atomic<bool> stream_active{false};
+
+    /// @brief Bumped on stream start/end/clear/cleanup so in-flight notifications from a
+    /// previous stream are recognized as stale and skipped by the decode thread, instead of
+    /// relying on draining the notify queue (which could discard a new stream's first image
+    /// if it was queued before the flush was serviced).
+    std::atomic<uint32_t> stream_epoch{0};
 };
 
 }  // namespace sendspin

--- a/src/visualizer_role.cpp
+++ b/src/visualizer_role.cpp
@@ -81,8 +81,9 @@ namespace {
 // fields in an order the parser cannot decode correctly. Reorder (and de-duplicate) the
 // advertised types here so the wire order always matches the parser, regardless of what
 // order the caller populated VisualizerRoleConfig::support.types in. BEAT is not a per-frame
-// field (it arrives as a separate binary message type), so it is kept but sorted last along
-// with any other/unknown type.
+// field (it arrives as a separate binary message type), so it is kept but sorted last. Any
+// type the parser does not recognize is dropped, since the fixed-order parser cannot decode a
+// field it does not understand.
 std::vector<VisualizerDataType> normalize_type_order(const std::vector<VisualizerDataType>& types) {
     bool has_loudness = false;
     bool has_f_peak = false;
@@ -503,9 +504,11 @@ void VisualizerRole::Impl::drain_thread_func(VisualizerRole::Impl* self) {
                 offset += 2;
             }
             if ((frame_flags & FLAG_HAS_SPECTRUM) && bin_count > 0) {
-                // resize() only reallocates when growing past the current capacity; once the
-                // largest bin_count has been seen, subsequent frames reuse the same allocation.
-                frame.spectrum.resize(bin_count);
+                // assign() zero-initializes all bin_count elements and reuses the existing
+                // allocation when capacity suffices (no per-frame heap churn). Zeroing up front
+                // means a short or corrupt entry that exits the fill loop early cannot leak
+                // stale bins from a previous frame through the reused vector.
+                frame.spectrum.assign(bin_count, 0);
                 for (uint8_t b = 0; b < bin_count && offset + 2 <= data_len; ++b) {
                     frame.spectrum[b] = read_be16(fields + offset);
                     offset += 2;

--- a/src/visualizer_role.cpp
+++ b/src/visualizer_role.cpp
@@ -72,6 +72,54 @@ static uint16_t read_be16(const uint8_t* p) {
 
 namespace sendspin {
 
+namespace {
+
+// The server packs per-frame fields in the order of the `types` list advertised in the
+// client's hello (see ClientHelloMessage::visualizer_support), but the drain thread parser
+// always reads fields in a fixed order: LOUDNESS, then F_PEAK, then SPECTRUM (see
+// drain_thread_func below). If the advertised order did not match, the server would pack
+// fields in an order the parser cannot decode correctly. Reorder (and de-duplicate) the
+// advertised types here so the wire order always matches the parser, regardless of what
+// order the caller populated VisualizerRoleConfig::support.types in. BEAT is not a per-frame
+// field (it arrives as a separate binary message type), so it is kept but sorted last along
+// with any other/unknown type.
+std::vector<VisualizerDataType> normalize_type_order(const std::vector<VisualizerDataType>& types) {
+    bool has_loudness = false;
+    bool has_f_peak = false;
+    bool has_spectrum = false;
+    bool has_beat = false;
+
+    for (auto type : types) {
+        if (type == VisualizerDataType::LOUDNESS) {
+            has_loudness = true;
+        } else if (type == VisualizerDataType::F_PEAK) {
+            has_f_peak = true;
+        } else if (type == VisualizerDataType::SPECTRUM) {
+            has_spectrum = true;
+        } else if (type == VisualizerDataType::BEAT) {
+            has_beat = true;
+        }
+    }
+
+    std::vector<VisualizerDataType> ordered;
+    ordered.reserve(types.size());
+    if (has_loudness) {
+        ordered.push_back(VisualizerDataType::LOUDNESS);
+    }
+    if (has_f_peak) {
+        ordered.push_back(VisualizerDataType::F_PEAK);
+    }
+    if (has_spectrum) {
+        ordered.push_back(VisualizerDataType::SPECTRUM);
+    }
+    if (has_beat) {
+        ordered.push_back(VisualizerDataType::BEAT);
+    }
+    return ordered;
+}
+
+}  // namespace
+
 // ============================================================================
 // Impl constructor / destructor
 // ============================================================================
@@ -84,6 +132,10 @@ VisualizerRole::Impl::Impl(VisualizerRoleConfig config, SendspinClient* client)
     this->event_state->queue.create(8);
 
     if (this->visualizer_support.has_value()) {
+        // Normalize the advertised type order so the server packs fields in the order the
+        // drain thread parser expects. See normalize_type_order() above for the constraint.
+        this->visualizer_support->types = normalize_type_order(this->visualizer_support->types);
+
         this->drain_task = std::make_unique<DrainTask>();
 
         // The ring buffer needs more space than the raw data capacity because each entry
@@ -358,6 +410,10 @@ void VisualizerRole::Impl::drain_thread_func(VisualizerRole::Impl* self) {
     auto& rb = self->drain_task->ring_buffer;
     auto& flags = self->drain_task->event_flags;
 
+    // Reused across iterations to avoid a heap alloc/free per frame. The spectrum vector's
+    // capacity grows to the largest bin_count seen and is resized (not reallocated) after that.
+    VisualizerFrame frame{};
+
     while (true) {
         // Non-blocking check for commands
         uint32_t cmd = flags.wait(COMMAND_STOP | COMMAND_FLUSH, false, true, 0);
@@ -433,8 +489,10 @@ void VisualizerRole::Impl::drain_thread_func(VisualizerRole::Impl* self) {
             size_t data_len = item_size - FRAME_HEADER_SIZE - TIMESTAMP_SIZE;
             size_t offset = 0;
 
-            VisualizerFrame frame{};
+            // Reset all fields so no stale data from a previous frame leaks through.
             frame.timestamp = client_ts;
+            frame.loudness.reset();
+            frame.peak_freq.reset();
 
             if ((frame_flags & FLAG_HAS_LOUDNESS) && offset + 2 <= data_len) {
                 frame.loudness = read_be16(fields + offset);
@@ -445,11 +503,15 @@ void VisualizerRole::Impl::drain_thread_func(VisualizerRole::Impl* self) {
                 offset += 2;
             }
             if ((frame_flags & FLAG_HAS_SPECTRUM) && bin_count > 0) {
+                // resize() only reallocates when growing past the current capacity; once the
+                // largest bin_count has been seen, subsequent frames reuse the same allocation.
                 frame.spectrum.resize(bin_count);
                 for (uint8_t b = 0; b < bin_count && offset + 2 <= data_len; ++b) {
                     frame.spectrum[b] = read_be16(fields + offset);
                     offset += 2;
                 }
+            } else {
+                frame.spectrum.clear();
             }
 
             rb.return_item(item);

--- a/src/visualizer_role.cpp
+++ b/src/visualizer_role.cpp
@@ -263,7 +263,9 @@ void VisualizerRole::Impl::handle_stream_start(const ServerVisualizerStreamObjec
 
     // Shadow the config for main-thread callback, then signal
     this->event_state->shadow_config.write(stream);
-    this->event_state->queue.send(VisualizerEventType::STREAM_START, 0);
+    if (!this->event_state->queue.send(VisualizerEventType::STREAM_START, 0)) {
+        SS_LOGW(TAG, "Visualizer event queue full; dropping STREAM_START");
+    }
 }
 
 void VisualizerRole::Impl::handle_stream_end() {
@@ -273,7 +275,9 @@ void VisualizerRole::Impl::handle_stream_end() {
         this->drain_task->event_flags.set(COMMAND_FLUSH);
     }
 
-    this->event_state->queue.send(VisualizerEventType::STREAM_END, 0);
+    if (!this->event_state->queue.send(VisualizerEventType::STREAM_END, 0)) {
+        SS_LOGW(TAG, "Visualizer event queue full; dropping STREAM_END");
+    }
 }
 
 void VisualizerRole::Impl::handle_stream_clear() {
@@ -283,7 +287,9 @@ void VisualizerRole::Impl::handle_stream_clear() {
         this->drain_task->event_flags.set(COMMAND_FLUSH);
     }
 
-    this->event_state->queue.send(VisualizerEventType::STREAM_CLEAR, 0);
+    if (!this->event_state->queue.send(VisualizerEventType::STREAM_CLEAR, 0)) {
+        SS_LOGW(TAG, "Visualizer event queue full; dropping STREAM_CLEAR");
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
Fixes concurrency bugs in the artwork and visualizer roles and simplifies artwork slot configuration. The artwork decode path could race with the network thread (torn/stale images); slot configuration required a redundant explicit index. Visualizer field parsing depended on the caller advertising data types in exactly the right order.

## Changes

**Artwork:**

- Guard the double-buffer swap, write, and generation bump under a single `slot_mutex` so the decode thread can never observe a buffer mid-write.
- Adds per-buffer `write_generation + a stream_epoch` so the decode thread skips notifications whose bytes were overwritten or that belong to a prior stream, instead of decoding torn/stale data.
- Replaces the `COMMAND_FLUSH` queue-drain on stream start with `stream_epoch`,
fixing a bug where a new stream's first image could be dropped.
- Positional slot mapping (see breaking change below).
- Logs dropped images/events when the notify/event queue is full.
- Updates the relevant portion in the integration guide document 

**Visualizer:**
(Note this is still the draft visualizer role and not the v1 in the spec. I'm making these changes now to more easily update to the v1 role in a future PR.)

- Normalize the advertised types order (`LOUDNESS`, `F_PEAK`, `SPECTRUM`, then
`BEAT`; deduped) so the wire order always matches the parser regardless of the
order the caller populated `support.types`.
- Reuse the `VisualizerFrame` across frames to drop a per-frame heap alloc/free; all fields are reset each iteration.
- Log dropped lifecycle events on queue overflow.

## Breaking Change Description

`ImageSlotPreference` no longer has a `slot` field. The slot/channel number
is now the entry's **index** in `ArtworkRoleConfig::preferred_formats` — the
first entry is slot 0, the second slot 1, etc. (max `ARTWORK_MAX_SLOTS` = 4;
extra entries are truncated with a warning).

```cpp
// Before
artwork_config.preferred_formats = {
    {0, SendspinImageSource::ALBUM, SendspinImageFormat::JPEG, 300, 300},
};
// After — declare entries in slot order, no leading index
artwork_config.preferred_formats = {
    {SendspinImageSource::ALBUM, SendspinImageFormat::JPEG, 300, 300},
};
```