### PR TITLE
Reap connections that never complete the hello handshake

### DIFF
--- a/src/connection.h
+++ b/src/connection.h
@@ -124,6 +124,19 @@ public:
         return this->instance_id;
     }
 
+    /// @brief Records the accept/provisional timestamp (microseconds from platform_time_us()).
+    /// Called when the connection is admitted into a manager slot (on_new_connection /
+    /// connect_to), which may happen on a network thread. The provisional-connection timeout in
+    /// ConnectionManager::loop() reads it on the main loop, hence atomic.
+    void set_provisional_time_us(int64_t t) {
+        this->provisional_time_us_.store(t, std::memory_order_relaxed);
+    }
+
+    /// @brief Returns the accept/provisional timestamp, or 0 if not yet set.
+    int64_t get_provisional_time_us() const {
+        return this->provisional_time_us_.load(std::memory_order_relaxed);
+    }
+
     /// @brief Sends a text message to the server with a completion callback
     /// @param message The message string to send.
     /// @param cb Callback invoked with the send result. On asynchronous transports it is not
@@ -372,6 +385,11 @@ protected:
     std::unique_ptr<SendspinTimeFilter> time_filter_;
 
     // 64-bit fields
+
+    /// Monotonic timestamp (platform_time_us()) when this connection was admitted into a manager
+    /// slot. Atomic because it is written at admission (possibly on a network thread) and read on
+    /// the main loop (provisional-connection timeout check). 0 = not yet set.
+    std::atomic<int64_t> provisional_time_us_{0};
 
     /// EMA (microseconds) of format_client_time_message() duration. Atomic because the ESP
     /// server worker thread updates it while the hub thread reads it for logging.

--- a/src/connection_manager.cpp
+++ b/src/connection_manager.cpp
@@ -70,6 +70,10 @@ void ConnectionManager::connect_to(const std::string& url) {
 
     client_conn->init_time_filter();
 
+    // Start the provisional-timeout window: loop() reaps the connection if the hello handshake
+    // has not completed within PROVISIONAL_CONNECTION_TIMEOUT_US.
+    client_conn->set_provisional_time_us(platform_time_us());
+
     {
         std::lock_guard<std::mutex> lock(this->conn_ptr_mutex_);
         if (this->current_connection_ != nullptr && this->current_connection_->is_connected()) {
@@ -287,6 +291,35 @@ void ConnectionManager::loop() {
             }
         }
     }
+
+    // Provisional-connection timeout: drop any managed connection that has not completed the
+    // hello handshake within PROVISIONAL_CONNECTION_TIMEOUT_US. This is the only release path
+    // for connections whose socket died before the WebSocket session was established (the host
+    // transport never delivers a close for those, issue #75) and for peers that connect and then
+    // stall without completing the hello (both platforms).
+    {
+        std::lock_guard<std::mutex> lock(this->conn_ptr_mutex_);
+        const int64_t now_us = platform_time_us();
+        auto handshake_expired = [now_us](const std::shared_ptr<SendspinConnection>& conn) {
+            if (conn == nullptr || conn->is_handshake_complete()) {
+                return false;
+            }
+            const int64_t prov_time = conn->get_provisional_time_us();
+            return prov_time != 0 && (now_us - prov_time) >= PROVISIONAL_CONNECTION_TIMEOUT_US;
+        };
+        if (handshake_expired(this->pending_connection_)) {
+            SS_LOGW(TAG, "Pending connection timed out (>%d s without completing hello), dropping",
+                    static_cast<int>(PROVISIONAL_CONNECTION_TIMEOUT_S));
+            this->drop_connection(this->pending_connection_.get(),
+                                  SendspinGoodbyeReason::ANOTHER_SERVER);
+        }
+        if (handshake_expired(this->current_connection_)) {
+            SS_LOGW(TAG, "Current connection timed out (>%d s without completing hello), dropping",
+                    static_cast<int>(PROVISIONAL_CONNECTION_TIMEOUT_S));
+            this->drop_connection(this->current_connection_.get(),
+                                  SendspinGoodbyeReason::ANOTHER_SERVER);
+        }
+    }
 }
 
 // ============================================================================
@@ -359,6 +392,12 @@ void ConnectionManager::on_new_connection(std::shared_ptr<SendspinServerConnecti
     conn->on_disconnected_cb = [](SendspinConnection* /*c*/) {
         // Cleanup happens in on_connection_lost triggered by the server
     };
+
+    // Start the provisional-timeout window: loop() reaps the connection if the hello handshake
+    // has not completed within PROVISIONAL_CONNECTION_TIMEOUT_US. This is the release path for
+    // sockets that die before the WebSocket session is established: the host transport delivers
+    // no close for those, so without the timeout they would hold a slot forever (issue #75).
+    conn->set_provisional_time_us(platform_time_us());
 
     std::lock_guard<std::mutex> lock(this->conn_ptr_mutex_);
     SendspinConnection* accepted_conn = nullptr;
@@ -476,23 +515,48 @@ void ConnectionManager::on_connection_lost(SendspinConnection* conn) {
         return;
     }
 
-    if (this->current_connection_ != nullptr && this->current_connection_.get() == conn) {
+    if (conn == this->current_connection_.get()) {
         SS_LOGI(TAG, "Current connection lost");
+    } else if (conn == this->pending_connection_.get()) {
+        SS_LOGD(TAG, "Pending connection lost");
+    }
+
+    // The transport is already gone, so no goodbye is attempted (nullopt).
+    this->drop_connection(conn, std::nullopt);
+}
+
+void ConnectionManager::drop_connection(SendspinConnection* conn,
+                                        std::optional<SendspinGoodbyeReason> goodbye) {
+    // Note: caller must hold conn_ptr_mutex_
+    if (conn == nullptr) {
+        return;
+    }
+
+    this->remove_hello_retry(conn);
+
+    if (conn == this->current_connection_.get()) {
+        // Dropping the admitted connection: block stale network-thread events, quiesce the
+        // client's per-connection state, and promote the pending connection if one exists.
         conn->disable_message_dispatch();
         this->client_->time_burst_->reset();
         this->client_->cleanup_connection_state();
-        this->remove_hello_retry(conn);
-        this->current_connection_.reset();
-
+        auto conn_to_drop = std::move(this->current_connection_);
         if (this->pending_connection_ != nullptr) {
             SS_LOGD(TAG, "Promoting pending connection to current");
             this->current_connection_ = std::move(this->pending_connection_);
         }
-    } else if (this->pending_connection_ != nullptr && this->pending_connection_.get() == conn) {
-        SS_LOGD(TAG, "Pending connection lost");
-        this->remove_hello_retry(conn);
-        this->pending_connection_.reset();
+        if (goodbye.has_value()) {
+            this->disconnect_and_release(std::move(conn_to_drop), goodbye.value());
+        }
+        // Without a goodbye (connection already lost), conn_to_drop releases here.
+    } else if (conn == this->pending_connection_.get()) {
+        // Dropping a pending connection: no client-state cleanup (it was never promoted).
+        auto conn_to_drop = std::move(this->pending_connection_);
+        if (goodbye.has_value()) {
+            this->disconnect_and_release(std::move(conn_to_drop), goodbye.value());
+        }
     }
+    // Not a managed connection: nothing to do (already released by an earlier event this tick).
 }
 
 bool ConnectionManager::should_switch_to_new_server(SendspinConnection* current,
@@ -538,26 +602,18 @@ void ConnectionManager::complete_handoff(bool switch_to_new) {
     if (switch_to_new) {
         SS_LOGD(TAG, "Completing handoff: switching to new server");
         if (this->current_connection_ != nullptr) {
-            this->current_connection_->disable_message_dispatch();
-            this->client_->time_burst_->reset();
-            this->client_->cleanup_connection_state();
-            auto old_current = std::move(this->current_connection_);
-            this->current_connection_ = std::move(this->pending_connection_);
-            // Drop any retry entry now that this connection is leaving the managed set, mirroring
-            // on_connection_lost. (loop() also prunes orphaned entries, but removing it here closes
-            // the window where a retry could fire against an already-handed-off connection.)
-            this->remove_hello_retry(old_current.get());
-            this->disconnect_and_release(std::move(old_current),
-                                         SendspinGoodbyeReason::ANOTHER_SERVER);
+            // drop_connection tears down the displaced current connection (with goodbye) and
+            // promotes the pending connection into the current slot.
+            this->drop_connection(this->current_connection_.get(),
+                                  SendspinGoodbyeReason::ANOTHER_SERVER);
         } else {
             this->current_connection_ = std::move(this->pending_connection_);
         }
     } else {
         SS_LOGD(TAG, "Completing handoff: keeping current server");
         if (this->pending_connection_ != nullptr) {
-            this->remove_hello_retry(this->pending_connection_.get());
-            this->disconnect_and_release(std::move(this->pending_connection_),
-                                         SendspinGoodbyeReason::ANOTHER_SERVER);
+            this->drop_connection(this->pending_connection_.get(),
+                                  SendspinGoodbyeReason::ANOTHER_SERVER);
         }
     }
 }

--- a/src/connection_manager.cpp
+++ b/src/connection_manager.cpp
@@ -23,6 +23,8 @@
 #include "time_burst.h"
 #include "ws_server.h"
 
+#include <utility>
+
 namespace sendspin {
 
 static const char* const TAG = "sendspin.conn_mgr";
@@ -511,6 +513,7 @@ bool ConnectionManager::send_hello_message(uint8_t remaining_attempts, SendspinC
 // ============================================================================
 
 void ConnectionManager::on_connection_lost(SendspinConnection* conn) {
+    // Note: caller must hold conn_ptr_mutex_ (reads the slots and calls drop_connection)
     if (conn == nullptr) {
         return;
     }
@@ -540,10 +543,12 @@ void ConnectionManager::drop_connection(SendspinConnection* conn,
         conn->disable_message_dispatch();
         this->client_->time_burst_->reset();
         this->client_->cleanup_connection_state();
-        auto conn_to_drop = std::move(this->current_connection_);
+        // std::exchange (not std::move) so the slots are never left in a moved-from state the
+        // static analyzer flags when a later event in the same loop() pass reads them.
+        auto conn_to_drop = std::exchange(this->current_connection_, nullptr);
         if (this->pending_connection_ != nullptr) {
             SS_LOGD(TAG, "Promoting pending connection to current");
-            this->current_connection_ = std::move(this->pending_connection_);
+            this->current_connection_ = std::exchange(this->pending_connection_, nullptr);
         }
         if (goodbye.has_value()) {
             this->disconnect_and_release(std::move(conn_to_drop), goodbye.value());
@@ -551,7 +556,7 @@ void ConnectionManager::drop_connection(SendspinConnection* conn,
         // Without a goodbye (connection already lost), conn_to_drop releases here.
     } else if (conn == this->pending_connection_.get()) {
         // Dropping a pending connection: no client-state cleanup (it was never promoted).
-        auto conn_to_drop = std::move(this->pending_connection_);
+        auto conn_to_drop = std::exchange(this->pending_connection_, nullptr);
         if (goodbye.has_value()) {
             this->disconnect_and_release(std::move(conn_to_drop), goodbye.value());
         }
@@ -607,7 +612,7 @@ void ConnectionManager::complete_handoff(bool switch_to_new) {
             this->drop_connection(this->current_connection_.get(),
                                   SendspinGoodbyeReason::ANOTHER_SERVER);
         } else {
-            this->current_connection_ = std::move(this->pending_connection_);
+            this->current_connection_ = std::exchange(this->pending_connection_, nullptr);
         }
     } else {
         SS_LOGD(TAG, "Completing handoff: keeping current server");

--- a/src/connection_manager.h
+++ b/src/connection_manager.h
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -40,6 +41,19 @@ struct ServerHelloEvent {
     std::shared_ptr<SendspinConnection> conn;  ///< Connection that received the hello
     SendspinConnectionReason connection_reason;
 };
+
+/// @brief Timeout for provisional (pre-handshake) connections in seconds.
+/// A connection that has not completed the hello handshake within this window is closed. This
+/// reaps connections whose transport never delivers a close for sockets that die before the
+/// WebSocket session is established (host IXWebSocket, issue #75) as well as peers that connect
+/// and stall without completing the hello (both platforms). Mirrors the encryption branch's
+/// provisional-connection timeout, whose reap is gated on is_awaiting_activate();
+/// !is_handshake_complete() is the plaintext analogue.
+static constexpr double PROVISIONAL_CONNECTION_TIMEOUT_S = 30.0;
+
+/// @brief Timeout in microseconds (derived from PROVISIONAL_CONNECTION_TIMEOUT_S).
+static constexpr int64_t PROVISIONAL_CONNECTION_TIMEOUT_US =
+    static_cast<int64_t>(PROVISIONAL_CONNECTION_TIMEOUT_S * 1'000'000LL);
 
 /// @brief Hello retry state for exponential backoff
 struct HelloRetryState {
@@ -199,6 +213,15 @@ private:
     /// @param reason The goodbye reason to send before closing.
     void disconnect_and_release(std::shared_ptr<SendspinConnection>&& conn,
                                 SendspinGoodbyeReason reason);
+    /// @brief Single teardown path: releases a managed connection's slot, cleans up client state
+    /// (current slot only), promotes the pending connection, and optionally sends a goodbye.
+    ///
+    /// No-op if conn is null or not a managed connection. Caller must hold conn_ptr_mutex_.
+    ///
+    /// @param conn The connection to drop; must be current_connection_ or pending_connection_.
+    /// @param goodbye Goodbye reason to send before closing, or nullopt when the transport is
+    ///        already gone (connection-lost path) so no goodbye should be attempted.
+    void drop_connection(SendspinConnection* conn, std::optional<SendspinGoodbyeReason> goodbye);
 
     // Struct fields
     std::mutex conn_mutex_;              // Protects deferred lifecycle event queues

--- a/src/connection_manager.h
+++ b/src/connection_manager.h
@@ -196,6 +196,7 @@ private:
     // Connection lifecycle
     // ========================================
     /// @brief Tears down a lost connection and promotes the pending connection if one exists.
+    /// Caller must hold conn_ptr_mutex_.
     /// @param conn The connection that was lost.
     void on_connection_lost(SendspinConnection* conn);
     /// @brief Decides whether to switch from the current connection to the new one.
@@ -216,7 +217,9 @@ private:
     /// @brief Single teardown path: releases a managed connection's slot, cleans up client state
     /// (current slot only), promotes the pending connection, and optionally sends a goodbye.
     ///
-    /// No-op if conn is null or not a managed connection. Caller must hold conn_ptr_mutex_.
+    /// No-op if conn is null. If conn is not a managed connection (already released by an
+    /// earlier event in the same loop() pass), only its stale hello-retry entry, if any, is
+    /// pruned. Caller must hold conn_ptr_mutex_.
     ///
     /// @param conn The connection to drop; must be current_connection_ or pending_connection_.
     /// @param goodbye Goodbye reason to send before closing, or nullopt when the transport is


### PR DESCRIPTION
Drop any managed connection still short of a completed hello handshake after 30 s, via a single drop_connection teardown path. Releases slots held by sockets that die before the WebSocket session is established (host transport delivers no close for those) and by peers that connect and stall, so phantoms can no longer wedge the player.

Fixes #75