### PR TITLE
Audio player lifecycle & threading fixes

### DIFF
--- a/include/sendspin/controller_role.h
+++ b/include/sendspin/controller_role.h
@@ -109,7 +109,7 @@ public:
  * auto& controller = client.add_controller();
  * controller.set_listener(&listener);
  * controller.send_command(SendspinControllerCommand::PLAY);
- * controller.send_command(SendspinControllerCommand::VOLUME, 128);
+ * controller.send_command(SendspinControllerCommand::VOLUME, 75);  // volume range is 0-100
  * @endcode
  */
 class ControllerRole {

--- a/include/sendspin/player_role.h
+++ b/include/sendspin/player_role.h
@@ -83,9 +83,12 @@ public:
     ///
     /// Fires on the sync task's background thread. May block up to timeout_ms.
     /// @param data Pointer to the decoded PCM audio data
-    /// @param length Number of bytes to write
+    /// @param length Number of bytes to write; always a whole number of PCM frames
     /// @param timeout_ms Maximum time to wait for the write to complete
-    /// @return Number of bytes actually written
+    /// @return Number of bytes actually written. Partial writes are allowed but MUST be a
+    /// whole number of PCM frames (a multiple of channels * bytes-per-sample): the sync task
+    /// counts played frames from this value, so a mid-frame count drifts the playtime estimate
+    /// and starts the next write mid-frame.
     virtual size_t on_audio_write(uint8_t* data, size_t length, uint32_t timeout_ms) = 0;
 
     /// @brief Called when a new audio stream starts. Fires on the main loop thread
@@ -206,7 +209,7 @@ public:
     uint16_t get_static_delay_ms() const;
 
     /// @brief Returns the current volume level
-    /// @return Current volume level (0-255).
+    /// @return Current volume level (0-100).
     uint8_t get_volume() const;
 
 private:

--- a/src/audio_types.h
+++ b/src/audio_types.h
@@ -26,7 +26,6 @@ namespace sendspin {
 /// Not part of the protocol specification.
 enum ChunkType : uint8_t {
     CHUNK_TYPE_ENCODED_AUDIO = 0,    // Raw encoded audio data
-    CHUNK_TYPE_DECODED_AUDIO,        // Already-decoded PCM frames
     CHUNK_TYPE_PCM_DUMMY_HEADER,     // Synthetic header for PCM streams
     CHUNK_TYPE_OPUS_DUMMY_HEADER,    // Synthetic header for Opus streams
     CHUNK_TYPE_FLAC_HEADER,          // FLAC stream header block

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -379,11 +379,16 @@ void SendspinClient::acquire_high_performance() {
 }
 
 void SendspinClient::release_high_performance() {
-    if (this->high_performance_ref_count_.load() == 0) {
-        return;
-    }
-    if (this->high_performance_ref_count_.fetch_sub(1) == 1 && this->listener_) {
-        this->listener_->on_release_high_performance();
+    // Compare-exchange loop so two concurrent releases at count 1 can't both pass a
+    // plain zero-check and underflow the counter
+    uint8_t count = this->high_performance_ref_count_.load();
+    while (count != 0) {
+        if (this->high_performance_ref_count_.compare_exchange_weak(count, count - 1)) {
+            if (count == 1 && this->listener_) {
+                this->listener_->on_release_high_performance();
+            }
+            return;
+        }
     }
 }
 
@@ -651,7 +656,9 @@ void SendspinClient::process_json_message(SendspinConnection* conn, const char* 
             int64_t offset{0};
             int64_t max_error{0};
             if (process_server_time_message(root, timestamp, &offset, &max_error)) {
-                this->event_state_->time_queue.send({offset, max_error, timestamp}, 0);
+                if (!this->event_state_->time_queue.send({offset, max_error, timestamp}, 0)) {
+                    SS_LOGW(TAG, "Time response queue full; dropping measurement");
+                }
             }
             break;
         }

--- a/src/platform/spsc_ring_buffer.h
+++ b/src/platform/spsc_ring_buffer.h
@@ -204,6 +204,13 @@ public:
     /// @param storage Pointer to pre-allocated storage (must outlive this object).
     /// @return true on success.
     bool create(size_t size, uint8_t* storage) {
+        // Item offsets always advance in ALIGNMENT multiples, so an unaligned tail would
+        // desynchronize the writer/reader dummy-filler accounting (and a tail smaller than
+        // ItemHeader can never hold the wrap marker). Ignore any trailing remainder.
+        size &= ~(ALIGNMENT - 1);
+        if (size < sizeof(ItemHeader) + ALIGNMENT) {
+            return false;
+        }
         this->storage_ = storage;
         this->storage_size_ = size;
         this->write_offset_ = 0;

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -239,7 +239,7 @@ SS_HOT void PlayerRole::Impl::handle_binary(const uint8_t* data, size_t len) con
 void PlayerRole::Impl::handle_stream_start(const ServerPlayerStreamObject& player_obj) {
     if (this->config.audio_formats.empty()) {
         // No audio formats, just defer stream start callback
-        this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_START, 0);
+        this->enqueue_stream_event(PlayerStreamCallbackType::STREAM_START);
         return;
     }
 
@@ -286,24 +286,20 @@ void PlayerRole::Impl::handle_stream_start(const ServerPlayerStreamObject& playe
 
     if (!header_sent) {
         this->sync_task->signal_stream_end();
-        this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_END, 0);
+        this->enqueue_stream_event(PlayerStreamCallbackType::STREAM_END);
         return;
     }
 
-    // Request high-performance networking for playback
-    if (!this->high_performance_requested_for_playback) {
-        this->client->acquire_high_performance();
-        this->high_performance_requested_for_playback = true;
-    }
-
-    // Shadow stream params for main thread, then signal
+    // Shadow stream params for main thread, then signal. The high-performance acquire for
+    // playback happens when the main loop drains the STREAM_START event, keeping
+    // high_performance_requested_for_playback main-thread-only.
     this->event_state->shadow_stream_params.write(player_obj);
-    this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_START, 0);
+    this->enqueue_stream_event(PlayerStreamCallbackType::STREAM_START);
 }
 
 void PlayerRole::Impl::handle_stream_end() const {
     this->sync_task->signal_stream_end();
-    this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_END, 0);
+    this->enqueue_stream_event(PlayerStreamCallbackType::STREAM_END);
 }
 
 void PlayerRole::Impl::handle_stream_clear() const {
@@ -417,15 +413,28 @@ void PlayerRole::Impl::drain_events() {
 
             switch (event) {
                 case PlayerStreamCallbackType::STREAM_END:
-                    if (this->listener) {
+                    // Only fire the callback when a stream is actually open: cleanup() enqueues
+                    // an unconditional STREAM_END (and a failed stream start enqueues one with no
+                    // preceding START), so gating here keeps on_stream_end() paired 1:1 with
+                    // on_stream_start()
+                    if (this->listener && this->stream_active) {
                         this->listener->on_stream_end();
                     }
+                    this->stream_active = false;
                     if (this->high_performance_requested_for_playback) {
                         this->client->release_high_performance();
                         this->high_performance_requested_for_playback = false;
                     }
                     break;
                 case PlayerStreamCallbackType::STREAM_START: {
+                    // Request high-performance networking for playback (deferred from the
+                    // network thread's handle_stream_start so the listener callback and the
+                    // pairing flag stay on the main thread)
+                    if (!this->config.audio_formats.empty() &&
+                        !this->high_performance_requested_for_playback) {
+                        this->client->acquire_high_performance();
+                        this->high_performance_requested_for_playback = true;
+                    }
                     ServerPlayerStreamObject stream_params;
                     if (this->event_state->shadow_stream_params.take(stream_params)) {
                         this->current_stream_params = std::move(stream_params);
@@ -433,7 +442,12 @@ void PlayerRole::Impl::drain_events() {
                     if (this->listener) {
                         this->listener->on_stream_start();
                     }
+                    this->stream_active = true;
                     this->sync_task->signal_stream_start();
+                    // The sync task sets TASK_RUNNING asynchronously after this signal, so the
+                    // pre-loop snapshot is stale now: a STREAM_END later in this same batch must
+                    // wait for the just-started task to drain
+                    sync_idle = false;
                     break;
                 }
             }
@@ -459,7 +473,8 @@ void PlayerRole::Impl::cleanup() {
     this->event_state->shadow_stream_params.reset();
     this->event_state->shadow_command.reset();
 
-    // Enqueue a clean STREAM_END - drain_events() will fire the callback
+    // Enqueue a clean STREAM_END - drain_events() will fire the callback (the queue was just
+    // reset, so this send cannot fail)
     this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_END, 0);
 
     // Clear awaiting events too (main-thread only, no mutex needed)
@@ -487,7 +502,20 @@ bool PlayerRole::Impl::send_audio_chunk(const uint8_t* data, size_t data_size, i
 }
 
 void PlayerRole::Impl::enqueue_state_update(SendspinClientState state) const {
-    this->event_state->state_queue.send(state, 0);
+    if (!this->event_state->state_queue.send(state, 0)) {
+        // The drain takes only the newest state, so a dropped older one is recoverable -- but
+        // a full queue means the main loop has stalled for several ticks
+        SS_LOGW(TAG, "Client state queue full; dropping state update");
+    }
+}
+
+void PlayerRole::Impl::enqueue_stream_event(PlayerStreamCallbackType event) const {
+    if (!this->event_state->stream_queue.send(event, 0)) {
+        // A lost STREAM_START would leave the sync task waiting for its start signal forever;
+        // a lost STREAM_END would leave the consumer believing the stream is still active
+        SS_LOGE(TAG, "Stream event queue full; dropping %s event",
+                event == PlayerStreamCallbackType::STREAM_START ? "STREAM_START" : "STREAM_END");
+    }
 }
 
 void PlayerRole::Impl::load_static_delay() {

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -236,7 +236,7 @@ SS_HOT void PlayerRole::Impl::handle_binary(const uint8_t* data, size_t len) con
     }
 }
 
-void PlayerRole::Impl::handle_stream_start(const ServerPlayerStreamObject& player_obj) {
+void PlayerRole::Impl::handle_stream_start(const ServerPlayerStreamObject& player_obj) const {
     if (this->config.audio_formats.empty()) {
         // No audio formats, just defer stream start callback
         this->enqueue_stream_event(PlayerStreamCallbackType::STREAM_START);

--- a/src/player_role_impl.h
+++ b/src/player_role_impl.h
@@ -63,7 +63,7 @@ struct PlayerRole::Impl {
     void build_hello_fields(ClientHelloMessage& msg);
     void build_state_fields(ClientStateMessage& msg) const;
     void handle_binary(const uint8_t* data, size_t len) const;
-    void handle_stream_start(const ServerPlayerStreamObject& player_obj);
+    void handle_stream_start(const ServerPlayerStreamObject& player_obj) const;
     void handle_stream_end() const;
     void handle_stream_clear() const;
     void handle_server_command(const ServerCommandMessage& cmd) const;

--- a/src/player_role_impl.h
+++ b/src/player_role_impl.h
@@ -85,6 +85,7 @@ struct PlayerRole::Impl {
     bool send_audio_chunk(const uint8_t* data, size_t data_size, int64_t timestamp,
                           uint8_t chunk_type, uint32_t timeout_ms) const;
     void enqueue_state_update(SendspinClientState state) const;
+    void enqueue_stream_event(PlayerStreamCallbackType event) const;
     void load_static_delay();
     void persist_static_delay() const;
     uint16_t get_effective_static_delay_ms() const;
@@ -111,6 +112,9 @@ struct PlayerRole::Impl {
     // 8-bit fields
     bool high_performance_requested_for_playback{false};
     bool muted{false};
+    // True between the drained STREAM_START and STREAM_END callbacks (main-thread only); keeps
+    // on_stream_end() from firing without a matching on_stream_start()
+    bool stream_active{false};
     std::atomic<bool> static_delay_adjustable{false};
     uint8_t volume{0};
 };

--- a/src/sync_task.cpp
+++ b/src/sync_task.cpp
@@ -143,14 +143,26 @@ bool SyncTask::start(bool task_stack_in_psram, unsigned priority) {
 // ============================================================================
 
 void SyncTask::signal_stream_end() {
+    // The player role signals lifecycle events unconditionally, but init() only runs when the
+    // role has audio formats and a listener; on ESP, setting bits on uncreated event flags is a
+    // null-handle crash, so all signal/query paths guard on is_initialized().
+    if (!this->is_initialized()) {
+        return;
+    }
     this->event_flags_.set(EventGroupBits::COMMAND_STREAM_END);
 }
 
 void SyncTask::signal_stream_clear() {
+    if (!this->is_initialized()) {
+        return;
+    }
     this->event_flags_.set(EventGroupBits::COMMAND_STREAM_CLEAR);
 }
 
 void SyncTask::signal_stream_start() {
+    if (!this->is_initialized()) {
+        return;
+    }
     this->event_flags_.set(EventGroupBits::COMMAND_START);
 }
 
@@ -529,9 +541,8 @@ DecodeResult SyncTask::decode_chunk(SyncContext& sync_context) {
         return DecodeResult::SUCCESS;
     }
 
-    if ((sync_context.encoded_entry->chunk_type != CHUNK_TYPE_ENCODED_AUDIO) &&
-        (sync_context.encoded_entry->chunk_type != CHUNK_TYPE_DECODED_AUDIO)) {
-        // New codec header
+    if (sync_context.encoded_entry->chunk_type != CHUNK_TYPE_ENCODED_AUDIO) {
+        // New codec header (the stream/clear marker was already handled above)
         sync_context.decoder->reset_decoders();
         AudioStreamInfo decoded_stream_info;
         if (!sync_context.decoder->process_header(
@@ -576,8 +587,7 @@ DecodeResult SyncTask::decode_chunk(SyncContext& sync_context) {
                 }
             }
         }
-    } else if ((sync_context.decoder->get_current_codec() != SendspinCodecFormat::UNSUPPORTED) &&
-               (sync_context.encoded_entry->chunk_type == CHUNK_TYPE_ENCODED_AUDIO)) {
+    } else if (sync_context.decoder->get_current_codec() != SendspinCodecFormat::UNSUPPORTED) {
         int64_t client_timestamp =
             this->client_->get_client_time(sync_context.encoded_entry->timestamp) -
             static_cast<int64_t>(this->player_impl_->get_effective_static_delay_ms()) * US_PER_MS -
@@ -638,7 +648,6 @@ bool SyncTask::wait_for_codec_header(SyncContext& sync_context) {
             continue;  // Timed out; check flags and try again
         }
         if (entry->chunk_type != CHUNK_TYPE_ENCODED_AUDIO &&
-            entry->chunk_type != CHUNK_TYPE_DECODED_AUDIO &&
             entry->chunk_type != CHUNK_TYPE_STREAM_CLEAR_MARKER) {
             // Found a codec header
             sync_context.encoded_entry = entry;
@@ -660,7 +669,6 @@ void SyncTask::drain_ring_buffer(SyncContext& sync_context) {
             break;
         }
         if (entry->chunk_type != CHUNK_TYPE_ENCODED_AUDIO &&
-            entry->chunk_type != CHUNK_TYPE_DECODED_AUDIO &&
             entry->chunk_type != CHUNK_TYPE_STREAM_CLEAR_MARKER) {
             // Codec header for the next stream; hold onto it
             sync_context.encoded_entry = entry;

--- a/src/sync_task.h
+++ b/src/sync_task.h
@@ -140,6 +140,11 @@ public:
     /// Returns false when idle (waiting for a stream) or stopped.
     /// @return true if actively decoding and syncing a stream.
     bool is_running() const {
+        // Guarded so callers may query before init(); reading uncreated event flags is a
+        // null-handle crash on ESP
+        if (!this->is_initialized()) {
+            return false;
+        }
         return (this->event_flags_.get() & EventGroupBits::TASK_RUNNING) != 0U;
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(sendspin_tests
     test_time_filter.cpp
     test_protocol.cpp
     test_network_info.cpp
+    test_spsc_ring_buffer.cpp
 )
 
 # Reach the library's private headers (protocol_messages.h, time_filter.h, ...).

--- a/tests/test_spsc_ring_buffer.cpp
+++ b/tests/test_spsc_ring_buffer.cpp
@@ -1,0 +1,126 @@
+// Copyright 2026 Sendspin Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @file test_spsc_ring_buffer.cpp
+/// @brief Tests for the host SpscRingBuffer, focused on wrap-around accounting with
+/// storage sizes that are not a multiple of the internal alignment
+
+#include "platform/spsc_ring_buffer.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace sendspin {
+namespace {
+
+// Fills each item with a pattern derived from its sequence number so corruption from
+// overlapping writer/reader accounting is detected on read-back.
+void fill_pattern(uint8_t* dst, size_t size, uint32_t seq) {
+    for (size_t i = 0; i < size; ++i) {
+        dst[i] = static_cast<uint8_t>((seq * 31 + i) & 0xFF);
+    }
+}
+
+bool check_pattern(const uint8_t* src, size_t size, uint32_t seq) {
+    for (size_t i = 0; i < size; ++i) {
+        if (src[i] != static_cast<uint8_t>((seq * 31 + i) & 0xFF)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Repeatedly fills the buffer to capacity with varying item sizes, then drains and
+// verifies every item. Cycling many times forces the write offset through every
+// wrap position, including tails smaller than the item header.
+void run_fill_drain_cycles(size_t storage_size) {
+    std::vector<uint8_t> storage(storage_size);
+    SpscRingBuffer rb;
+    ASSERT_TRUE(rb.create(storage_size, storage.data()));
+
+    uint32_t write_seq = 0;
+    uint32_t read_seq = 0;
+    uint8_t item[97];
+
+    for (int cycle = 0; cycle < 200; ++cycle) {
+        // Vary the item size per cycle so wrap points shift around the storage.
+        size_t item_size = 1 + ((cycle * 13) % sizeof(item));
+
+        // Fill until the buffer rejects a non-blocking write.
+        int wrote = 0;
+        for (;;) {
+            fill_pattern(item, item_size, write_seq);
+            if (!rb.send(item, item_size, 0)) {
+                break;
+            }
+            ++write_seq;
+            ++wrote;
+        }
+        // An empty-drained buffer must always accept at least one small item; a
+        // failure here means the accounting stalled permanently.
+        ASSERT_GT(wrote, 0) << "buffer stalled at cycle " << cycle
+                            << " storage_size=" << storage_size;
+
+        // Drain everything and verify content and ordering.
+        for (;;) {
+            size_t got_size = 0;
+            void* got = rb.receive(&got_size, 0);
+            if (got == nullptr) {
+                break;
+            }
+            ASSERT_EQ(got_size, item_size);
+            ASSERT_TRUE(check_pattern(static_cast<uint8_t*>(got), got_size, read_seq))
+                << "corrupt item seq=" << read_seq << " cycle=" << cycle
+                << " storage_size=" << storage_size;
+            ++read_seq;
+            rb.return_item(got);
+        }
+        ASSERT_EQ(read_seq, write_seq);
+        ASSERT_TRUE(rb.is_empty());
+    }
+}
+
+TEST(SpscRingBuffer, AlignedStorageSize) {
+    run_fill_drain_cycles(4096);
+}
+
+// Regression: storage sizes that are not a multiple of the 8-byte alignment used to
+// corrupt data (unaligned dummy-filler size credited back rounded up) or stall forever
+// (tail too small for a dummy header). create() now rounds the usable size down.
+TEST(SpscRingBuffer, UnalignedStorageSizeOddByOne) {
+    run_fill_drain_cycles(4097);
+}
+
+TEST(SpscRingBuffer, UnalignedStorageSizeOddByFour) {
+    run_fill_drain_cycles(4100);
+}
+
+TEST(SpscRingBuffer, UnalignedStorageSizeJustUnderAligned) {
+    run_fill_drain_cycles(4093);
+}
+
+TEST(SpscRingBuffer, CreateRejectsTooSmallStorage) {
+    std::vector<uint8_t> storage(16);
+    SpscRingBuffer rb;
+    // After rounding down, less than one header plus one aligned byte of payload fits.
+    EXPECT_FALSE(rb.create(15, storage.data()));
+    EXPECT_FALSE(rb.create(8, storage.data()));
+    EXPECT_TRUE(rb.create(16, storage.data()));
+}
+
+}  // namespace
+}  // namespace sendspin

--- a/tests/test_spsc_ring_buffer.cpp
+++ b/tests/test_spsc_ring_buffer.cpp
@@ -116,7 +116,7 @@ TEST(SpscRingBuffer, UnalignedStorageSizeJustUnderAligned) {
 TEST(SpscRingBuffer, CreateRejectsTooSmallStorage) {
     std::vector<uint8_t> storage(16);
     SpscRingBuffer rb;
-    // After rounding down, less than one header plus one aligned byte of payload fits.
+    // After rounding down, less than one header plus one aligned payload unit fits.
     EXPECT_FALSE(rb.create(15, storage.data()));
     EXPECT_FALSE(rb.create(8, storage.data()));
     EXPECT_TRUE(rb.create(16, storage.data()));


### PR DESCRIPTION
Fixes a set of correctness and threading issues in the audio player path, plus a host ring-buffer alignment bug.

- SPSC ring buffer: round storage down to alignment. Unaligned `storage_size_ desynced` the writer/reader dummy-filler accounting at wrap points, causing data corruption or a permanent stall. `create()` now masks the usable size to an 8-byte multiple and rejects storage below one header + one aligned byte. Adds `test_spsc_ring_buffer.cpp` (fill/drain cycling across aligned and off-by-N sizes).
- `release_high_performance()` underflow. Replaced the load-then-`fetch_sub` with a compare-exchange loop so two concurrent releases at count 1 can't both pass the zero-check and underflow the counter.
- Player stream lifecycle races. Moved the high-performance acquire off the network thread to the main-loop `STREAM_START` drain, keeping the pairing flag and listener callbacks main-thread-only. Added a `stream_active` guard so `on_stream_end()` stays paired 1:1 with `on_stream_start()` (no spurious end from `cleanup()` or a failed start), and invalidated the stale `sync_idle` snapshot after a just-started stream so a same-batch `STREAM_END` waits for the task to drain.
- SyncTask init guards. `signal_stream_*` and `is_running()` now early-return when `init()` never ran, preventing a null-handle crash from touching uncreated event flags on ESP.
- Queue-full logging on the time, state, and stream-event queues.
- Removed dead `CHUNK_TYPE_DECODED_AUDIO`, simplifying the decode-path chunk-type checks.
- Docs: corrected volume range to 0–100, and documented that `on_audio_write` partial writes must be a whole number of PCM frames.