### PR TITLE
Replace the pending-connection slot with a prove-then-admit lifecycle

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -4,6 +4,12 @@ menu "sendspin-cpp"
         bool
         default y
         select HTTPD_WS_SUPPORT
+        # Event-driven WebSocket upgrade detection (src/esp/ws_server.cpp). The symbol only
+        # exists on IDF >= 5.5.5 / 6.0.1 (Kconfig default n there, with a `depends on
+        # HTTPD_WS_SUPPORT` satisfied by the select above). On older IDF the symbol is undefined
+        # and this select is silently ignored, which is fine: those versions dispatch the upgrade
+        # GET to the URI handler natively, so there is nothing to enable.
+        select HTTPD_WS_POST_HANDSHAKE_CB_SUPPORT
 
     config SENDSPIN_ENABLE_PLAYER
         bool "Enable player role (audio decode/playback)"

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -161,7 +161,7 @@ Network thread (IXWebSocket / esp_http_server)
 
 | Message | Action on Network Thread |
 |---------|------------------------|
-| `SERVER_HELLO` | Enqueues `ServerHelloEvent` into `ConnectionManager`'s mutex-protected vector |
+| `SERVER_HELLO` | Stores server info and connection reason on the connection, then sets `server_hello_received_` (an atomic store that publishes the fields to the main loop; the manager's promotion scan observes `is_handshake_complete()` on its next tick) |
 | `SERVER_TIME` | Enqueues `TimeResponseEvent` into `time_queue` |
 | `SERVER_STATE` | Writes to `ControllerRole::Impl::shadow`, `MetadataRole::Impl::shadow`, and `ColorRole::Impl::shadow` |
 | `SERVER_COMMAND` | Merges into `PlayerRole::Impl::shadow_command` |
@@ -195,9 +195,11 @@ The bump arena suits ArduinoJson's allocation pattern: during a parse the varian
    ├─ Start WS server if network ready
    ├─ Swap deferred connection events under mutex
    ├─ Process close/disconnect events (on_connection_lost)
-   ├─ Process hello events (handshake completion, handoff decisions)
-   ├─ Call loop() on current and pending connections
-   └─ Check per-connection hello retry timers
+   ├─ Promotion scan: establish nursery connections whose hello handshake completed
+   │  (handoff decisions against the incumbent)
+   ├─ Call loop() on the current and nursery connections
+   ├─ Check per-connection hello retry timers
+   └─ Reap nursery connections past the establish deadline; tick the platform ws_server
 
 2. time_burst_->loop(conn)  (skipped when no current connection)
    ├─ Send next time message if ready
@@ -382,27 +384,25 @@ The filter is protected by `state_mutex_` so that `compute_client_time()` can be
 
 ### Connection Management (`src/connection_manager.cpp`)
 
-The `ConnectionManager` maintains two observer slots for the connections it routes messages through:
+The `ConnectionManager` maintains one established slot plus a bounded nursery of unproven connections:
 
 | Slot | Purpose |
 |------|---------|
-| `current_connection_` | Active connection receiving messages |
-| `pending_connection_` | Handoff candidate completing its handshake |
+| `current_connection_` | Active connection receiving messages; holds only connections that completed the hello handshake |
+| `nursery_` | Unproven connections (inbound or outbound) awaiting establishment, bounded by `NURSERY_CAPACITY` inbound + 1 outbound |
 
-Both are `std::shared_ptr<SendspinConnection>`, and on the ESP server path they are observers rather than authoritative owners — the authoritative owner of a `SendspinServerConnection` is the httpd session itself (see [Server connection ownership (ESP)](#server-connection-ownership-esp)). On the host (IXWebSocket) client path the `shared_ptr` in these slots is the only owner.
+All are `std::shared_ptr<SendspinConnection>`, and on the ESP server path they are observers rather than authoritative owners; the authoritative owner of a `SendspinServerConnection` is the httpd session itself (see [Server connection ownership (ESP)](#server-connection-ownership-esp)). On the host (IXWebSocket) client path the `shared_ptr` in these slots is the only owner.
 
 ### Handshake and Handoff
 
-1. A new connection (outbound or inbound) is started. If a current connection exists, the new one becomes `pending_connection_`.
-2. The connection sends a CLIENT_HELLO. Retry with exponential backoff (100 ms base, 3 attempts). Each managed connection has its own retry entry in `ConnectionManager::hello_retries_`, so a handoff candidate arriving mid-handshake cannot clobber the current connection's pending hello (and vice versa).
-3. SERVER_HELLO arrives on the network thread → enqueued into mutex-protected vector.
-4. Main loop processes the hello event:
-   - Stores server info on the connection.
-   - If this was the pending connection, runs handoff decision logic:
-     - Prefer PLAYBACK reason over DISCOVERY.
-     - Among two DISCOVERY connections, prefer the last-played server.
-     - Default: keep current.
-5. Handoff executes: disable old message dispatch → cleanup state → move connections → send goodbye to the rejected connection.
+1. A new connection (outbound or inbound) enters the nursery. Inbound connections are delivered by the platform ws_server only after their WebSocket upgrade is observed.
+2. The connection sends a CLIENT_HELLO. Retry with exponential backoff (100 ms base, 3 attempts). Each managed connection has its own retry entry in `ConnectionManager::hello_retries_`, so a handoff candidate arriving mid-handshake cannot clobber another connection's pending hello.
+3. The handshake state lives on the connection as two atomic flags: `client_hello_sent_` (set by the hello send-completion callback) and `server_hello_received_` (set when SERVER_HELLO is processed on the network thread, after the server info fields it publishes).
+4. Establishment is level-triggered: each `loop()` tick, the promotion scan promotes any nursery connection whose `is_handshake_complete()` is true, so the order in which the two flags were set is irrelevant. If an incumbent exists, the handoff decision runs:
+   - Prefer PLAYBACK reason over DISCOVERY.
+   - Among two DISCOVERY connections, prefer the last-played server.
+   - Default: keep current.
+5. Handoff executes: disable the loser's message dispatch → cleanup client state (winner only gets `on_handshake_complete`) → send goodbye to the rejected connection via the deferred-release queue.
 
 ### Disconnection and Cleanup
 
@@ -410,10 +410,10 @@ When a connection is lost (`on_connection_lost`):
 
 ```api
 1. conn->disable_message_dispatch()      ← atomic, immediate on network thread
-2. time_burst_->reset()                  ← stop time sync
-3. client_->cleanup_connection_state()  ← drain all role queues/shadows, signal stream end
-4. current_connection_.reset()           ← destroy connection
-5. Promote pending to current if exists
+2. client_->cleanup_connection_state()  ← stop time sync, drain all role queues/shadows,
+                                           signal stream end
+3. Queue the connection on deferred_releases_ (released outside the manager lock)
+4. The current slot stays empty; the next promotion scan fills it from the nursery
 ```
 
 `disable_message_dispatch()` is the first step because it's an atomic flag that the network thread checks before invoking any callback. This prevents stale messages from a dead connection from racing into freshly-reset role queues.
@@ -430,7 +430,7 @@ When a connection is lost (`on_connection_lost`):
 On the ESP build, `SendspinServerConnection` lifetime is pinned to the httpd session rather than to `ConnectionManager`:
 
 1. `SendspinWsServer::open_callback` (the httpd `open_fn`) creates the `shared_ptr<SendspinServerConnection>`, heap-allocates a `shared_ptr*` slot, and calls `httpd_sess_set_ctx(handle, sockfd, slot, free_fn)` with a deleter that `delete`s the slot. That slot is the authoritative reference.
-2. The same shared_ptr is forwarded into `ConnectionManager::on_new_connection`, which stores it in `current_connection_` or `pending_connection_` as a *secondary observer*.
+2. The same shared_ptr is forwarded into `ConnectionManager::on_new_connection`, which admits it into the nursery as a *secondary observer* (it moves to `current_connection_` only once its hello handshake completes).
 3. The httpd WebSocket handler (`websocket_handler`) looks the connection up by `httpd_sess_get_ctx(handle, sockfd)` at run time, copying the slot's `shared_ptr` for the duration of its work; it never assumes the manager's observer slot is alive. The queued send workers (`async_send_text`, `async_send_time_text`) instead capture a `weak_ptr<SendspinServerConnection>` to the originating connection and `lock()` it when they run.
 4. When the socket closes, httpd calls the `close_fn` first (which fires `connection_closed_callback_` so `ConnectionManager` can drop its observer in the next `loop()`), then later calls the slot's `free_fn` to release the authoritative reference once no workers are queued for that session.
 

--- a/include/sendspin/client.h
+++ b/include/sendspin/client.h
@@ -214,6 +214,10 @@ public:
     void connect_to(const std::string& url);
 
     /// @brief Disconnects from the current server with the given reason
+    ///
+    /// Must be called from the main loop thread: the blocking transport close runs outside the
+    /// manager lock, so a call from another thread could race loop()'s own release of the same
+    /// connection (two concurrent transport stops).
     /// @param reason The goodbye reason to send
     void disconnect(SendspinGoodbyeReason reason);
 

--- a/include/sendspin/config.h
+++ b/include/sendspin/config.h
@@ -67,8 +67,16 @@ struct SendspinClientConfig {
     uint16_t httpd_ctrl_port{0};  ///< ESP-IDF httpd control port; 0 = ESP_HTTPD_DEF_CTRL_PORT
                                   ///< + 1 (avoids conflict with web_server component)
     uint16_t server_port{DEFAULT_SERVER_PORT};  ///< WebSocket server port
-    uint8_t server_max_connections{2};          ///< Maximum simultaneous connections (default: 2
-                                                ///< for handoff protocol)
+
+    /// @brief Default maximum simultaneous inbound connections: one established connection, two
+    /// unproven connections awaiting the hello handshake (the manager's nursery capacity), and
+    /// one spare so a surplus peer can still be accepted long enough to receive a graceful
+    /// client/goodbye. Values below this trade that goodbye for a transport-level refusal at
+    /// accept (on ESP the surplus peer waits unanswered in the TCP backlog instead).
+    static constexpr uint8_t DEFAULT_SERVER_MAX_CONNECTIONS = 4U;
+
+    uint8_t server_max_connections{
+        DEFAULT_SERVER_MAX_CONNECTIONS};  ///< Maximum simultaneous connections
 
     static constexpr int64_t DEFAULT_BURST_INTERVAL_MS = 10000;  ///< Default ms between bursts
     static constexpr int64_t DEFAULT_BURST_TIMEOUT_MS = 10000;   ///< Default burst timeout ms

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -183,9 +183,9 @@ void SendspinClient::loop() {
         }
     }
 
-    // Process deferred events -- all state mutations and user callbacks happen here,
-    // on the main loop thread, to avoid cross-thread data races.
-    // Each role drains its own queues/shadows internally.
+    // Process deferred events: all state mutations and user callbacks happen here, on the main
+    // loop thread, to avoid cross-thread data races. Each role drains its own queues/shadows
+    // internally.
 
     // --- Time sync events ---
     {
@@ -411,6 +411,10 @@ void SendspinClient::release_high_performance() {
 
 void SendspinClient::cleanup_connection_state() {
     SS_LOGV(TAG, "Cleaning up connection state");
+
+    // The time burst is per-connection state too; resetting it here keeps it impossible to tear
+    // down a connection without also stopping its burst.
+    this->time_burst_->reset();
 
     // Reset client event state
     this->event_state_->time_queue.reset();
@@ -666,10 +670,10 @@ void SendspinClient::process_json_message(SendspinConnection* conn, const char* 
                 if (conn != nullptr) {
                     conn->set_server_information(std::move(hello_msg.server));
                     conn->set_connection_reason(hello_msg.connection_reason);
+                    // Set last: this atomic store publishes the fields above to the manager's
+                    // promotion scan on the main loop, which observes is_handshake_complete()
+                    // and establishes the connection; nothing needs to be scheduled here.
                     conn->set_server_hello_received(true);
-
-                    this->connection_manager_->schedule_hello(
-                        {conn->shared_from_this(), hello_msg.connection_reason});
                 }
             }
             break;

--- a/src/connection.h
+++ b/src/connection.h
@@ -52,8 +52,8 @@ using SendCompleteCallback = std::function<void(bool)>;
  *
  * Usage:
  * 1. Construct a concrete subclass (SendspinServerConnection or SendspinClientConnection)
- * 2. Set the on_connected_cb, on_handshake_complete_cb, on_disconnected_cb, on_json_message_cb,
- *    and on_binary_message_cb callbacks
+ * 2. Set the on_connected_cb, on_disconnected_cb, on_json_message_cb, and on_binary_message_cb
+ *    callbacks
  * 3. Call start() to initialize the transport and begin connecting
  * 4. Call loop() periodically to drive the state machine and process events
  * 5. Call send_text_message() to send JSON messages to the peer
@@ -95,8 +95,8 @@ public:
 
     /// @brief Prevents any further message callbacks from firing on the network thread
     ///
-    /// Called on the main thread before connection cleanup so that no stale events from a dying
-    /// connection can sneak into role queues after they've been reset. Thread-safe: the flag is
+    /// Called on the main thread before connection cleanup so that no stale events from a closing
+    /// connection can reach role queues after they have been reset. Thread-safe: the flag is
     /// checked atomically in dispatch_completed_message() which runs on the network thread.
     void disable_message_dispatch() {
         this->message_dispatch_enabled_.store(false, std::memory_order_release);
@@ -197,8 +197,8 @@ public:
     /// @brief Callback invoked when a JSON message is received
     /// @param conn Pointer to this connection.
     /// @param data Pointer to the message bytes, owned by the connection. Valid only until the
-    /// callback returns -- it is reused for the next message immediately afterwards, so the
-    /// callback must not retain it. Not null-terminated; use @p len.
+    /// callback returns; it is reused for the next message immediately afterwards, so the callback
+    /// must not retain it. Not null-terminated; use @p len.
     /// @param len Length of the message in bytes.
     /// @param timestamp The client timestamp when the message was received.
     std::function<void(SendspinConnection*, const char*, size_t, int64_t)> on_json_message_cb;
@@ -212,14 +212,11 @@ public:
 
     /// @brief Callback invoked when the transport connection is ready for messaging
     /// @param conn Pointer to this connection.
-    /// @note For server connections, this is called when the WebSocket handshake completes.
-    ///       For client connections, this is called when the connection to server succeeds.
-    ///       The hub uses this to initiate the hello handshake.
+    /// @note Fired by outbound (client) transports only, once the connect and WebSocket upgrade
+    ///       complete; the manager uses it to arm the hello. Inbound server connections are
+    ///       delivered to the manager already upgraded (their hello is armed at nursery
+    ///       admission) and never fire this.
     std::function<void(SendspinConnection*)> on_connected_cb;
-
-    /// @brief Callback invoked when the hello handshake completes successfully
-    /// @param conn Pointer to this connection.
-    std::function<void(SendspinConnection*)> on_handshake_complete_cb;
 
     /// @brief Callback invoked when the connection is closed or lost
     /// @param conn Pointer to this connection.
@@ -281,6 +278,28 @@ public:
     /// @note Called by hub to track handshake state.
     void set_client_hello_sent(bool sent) {
         this->client_hello_sent_ = sent;
+    }
+
+    /// @brief Returns whether this connection has successfully sent its client/hello.
+    /// @return true once a client/hello send has completed on this connection.
+    bool has_client_hello_sent() const {
+        return this->client_hello_sent_;
+    }
+
+    /// @brief Marks that the WebSocket upgrade completed
+    /// @note Distinct from is_connected(): on ESP the socket is accepted (and is_connected() true)
+    ///       before any WebSocket handshake, so this flag signals that the peer spoke the WebSocket
+    ///       protocol. Set by the platform ws_server just before it delivers an inbound connection
+    ///       to the manager, or by the outbound transport's connected callback, either way on a
+    ///       network thread. Read on the main loop (reap diagnostics), hence atomic with
+    ///       release/acquire ordering.
+    void mark_ws_upgraded() {
+        this->ws_upgraded_.store(true, std::memory_order_release);
+    }
+
+    /// @brief Returns whether the WebSocket upgrade completed.
+    bool is_ws_upgraded() const {
+        return this->ws_upgraded_.load(std::memory_order_acquire);
     }
 
     /// @brief Sets the connection reason (from server/hello message)
@@ -412,6 +431,12 @@ protected:
     /// worker thread on ESP) and the disconnect handlers (network thread), while
     /// is_handshake_complete() and the pre-hello send gate read it from other threads.
     std::atomic<bool> client_hello_sent_{false};
+
+    /// true once the transport delivered the connected event (WebSocket upgrade completed).
+    /// Written from the transport connected callback (network thread), read by the manager's
+    /// setup-stage derivation on the main loop and on other network threads, hence atomic.
+    /// See mark_ws_upgraded().
+    std::atomic<bool> ws_upgraded_{false};
 
     /// true if the current message being assembled is text, false if binary
     /// Needed because WebSocket continuation frames do not carry the original frame type

--- a/src/connection_manager.cpp
+++ b/src/connection_manager.cpp
@@ -172,14 +172,19 @@ void ConnectionManager::disconnect(SendspinGoodbyeReason reason) {
         if (this->current_connection_ != nullptr && this->current_connection_->is_connected()) {
             to_disconnect.push_back(this->current_connection_);
         }
-        // Drain the nursery too: on shutdown an unproven connection would otherwise keep holding
-        // its transport until a nursery deadline reaps it.
-        for (auto& entry : this->nursery_) {
-            if (entry.conn->is_connected()) {
-                to_disconnect.push_back(entry.conn);
+        // Drain the nursery too. A connected entry gets a goodbye and leaves on its close event; an
+        // unconnected (pre-upgrade) entry has no transport to goodbye and yields no close, so
+        // release it here rather than leave it for the nursery deadline to reap.
+        for (auto it = this->nursery_.begin(); it != this->nursery_.end();) {
+            if (it->conn->is_connected()) {
+                to_disconnect.push_back(it->conn);
+                ++it;
+            } else {
+                it = this->release_nursery_entry(it, std::nullopt);
             }
         }
     }
+    this->flush_deferred_releases();
     for (auto& conn : to_disconnect) {
         conn->disconnect(reason, nullptr);
     }

--- a/src/connection_manager.cpp
+++ b/src/connection_manager.cpp
@@ -23,6 +23,7 @@
 #include "time_burst.h"
 #include "ws_server.h"
 
+#include <array>
 #include <utility>
 
 namespace sendspin {
@@ -36,6 +37,40 @@ static constexpr int64_t HELLO_INITIAL_DELAY_US = HELLO_INITIAL_DELAY_MS * US_PE
 static constexpr int64_t WS_SERVER_START_RETRY_MS = 5000LL;
 static constexpr int64_t WS_SERVER_START_RETRY_US = WS_SERVER_START_RETRY_MS * US_PER_MS;
 
+/// @brief Transport-establishment progress of a nursery connection, used for reap diagnostics
+///
+/// Derived on demand from the connection's proven flags rather than stored, so it can never go
+/// stale. Inbound entries are WS_UP or later by construction (delivered only after their upgrade);
+/// only an outbound connect_to() still awaiting DNS/TCP resolve can be TCP_OPEN.
+enum class SetupStage : uint8_t { TCP_OPEN, WS_UP, HELLO_SENT, ESTABLISHED };
+
+static SetupStage setup_stage(const SendspinConnection& conn) {
+    if (conn.is_handshake_complete()) {
+        return SetupStage::ESTABLISHED;
+    }
+    if (conn.has_client_hello_sent()) {
+        return SetupStage::HELLO_SENT;
+    }
+    if (conn.is_ws_upgraded()) {
+        return SetupStage::WS_UP;
+    }
+    return SetupStage::TCP_OPEN;
+}
+
+static const char* to_cstr(SetupStage stage) {
+    switch (stage) {
+        case SetupStage::TCP_OPEN:
+            return "TCP_OPEN";
+        case SetupStage::WS_UP:
+            return "WS_UP";
+        case SetupStage::HELLO_SENT:
+            return "HELLO_SENT";
+        case SetupStage::ESTABLISHED:
+            return "ESTABLISHED";
+    }
+    return "UNKNOWN";
+}
+
 // ============================================================================
 // Constructor / Destructor
 // ============================================================================
@@ -43,12 +78,21 @@ static constexpr int64_t WS_SERVER_START_RETRY_US = WS_SERVER_START_RETRY_MS * U
 ConnectionManager::ConnectionManager(SendspinClient* client) : client_(client) {}
 
 ConnectionManager::~ConnectionManager() {
-    std::lock_guard<std::mutex> lock(this->conn_ptr_mutex_);
-    this->current_connection_.reset();
-    this->pending_connection_.reset();
-    // Clear under the same lock that guards every other access to hello_retries_, keeping the
-    // locking discipline uniform.
-    this->hello_retries_.clear();
+    // Move everything out under the lock, destroy outside it: a connection destructor can join
+    // its transport thread (see DeferredRelease), which must not happen while the lock is held.
+    std::shared_ptr<SendspinConnection> current;
+    std::vector<NurseryEntry> nursery;
+    std::vector<HelloRetryState> retries;
+    std::vector<DeferredRelease> releases;
+    {
+        std::lock_guard<std::mutex> lock(this->conn_ptr_mutex_);
+        current = std::move(this->current_connection_);
+        nursery = std::move(this->nursery_);
+        retries = std::move(this->hello_retries_);
+        releases = std::move(this->deferred_releases_);
+    }
+    // Locals release here. Queued goodbyes are skipped on destruction; shutdown drops slots
+    // without a send.
 }
 
 // ============================================================================
@@ -58,12 +102,21 @@ ConnectionManager::~ConnectionManager() {
 void ConnectionManager::connect_to(const std::string& url) {
     SS_LOGI(TAG, "Initiating client connection to: %s", url.c_str());
 
-    auto client_conn = std::make_unique<SendspinClientConnection>(url);
+    auto client_conn = std::make_shared<SendspinClientConnection>(url);
     client_conn->set_auto_reconnect(false);
     client_conn->set_task_config(this->client_->config_.websocket_priority);
     client_conn->set_websocket_payload_location(this->client_->config_.websocket_payload_location);
 
     this->setup_connection_callbacks(client_conn.get());
+    client_conn->on_connected_cb = [this](SendspinConnection* c) {
+        // Only outbound transports fire this, so it is wired here rather than in
+        // setup_connection_callbacks. The connect succeeded, so the WebSocket upgrade is complete;
+        // record it and defer the hello arming to loop() (this runs on the network thread).
+        // Inbound connections arrive already upgraded and arm their hello at admission.
+        c->mark_ws_upgraded();
+        std::lock_guard<std::mutex> lock(this->conn_mutex_);
+        this->pending_connected_events_.push_back(c->shared_from_this());
+    };
     client_conn->on_disconnected_cb = [this](SendspinConnection* conn) {
         // Defer to loop(); this callback runs on IXWebSocket's internal thread
         std::lock_guard<std::mutex> lock(this->conn_mutex_);
@@ -72,45 +125,63 @@ void ConnectionManager::connect_to(const std::string& url) {
 
     client_conn->init_time_filter();
 
-    // Start the provisional-timeout window: loop() reaps the connection if the hello handshake
-    // has not completed within PROVISIONAL_CONNECTION_TIMEOUT_US.
+    // Start the nursery clock: loop() reaps the connection if it has not completed the hello
+    // handshake within NURSERY_ESTABLISH_TIMEOUT_US. The stamp predates DNS/TCP resolve, which is
+    // why outbound entries are exempt from the short upgrade deadline.
     client_conn->set_provisional_time_us(platform_time_us());
 
     {
         std::lock_guard<std::mutex> lock(this->conn_ptr_mutex_);
-        if (this->current_connection_ != nullptr && this->current_connection_->is_connected()) {
-            SS_LOGD(TAG, "Existing connection active, new connection will go through handoff");
-            // Release any existing pending connection (e.g. an inbound handoff candidate) before
-            // overwriting the slot, mirroring on_new_connection and complete_handoff; otherwise it
-            // is dropped with no goodbye and, on ESP, leaves its httpd session pinned.
-            if (this->pending_connection_ != nullptr) {
-                this->remove_hello_retry(this->pending_connection_.get());
-                this->disconnect_and_release(std::move(this->pending_connection_),
-                                             SendspinGoodbyeReason::ANOTHER_SERVER);
-            }
-            this->pending_connection_ = std::move(client_conn);
-            this->pending_connection_->start();
-        } else {
-            // A present-but-disconnected current connection (its close event not yet processed) is
-            // being replaced. Tear its state down as on_connection_lost would, instead of
-            // overwriting the slot and orphaning dispatch/time-filter/client state and its retry.
-            if (this->current_connection_ != nullptr) {
-                this->current_connection_->disable_message_dispatch();
-                this->client_->time_burst_->reset();
-                this->client_->cleanup_connection_state();
-                this->remove_hello_retry(this->current_connection_.get());
-                this->current_connection_.reset();
-            }
-            this->current_connection_ = std::move(client_conn);
-            this->current_connection_->start();
+
+        // A present-but-disconnected current connection (its close event not yet processed) is
+        // being replaced. Tear its state down as on_connection_lost would (the transport is
+        // already gone, so no goodbye), instead of leaving it to occupy the slot with orphaned
+        // dispatch/time-filter/client state.
+        if (this->current_connection_ != nullptr && !this->current_connection_->is_connected()) {
+            this->drop_connection(this->current_connection_.get(), std::nullopt);
         }
+
+        // Only one outbound attempt at a time: release any previous outbound entry before pushing
+        // the new one. Otherwise it would be dropped with no goodbye and, on ESP, leave its httpd
+        // session pinned.
+        for (auto it = this->nursery_.begin(); it != this->nursery_.end();) {
+            if (!it->inbound) {
+                it = this->release_nursery_entry(it, SendspinGoodbyeReason::ANOTHER_SERVER);
+            } else {
+                ++it;
+            }
+        }
+
+        // A user-initiated connect is admitted even against a full nursery: there is at most one
+        // outbound entry (replaced above), so the nursery is still bounded (NURSERY_CAPACITY + 1)
+        // and an explicit user request never fails against inbound peers.
+        this->nursery_.push_back(NurseryEntry{client_conn, /*inbound=*/false});
+        client_conn->start();
     }
+    this->flush_deferred_releases();
 }
 
 void ConnectionManager::disconnect(SendspinGoodbyeReason reason) {
-    std::lock_guard<std::mutex> lock(this->conn_ptr_mutex_);
-    if (this->current_connection_ != nullptr && this->current_connection_->is_connected()) {
-        this->current_connection_->disconnect(reason, nullptr);
+    // Collect under the lock, send outside it: disconnect() can block on the transport (and on
+    // host outbound it joins the transport thread), which must not stall other manager entry
+    // points. The connections stay in their slots until their close events arrive (or the
+    // manager is destroyed).
+    std::vector<std::shared_ptr<SendspinConnection>> to_disconnect;
+    {
+        std::lock_guard<std::mutex> lock(this->conn_ptr_mutex_);
+        if (this->current_connection_ != nullptr && this->current_connection_->is_connected()) {
+            to_disconnect.push_back(this->current_connection_);
+        }
+        // Drain the nursery too: on shutdown an unproven connection would otherwise keep holding
+        // its transport until a nursery deadline reaps it.
+        for (auto& entry : this->nursery_) {
+            if (entry.conn->is_connected()) {
+                to_disconnect.push_back(entry.conn);
+            }
+        }
+    }
+    for (auto& conn : to_disconnect) {
+        conn->disconnect(reason, nullptr);
     }
 }
 
@@ -126,18 +197,35 @@ void ConnectionManager::init_server(SendspinClient* client) {
     this->ws_server_->set_max_connections(this->client_->config_.server_max_connections);
     this->ws_server_->set_ctrl_port(this->client_->config_.httpd_ctrl_port);
 
+    // Graceful rejection needs transport headroom: the manager can hold one established inbound
+    // connection plus NURSERY_CAPACITY unproven ones, and rejecting a surplus peer with a
+    // client/goodbye requires the transport to accept that peer's socket on top. Below this bound
+    // the nursery-full goodbye path is unreachable; surplus peers are refused at accept instead
+    // (and on ESP they wait unanswered in the TCP backlog, since httpd stops accepting).
+    if (this->client_->config_.server_max_connections < NURSERY_CAPACITY + 2) {
+        SS_LOGW(TAG,
+                "server_max_connections (%u) is below %u (1 established + %u nursery + 1 spare); "
+                "surplus peers will be refused at accept instead of receiving a goodbye",
+                static_cast<unsigned>(this->client_->config_.server_max_connections),
+                static_cast<unsigned>(NURSERY_CAPACITY + 2),
+                static_cast<unsigned>(NURSERY_CAPACITY));
+    }
+
     this->ws_server_->set_new_connection_callback(
         [this](std::shared_ptr<SendspinServerConnection> conn) {
             this->on_new_connection(std::move(conn));
         });
 
-    this->ws_server_->set_connection_closed_callback([this](int sockfd) {
-        SS_LOGD(TAG, "Connection closed callback for socket %d", sockfd);
-        // Defer the actual cleanup to loop() so on_connection_lost runs on the main thread
-        // alongside the rest of the connection state mutations.
-        std::lock_guard<std::mutex> lock(this->conn_mutex_);
-        this->pending_close_events_.push_back(sockfd);
-    });
+    this->ws_server_->set_connection_closed_callback(
+        [this](std::shared_ptr<SendspinServerConnection> conn) {
+            SS_LOGD(TAG, "Connection closed callback for socket %d", conn->get_sockfd());
+            // Defer cleanup to loop() so on_connection_lost runs on the main thread alongside the
+            // rest of the connection state mutations. Inbound closes share the outbound disconnect
+            // queue: both carry the connection itself, so a stale event can never be mis-routed to
+            // a new connection (drop_connection no-ops on connections it does not manage).
+            std::lock_guard<std::mutex> lock(this->conn_mutex_);
+            this->pending_disconnect_events_.push_back(std::move(conn));
+        });
 
     // Connection lookup-by-sockfd. Used by the host build's ws_server to route IXWebSocket
     // messages; the ESP build ignores this and looks the connection up directly via
@@ -149,9 +237,10 @@ void ConnectionManager::init_server(SendspinClient* client) {
                 this->current_connection_->get_sockfd() == sockfd) {
                 return this->current_connection_;
             }
-            if (this->pending_connection_ != nullptr &&
-                this->pending_connection_->get_sockfd() == sockfd) {
-                return this->pending_connection_;
+            for (const auto& entry : this->nursery_) {
+                if (entry.conn->get_sockfd() == sockfd) {
+                    return entry.conn;
+                }
             }
             return nullptr;
         });
@@ -173,87 +262,106 @@ void ConnectionManager::loop() {
 
     // Process deferred connection lifecycle events
     {
-        std::vector<int> close_events;
         std::vector<std::shared_ptr<SendspinConnection>> connected_events;
         std::vector<std::shared_ptr<SendspinConnection>> disconnect_events;
-        std::vector<ServerHelloEvent> hello_events;
         {
             std::lock_guard<std::mutex> lock(this->conn_mutex_);
-            close_events.swap(this->pending_close_events_);
             connected_events.swap(this->pending_connected_events_);
             disconnect_events.swap(this->pending_disconnect_events_);
-            hello_events.swap(this->pending_hello_events_);
         }
 
         {
             std::lock_guard<std::mutex> lock(this->conn_ptr_mutex_);
 
-            // Server connection close events (ESP httpd)
-            for (int sockfd : close_events) {
-                if (this->current_connection_ != nullptr &&
-                    this->current_connection_->get_sockfd() == sockfd) {
-                    SendspinConnection* conn = this->current_connection_.get();
-                    this->on_connection_lost(conn);
-                } else if (this->pending_connection_ != nullptr &&
-                           this->pending_connection_->get_sockfd() == sockfd) {
-                    SendspinConnection* conn = this->pending_connection_.get();
-                    this->on_connection_lost(conn);
-                }
-            }
-
-            // Client connection disconnect events (host IXWebSocket)
+            // Connection close/disconnect events (inbound ws_server closes on both platforms,
+            // outbound host IXWebSocket disconnects). Keyed on connection identity, never on
+            // sockfd: the OS recycles fds, so an fd-keyed event could outlive its connection and
+            // mis-route to a newcomer admitted onto the recycled fd. A connection already
+            // released by an earlier event is a no-op inside drop_connection.
             for (auto& conn : disconnect_events) {
                 this->on_connection_lost(conn.get());
             }
 
-            // Process deferred connected events (initiate hello on main thread)
+            // Transport connected events: an outbound connection's WebSocket upgrade completed,
+            // so arm its hello. (Inbound connections arrive already upgraded and armed theirs at
+            // admission.) Guarded by nursery membership: a connection promoted or released by an
+            // earlier event is skipped, and a duplicate event just re-arms the retry in place.
             for (auto& conn : connected_events) {
-                if (conn == this->current_connection_ || conn == this->pending_connection_) {
+                if (this->find_in_nursery(conn.get()) != this->nursery_.end()) {
                     this->initiate_hello(conn.get());
                 }
             }
 
-            // Server hello events: handshake completion and handoff
-            for (auto& event : hello_events) {
-                // Verify the connection is still one we manage (and not null)
-                if (!event.conn || (event.conn != this->current_connection_ &&
-                                    event.conn != this->pending_connection_)) {
+            // Establishment: promote nursery connections whose hello handshake has completed.
+            // Level-triggered on the connection's own proven flags (client_hello_sent_ from the
+            // send completion, server_hello_received_ from server/hello processing, both set on
+            // network threads) rather than edge-triggered on producer events, so the order the two
+            // flags are set in is irrelevant: a nonconforming peer whose server/hello races ahead
+            // of our client/hello is picked up on the tick after the send completes. A connection
+            // leaves the nursery only here (handshake complete) or by being reaped, so the current
+            // slot never holds a connection that has not proven itself.
+            for (auto it = this->nursery_.begin(); it != this->nursery_.end();) {
+                if (!it->conn->is_handshake_complete()) {
+                    ++it;
+                    continue;
+                }
+                auto conn = std::move(it->conn);
+                it = this->nursery_.erase(it);
+                this->remove_hello_retry(conn.get());
+
+                if (this->current_connection_ == nullptr) {
+                    this->current_connection_ = std::move(conn);
+                } else if (this->should_switch_to_new_server(this->current_connection_.get(),
+                                                             conn.get())) {
+                    // Both sides of the comparison are established, so the PLAYBACK-reason and
+                    // last-played-server preferences always ran on real data. No incumbent is
+                    // ever evicted on timing alone.
+                    SS_LOGI(TAG, "Handoff decision: switch to new server");
+                    this->drop_connection(this->current_connection_.get(),
+                                          SendspinGoodbyeReason::ANOTHER_SERVER);
+                    this->current_connection_ = std::move(conn);
+                } else {
+                    SS_LOGI(TAG, "Handoff decision: keep current server");
+                    // Leaving management: block stale network-thread dispatch during the goodbye
+                    // window (outgoing sends, including the goodbye itself, are unaffected).
+                    conn->disable_message_dispatch();
+                    this->deferred_releases_.push_back(
+                        {std::move(conn), SendspinGoodbyeReason::ANOTHER_SERVER});
                     continue;
                 }
 
-                // Notify client and publish state
-                this->client_->on_handshake_complete(event.conn.get());
+                // Notify the client and publish state, only for the winner and never for a
+                // connection that is about to receive a goodbye.
+                this->client_->on_handshake_complete(this->current_connection_.get());
 
                 SS_LOGI(TAG, "Connection handshake complete: server_id=%s, connection_reason=%s",
-                        event.conn->get_server_id().c_str(),
-                        to_cstr(event.conn->get_connection_reason()));
-
-                // Handle handoff if pending connection completed its handshake
-                if (this->pending_connection_ != nullptr &&
-                    this->pending_connection_ == event.conn) {
-                    bool should_switch = this->should_switch_to_new_server(
-                        this->current_connection_.get(), event.conn.get());
-                    SS_LOGI(TAG, "Handoff decision: %s",
-                            should_switch ? "switch to new" : "keep current");
-                    this->complete_handoff(should_switch);
-                }
+                        this->current_connection_->get_server_id().c_str(),
+                        to_cstr(this->current_connection_->get_connection_reason()));
             }
         }
+
+        // Send the goodbyes and release the connections dropped above, outside the lock.
+        this->flush_deferred_releases();
     }
 
-    // Call loop on active connections using shared_ptr copies to avoid holding the lock
+    // Call loop on active connections using shared_ptr copies to avoid holding the lock. The
+    // nursery is bounded (NURSERY_CAPACITY inbound + 1 outbound), so a fixed array avoids a
+    // per-tick heap allocation while connections are being set up.
     std::shared_ptr<SendspinConnection> current_copy;
-    std::shared_ptr<SendspinConnection> pending_copy;
+    std::array<std::shared_ptr<SendspinConnection>, NURSERY_CAPACITY + 1> nursery_copies;
+    size_t nursery_count = 0;
     {
         std::lock_guard<std::mutex> lock(this->conn_ptr_mutex_);
         current_copy = this->current_connection_;
-        pending_copy = this->pending_connection_;
+        for (const auto& entry : this->nursery_) {
+            nursery_copies[nursery_count++] = entry.conn;
+        }
     }
     if (current_copy) {
         current_copy->loop();
     }
-    if (pending_copy) {
-        pending_copy->loop();
+    for (size_t i = 0; i < nursery_count; ++i) {
+        nursery_copies[i]->loop();
     }
 
     // Check hello retry timers (one entry per managed connection, so a second connection arriving
@@ -264,9 +372,10 @@ void ConnectionManager::loop() {
         for (auto it = this->hello_retries_.begin(); it != this->hello_retries_.end();) {
             HelloRetryState& retry = *it;
 
-            // Drop retries whose connection is no longer managed.
-            if (retry.conn != this->current_connection_ &&
-                retry.conn != this->pending_connection_) {
+            // Drop retries whose connection has left the nursery. A retry entry is live only for
+            // nursery members: the current connection is established by construction and never
+            // awaits a hello.
+            if (this->find_in_nursery(retry.conn.get()) == this->nursery_.end()) {
                 it = this->hello_retries_.erase(it);
                 continue;
             }
@@ -277,12 +386,12 @@ void ConnectionManager::loop() {
             }
 
             if (this->send_hello_message(retry.attempts - 1, retry.conn.get())) {
-                // Sent successfully (or connection no longer valid) - retry is complete.
+                // Sent, or the connection left the nursery; the retry is complete.
                 it = this->hello_retries_.erase(it);
                 continue;
             }
 
-            // Transient failure - retry with exponential backoff until attempts are exhausted.
+            // Transient failure: retry with exponential backoff until attempts are exhausted.
             if (retry.attempts > 1) {
                 retry.delay_ms *= 2;
                 retry.attempts--;
@@ -294,33 +403,35 @@ void ConnectionManager::loop() {
         }
     }
 
-    // Provisional-connection timeout: drop any managed connection that has not completed the
-    // hello handshake within PROVISIONAL_CONNECTION_TIMEOUT_US. This is the only release path
-    // for connections whose socket died before the WebSocket session was established (the host
-    // transport never delivers a close for those, issue #75) and for peers that connect and then
-    // stall without completing the hello (both platforms).
+    // Nursery tick: reap connections that miss the establish deadline. This is the only release
+    // path for peers that connect and then stall without completing the hello, and for outbound
+    // sockets whose transport never delivers a close (host IXWebSocket, issue #75). Hello arming
+    // is event-driven (admission for inbound, connected event for outbound), so the tick only
+    // ever reaps.
     {
         std::lock_guard<std::mutex> lock(this->conn_ptr_mutex_);
         const int64_t now_us = platform_time_us();
-        auto handshake_expired = [now_us](const std::shared_ptr<SendspinConnection>& conn) {
-            if (conn == nullptr || conn->is_handshake_complete()) {
-                return false;
+        for (auto it = this->nursery_.begin(); it != this->nursery_.end();) {
+            NurseryEntry& entry = *it;
+            if (now_us - entry.conn->get_provisional_time_us() >= NURSERY_ESTABLISH_TIMEOUT_US) {
+                SS_LOGW(TAG, "Nursery connection stalled at %s (>%d s), dropping",
+                        to_cstr(setup_stage(*entry.conn)),
+                        static_cast<int>(NURSERY_ESTABLISH_TIMEOUT_US / US_PER_SECOND));
+                it = this->release_nursery_entry(it, SendspinGoodbyeReason::ANOTHER_SERVER);
+                continue;
             }
-            const int64_t prov_time = conn->get_provisional_time_us();
-            return prov_time != 0 && (now_us - prov_time) >= PROVISIONAL_CONNECTION_TIMEOUT_US;
-        };
-        if (handshake_expired(this->pending_connection_)) {
-            SS_LOGW(TAG, "Pending connection timed out (>%d s without completing hello), dropping",
-                    static_cast<int>(PROVISIONAL_CONNECTION_TIMEOUT_S));
-            this->drop_connection(this->pending_connection_.get(),
-                                  SendspinGoodbyeReason::ANOTHER_SERVER);
+            ++it;
         }
-        if (handshake_expired(this->current_connection_)) {
-            SS_LOGW(TAG, "Current connection timed out (>%d s without completing hello), dropping",
-                    static_cast<int>(PROVISIONAL_CONNECTION_TIMEOUT_S));
-            this->drop_connection(this->current_connection_.get(),
-                                  SendspinGoodbyeReason::ANOTHER_SERVER);
-        }
+    }
+
+    // Send the goodbyes and release the connections reaped by the nursery tick, outside the lock.
+    this->flush_deferred_releases();
+
+    // Drive the platform ws_server's pending-upgrade reap (ESP: close sessions that never
+    // complete their upgrade; host: no-op, IXWebSocket times them out itself). Called with no
+    // manager lock held.
+    if (this->ws_server_ != nullptr) {
+        this->ws_server_->tick();
     }
 }
 
@@ -332,15 +443,6 @@ bool ConnectionManager::is_connected() const {
     std::lock_guard<std::mutex> lock(this->conn_ptr_mutex_);
     return this->current_connection_ != nullptr && this->current_connection_->is_connected() &&
            this->current_connection_->is_handshake_complete();
-}
-
-// ============================================================================
-// Event queuing (thread-safe)
-// ============================================================================
-
-void ConnectionManager::schedule_hello(ServerHelloEvent event) {
-    std::lock_guard<std::mutex> lock(this->conn_mutex_);
-    this->pending_hello_events_.push_back(std::move(event));
 }
 
 // ============================================================================
@@ -366,11 +468,6 @@ uint32_t ConnectionManager::fnv1_hash(const char* str) {
 // ============================================================================
 
 void ConnectionManager::setup_connection_callbacks(SendspinConnection* conn) {
-    conn->on_connected_cb = [this](SendspinConnection* c) {
-        // Defer to loop(); this callback runs on the network thread
-        std::lock_guard<std::mutex> lock(this->conn_mutex_);
-        this->pending_connected_events_.push_back(c->shared_from_this());
-    };
     conn->on_json_message_cb = [this](SendspinConnection* c, const char* data, size_t len,
                                       int64_t timestamp) {
         this->client_->process_json_message(c, data, len, timestamp);
@@ -378,15 +475,14 @@ void ConnectionManager::setup_connection_callbacks(SendspinConnection* conn) {
     conn->on_binary_message_cb = [this](SendspinConnection* /*c*/, uint8_t* payload, size_t len) {
         this->client_->process_binary_message(payload, len);
     };
-    conn->on_handshake_complete_cb = [](SendspinConnection* /*c*/) {
-        // Handshake completion is handled via deferred hello events in loop()
-    };
 }
 
 void ConnectionManager::on_new_connection(std::shared_ptr<SendspinServerConnection> conn) {
-    // Called from the platform's new-connection callback (ESP: httpd open_callback). The
-    // authoritative owner is the platform's session/transport context; this observer shared_ptr
-    // can be reset at any time without freeing the conn out from under in-flight workers.
+    // Called from the platform ws_server's delivery path (ESP: httpd task, host: IXWebSocket
+    // thread) once the connection's WebSocket upgrade has been observed, so the manager never sees
+    // a socket that has not proven it speaks WebSocket. The authoritative owner is the platform's
+    // session/transport context; this observer shared_ptr can be reset at any time without freeing
+    // the conn out from under in-flight workers.
     conn->init_time_filter();
     conn->set_websocket_payload_location(this->client_->config_.websocket_payload_location);
 
@@ -395,36 +491,42 @@ void ConnectionManager::on_new_connection(std::shared_ptr<SendspinServerConnecti
         // Cleanup happens in on_connection_lost triggered by the server
     };
 
-    // Start the provisional-timeout window: loop() reaps the connection if the hello handshake
-    // has not completed within PROVISIONAL_CONNECTION_TIMEOUT_US. This is the release path for
-    // sockets that die before the WebSocket session is established: the host transport delivers
-    // no close for those, so without the timeout they would hold a slot forever (issue #75).
+    // Start the establish clock: loop() reaps the connection if it does not complete the hello
+    // handshake within NURSERY_ESTABLISH_TIMEOUT_US.
     conn->set_provisional_time_us(platform_time_us());
 
-    std::lock_guard<std::mutex> lock(this->conn_ptr_mutex_);
-    SendspinConnection* accepted_conn = nullptr;
-    if (this->current_connection_ == nullptr) {
-        SS_LOGD(TAG, "No existing connection, accepting as current");
-        this->current_connection_ = std::move(conn);
-        accepted_conn = this->current_connection_.get();
-    } else {
-        SS_LOGD(TAG, "Existing connection present, setting as pending for handoff");
-        if (this->pending_connection_ != nullptr) {
-            SS_LOGW(TAG, "Already have pending connection, rejecting new connection");
-            this->disconnect_and_release(std::move(conn), SendspinGoodbyeReason::ANOTHER_SERVER);
-            return;
-        }
-        this->pending_connection_ = std::move(conn);
-        accepted_conn = this->pending_connection_.get();
-    }
+    {
+        std::lock_guard<std::mutex> lock(this->conn_ptr_mutex_);
 
-    // Some ESP-IDF/httpd versions complete the WebSocket upgrade without dispatching the initial
-    // HTTP_GET request to websocket_handler(). Arm the hello retry from the accept path as well so
-    // server-initiated connections always receive client/hello. If the GET callback arrives later,
-    // initiate_hello() only re-arms the existing per-connection retry entry.
-    if (accepted_conn != nullptr) {
-        this->initiate_hello(accepted_conn);
+        // The newcomer has not completed the hello handshake, so it never touches the current
+        // slot; it enters the bounded nursery and is promoted only once it establishes. Only
+        // inbound entries count against the capacity (see NURSERY_CAPACITY). If the inbound slots
+        // are full, reject the newcomer: every occupant speaks WebSocket, so there is no safe
+        // eviction candidate. The goodbye reaches the peer because its session is already upgraded,
+        // provided the transport had a socket to accept it on (the NURSERY_CAPACITY + 2 budget).
+        size_t inbound_count = 0;
+        for (const auto& entry : this->nursery_) {
+            if (entry.inbound) {
+                ++inbound_count;
+            }
+        }
+        if (inbound_count >= NURSERY_CAPACITY) {
+            SS_LOGW(TAG, "Nursery full of live connections, rejecting new connection");
+            // Never managed, but its callbacks are already wired: block dispatch so it cannot
+            // inject messages during the goodbye window.
+            conn->disable_message_dispatch();
+            this->deferred_releases_.push_back(
+                {std::move(conn), SendspinGoodbyeReason::ANOTHER_SERVER});
+        } else {
+            SS_LOGD(TAG, "Admitting new connection into the nursery");
+            // Arm the hello right away: the connection arrives WS-upgraded, so there is no
+            // earlier signal to wait for. (Outbound connections instead arm theirs when the
+            // transport's connected event is processed in loop().)
+            this->initiate_hello(conn.get());
+            this->nursery_.push_back(NurseryEntry{std::move(conn), /*inbound=*/true});
+        }
     }
+    this->flush_deferred_releases();
 }
 
 // ============================================================================
@@ -470,8 +572,9 @@ void ConnectionManager::remove_hello_retry(SendspinConnection* conn) {
 }
 
 bool ConnectionManager::send_hello_message(uint8_t remaining_attempts, SendspinConnection* conn) {
-    // Verify the connection is still one of our managed connections
-    if (conn != this->current_connection_.get() && conn != this->pending_connection_.get()) {
+    // Verify the connection is still awaiting establishment (hellos are only ever sent to nursery
+    // members; the current connection is established by construction).
+    if (this->find_in_nursery(conn) == this->nursery_.end()) {
         SS_LOGW(TAG, "Connection no longer valid for hello message");
         return true;
     }
@@ -486,11 +589,16 @@ bool ConnectionManager::send_hello_message(uint8_t remaining_attempts, SendspinC
     SsErr err = conn->send_text_message(
         hello_message,
         [conn](bool success) {
-            if (success) {
-                conn->set_client_hello_sent(true);
-            } else {
+            // Runs on the transport's send-completion context (httpd worker on ESP, inline on
+            // host); conn is kept alive for the duration by the transport (see AsyncRespArg).
+            // Setting the flag is all that is needed: establishment is level-triggered, so
+            // loop()'s promotion scan observes is_handshake_complete() on its next tick even
+            // when the peer's server/hello raced ahead of this send.
+            if (!success) {
                 SS_LOGW(TAG, "Hello message send failed");
+                return;
             }
+            conn->set_client_hello_sent(true);
         },
         /*allow_before_hello=*/true);
 
@@ -512,6 +620,47 @@ bool ConnectionManager::send_hello_message(uint8_t remaining_attempts, SendspinC
 // Connection lifecycle
 // ============================================================================
 
+std::vector<NurseryEntry>::iterator ConnectionManager::find_in_nursery(
+    const SendspinConnection* conn) {
+    // Note: caller must hold conn_ptr_mutex_
+    for (auto it = this->nursery_.begin(); it != this->nursery_.end(); ++it) {
+        if (it->conn.get() == conn) {
+            return it;
+        }
+    }
+    return this->nursery_.end();
+}
+
+std::vector<NurseryEntry>::iterator ConnectionManager::release_nursery_entry(
+    std::vector<NurseryEntry>::iterator it, std::optional<SendspinGoodbyeReason> reason) {
+    // Note: caller must hold conn_ptr_mutex_ and flush_deferred_releases() after dropping it
+    auto conn = std::move(it->conn);
+    auto next = this->nursery_.erase(it);
+    // Leaving management: block stale network-thread dispatch into role/state queues during the
+    // goodbye window. Outgoing sends, including the goodbye itself, are unaffected.
+    conn->disable_message_dispatch();
+    this->remove_hello_retry(conn.get());
+    this->deferred_releases_.push_back({std::move(conn), reason});
+    return next;
+}
+
+void ConnectionManager::flush_deferred_releases() {
+    // Note: caller must NOT hold conn_ptr_mutex_ (see DeferredRelease)
+    std::vector<DeferredRelease> releases;
+    {
+        std::lock_guard<std::mutex> lock(this->conn_ptr_mutex_);
+        releases.swap(this->deferred_releases_);
+    }
+    for (auto& release : releases) {
+        if (release.goodbye.has_value()) {
+            this->disconnect_and_release(std::move(release.conn), release.goodbye.value());
+        }
+        // Without a goodbye the shared_ptr simply drops (below, when `releases` goes out of
+        // scope): even bare destruction happens outside the lock, because a connection
+        // destructor can join its transport thread.
+    }
+}
+
 void ConnectionManager::on_connection_lost(SendspinConnection* conn) {
     // Note: caller must hold conn_ptr_mutex_ (reads the slots and calls drop_connection)
     if (conn == nullptr) {
@@ -520,8 +669,8 @@ void ConnectionManager::on_connection_lost(SendspinConnection* conn) {
 
     if (conn == this->current_connection_.get()) {
         SS_LOGI(TAG, "Current connection lost");
-    } else if (conn == this->pending_connection_.get()) {
-        SS_LOGD(TAG, "Pending connection lost");
+    } else if (this->find_in_nursery(conn) != this->nursery_.end()) {
+        SS_LOGD(TAG, "Nursery connection lost");
     }
 
     // The transport is already gone, so no goodbye is attempted (nullopt).
@@ -538,38 +687,28 @@ void ConnectionManager::drop_connection(SendspinConnection* conn,
     this->remove_hello_retry(conn);
 
     if (conn == this->current_connection_.get()) {
-        // Dropping the admitted connection: block stale network-thread events, quiesce the
-        // client's per-connection state, and promote the pending connection if one exists.
+        // Dropping the admitted connection: block stale network-thread events and quiesce the
+        // client's per-connection state (including the time burst). The slot stays empty; the next
+        // nursery establishment promotes into it. The goodbye send and the release itself are
+        // deferred (see DeferredRelease).
         conn->disable_message_dispatch();
-        this->client_->time_burst_->reset();
         this->client_->cleanup_connection_state();
-        // std::exchange (not std::move) so the slots are never left in a moved-from state the
-        // static analyzer flags when a later event in the same loop() pass reads them.
-        auto conn_to_drop = std::exchange(this->current_connection_, nullptr);
-        if (this->pending_connection_ != nullptr) {
-            SS_LOGD(TAG, "Promoting pending connection to current");
-            this->current_connection_ = std::exchange(this->pending_connection_, nullptr);
-        }
-        if (goodbye.has_value()) {
-            this->disconnect_and_release(std::move(conn_to_drop), goodbye.value());
-        }
-        // Without a goodbye (connection already lost), conn_to_drop releases here.
-    } else if (conn == this->pending_connection_.get()) {
-        // Dropping a pending connection: no client-state cleanup (it was never promoted).
-        auto conn_to_drop = std::exchange(this->pending_connection_, nullptr);
-        if (goodbye.has_value()) {
-            this->disconnect_and_release(std::move(conn_to_drop), goodbye.value());
-        }
+        // std::exchange (not std::move) so the slot is never left in a moved-from state the
+        // static analyzer flags when a later event in the same loop() pass reads it.
+        this->deferred_releases_.push_back(
+            {std::exchange(this->current_connection_, nullptr), goodbye});
+        return;
+    }
+
+    if (auto it = this->find_in_nursery(conn); it != this->nursery_.end()) {
+        // Dropping an unproven connection: no client-state cleanup (it was never admitted).
+        this->release_nursery_entry(it, goodbye);
     }
     // Not a managed connection: nothing to do (already released by an earlier event this tick).
 }
 
 bool ConnectionManager::should_switch_to_new_server(SendspinConnection* current,
                                                     SendspinConnection* new_conn) const {
-    if (current == nullptr || new_conn == nullptr) {
-        return new_conn != nullptr;
-    }
-
     auto new_reason = new_conn->get_connection_reason();
     auto current_reason = current->get_connection_reason();
 
@@ -600,27 +739,6 @@ bool ConnectionManager::should_switch_to_new_server(SendspinConnection* current,
 
     SS_LOGD(TAG, "Default handoff decision: keep existing");
     return false;
-}
-
-void ConnectionManager::complete_handoff(bool switch_to_new) {
-    // Note: caller must hold conn_ptr_mutex_
-    if (switch_to_new) {
-        SS_LOGD(TAG, "Completing handoff: switching to new server");
-        if (this->current_connection_ != nullptr) {
-            // drop_connection tears down the displaced current connection (with goodbye) and
-            // promotes the pending connection into the current slot.
-            this->drop_connection(this->current_connection_.get(),
-                                  SendspinGoodbyeReason::ANOTHER_SERVER);
-        } else {
-            this->current_connection_ = std::exchange(this->pending_connection_, nullptr);
-        }
-    } else {
-        SS_LOGD(TAG, "Completing handoff: keeping current server");
-        if (this->pending_connection_ != nullptr) {
-            this->drop_connection(this->pending_connection_.get(),
-                                  SendspinGoodbyeReason::ANOTHER_SERVER);
-        }
-    }
 }
 
 void ConnectionManager::disconnect_and_release(std::shared_ptr<SendspinConnection>&& conn,

--- a/src/connection_manager.h
+++ b/src/connection_manager.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "constants.h"
 #include "protocol_messages.h"
 #include "sendspin/client.h"
 
@@ -36,24 +37,45 @@ class SendspinConnection;
 class SendspinServerConnection;
 class SendspinWsServer;
 
-/// @brief Deferred server hello event, processed in ConnectionManager::loop()
-struct ServerHelloEvent {
-    std::shared_ptr<SendspinConnection> conn;  ///< Connection that received the hello
-    SendspinConnectionReason connection_reason;
+/// @brief Converts a duration in seconds to microseconds at compile time.
+constexpr int64_t seconds_to_us(double s) {
+    return static_cast<int64_t>(s * US_PER_SECOND);
+}
+
+/// @brief Deadline (seconds) for a nursery connection to complete the hello handshake, measured
+/// from delivery (inbound, already WS-upgraded) or initiation (outbound, before DNS/TCP resolve)
+///
+/// Reaps peers that connect and then stall before completing the hello, and outbound sockets whose
+/// transport never delivers a close (host IXWebSocket, issue #75). Sockets that never upgrade are
+/// closed in the platform layer before the manager sees them (ESP ws_server tick() at
+/// WS_UPGRADE_TIMEOUT_US; host IXWebSocket's 3 s handshake timeout).
+static constexpr double NURSERY_ESTABLISH_TIMEOUT_S = 30.0;
+
+/// @brief Timeout in microseconds (derived from NURSERY_ESTABLISH_TIMEOUT_S).
+static constexpr int64_t NURSERY_ESTABLISH_TIMEOUT_US = seconds_to_us(NURSERY_ESTABLISH_TIMEOUT_S);
+
+/// @brief A connection that has not completed the hello handshake
+///
+/// Unproven connections never occupy the current-connection slot; they wait in the bounded nursery
+/// until they establish, then are promoted (or released after losing the handoff comparison to an
+/// established incumbent). Inbound entries arrive WS-upgraded, so their hello is armed at
+/// admission; outbound entries arm theirs when the transport's connected event arrives.
+struct NurseryEntry {
+    std::shared_ptr<SendspinConnection> conn;  ///< Observer; the session slot / transport owns
+    bool inbound;  ///< true if accepted by the WS server, false for connect_to()
 };
 
-/// @brief Timeout for provisional (pre-handshake) connections in seconds.
-/// A connection that has not completed the hello handshake within this window is closed. This
-/// reaps connections whose transport never delivers a close for sockets that die before the
-/// WebSocket session is established (host IXWebSocket, issue #75) as well as peers that connect
-/// and stall without completing the hello (both platforms). Mirrors the encryption branch's
-/// provisional-connection timeout, whose reap is gated on is_awaiting_activate();
-/// !is_handshake_complete() is the plaintext analogue.
-static constexpr double PROVISIONAL_CONNECTION_TIMEOUT_S = 30.0;
-
-/// @brief Timeout in microseconds (derived from PROVISIONAL_CONNECTION_TIMEOUT_S).
-static constexpr int64_t PROVISIONAL_CONNECTION_TIMEOUT_US =
-    static_cast<int64_t>(PROVISIONAL_CONNECTION_TIMEOUT_S * 1'000'000LL);
+/// @brief A connection release deferred until conn_ptr_mutex_ has been dropped
+///
+/// Sending a goodbye can block on the transport, and even shared_ptr destruction can join the
+/// transport thread (the host outbound destructor stops its IXWebSocket). Neither may happen under
+/// the manager lock: the join can deadlock against a transport callback waiting on that same lock,
+/// and any block stalls every other manager entry point. Locked sections only queue releases;
+/// flush_deferred_releases() performs them lock-free.
+struct DeferredRelease {
+    std::shared_ptr<SendspinConnection> conn;      ///< Sole remaining manager reference
+    std::optional<SendspinGoodbyeReason> goodbye;  ///< nullopt: transport gone, just release
+};
 
 /// @brief Hello retry state for exponential backoff
 struct HelloRetryState {
@@ -69,6 +91,14 @@ struct HelloRetryState {
  *
  * Accepts and creates connections, handles the hello handshake, orchestrates server handoff
  * decisions, and performs graceful disconnection with deferred cleanup.
+ *
+ * Connections prove themselves before they are trusted: every new connection enters a bounded
+ * nursery and leaves it only by completing the hello handshake (promotion, or a fair comparison
+ * against the incumbent) or by missing the establish deadline (reaped). The platform ws_server
+ * delivers inbound connections only after observing their WebSocket upgrade, so the manager never
+ * reasons about raw sockets that might not speak WebSocket; those are closed inside the platform
+ * layer. Invariant: `current_connection_ != nullptr` implies
+ * `current_connection_->is_handshake_complete()`.
  *
  * Typical usage:
  *  1. Construct with a `SendspinClient*`.
@@ -103,6 +133,11 @@ public:
     void connect_to(const std::string& url);
 
     /// @brief Disconnects from the current server.
+    ///
+    /// Must be called from the main loop thread: conn->disconnect() runs outside conn_ptr_mutex_
+    /// (it can block on the transport, and on host outbound it joins the transport thread), so
+    /// only the main loop's serialization keeps it from racing loop()'s reap/handoff release of
+    /// the same connection into two concurrent transport stops.
     /// @param reason The goodbye reason to send before closing.
     void disconnect(SendspinGoodbyeReason reason);
 
@@ -145,14 +180,6 @@ public:
     }
 
     // ========================================
-    // Event queuing (thread-safe)
-    // ========================================
-
-    /// @brief Schedules a server hello event for deferred processing in loop().
-    /// @param event The server hello event to schedule (moved).
-    void schedule_hello(ServerHelloEvent event);
-
-    // ========================================
     // Handoff support
     // ========================================
 
@@ -170,11 +197,37 @@ private:
     /// @brief Attaches message and lifecycle callbacks to a connection.
     /// @param conn The connection to configure.
     void setup_connection_callbacks(SendspinConnection* conn);
-    /// @brief Accepts an incoming server connection as current or pending for handoff.
-    /// @param conn The newly accepted server connection. The session slot keeps a parallel
+    /// @brief Admits an incoming server connection into the nursery and arms its hello
+    ///
+    /// Never enters the current slot directly (the hello handshake is not complete yet). If the
+    /// inbound slots are full (outbound entries do not count) the newcomer is rejected with a
+    /// goodbye, which reaches the peer because its session is already upgraded.
+    /// @param conn The newly delivered server connection. The session slot keeps a parallel
     ///             refcount, so this observer can be reset at any time without freeing the conn
     ///             out from under in-flight httpd workers.
     void on_new_connection(std::shared_ptr<SendspinServerConnection> conn);
+
+    /// @brief Finds the nursery entry holding the given connection. Caller must hold
+    /// conn_ptr_mutex_.
+    /// @param conn The connection to look up.
+    /// @return Iterator into nursery_, or nursery_.end() if the connection is not in the nursery.
+    std::vector<NurseryEntry>::iterator find_in_nursery(const SendspinConnection* conn);
+
+    /// @brief Releases a nursery entry: erases it, prunes its hello retry, and queues the
+    /// goodbye+release on deferred_releases_. Caller must hold conn_ptr_mutex_ and call
+    /// flush_deferred_releases() after dropping it.
+    /// @param it Valid iterator into nursery_.
+    /// @param reason The goodbye reason to send before closing, or nullopt when the transport is
+    ///        already gone so no goodbye should be attempted.
+    /// @return Iterator to the entry after the erased one.
+    std::vector<NurseryEntry>::iterator release_nursery_entry(
+        std::vector<NurseryEntry>::iterator it, std::optional<SendspinGoodbyeReason> reason);
+
+    /// @brief Performs the queued goodbye sends and connection releases from deferred_releases_.
+    /// Caller must NOT hold conn_ptr_mutex_ (see DeferredRelease). Safe to call from any thread;
+    /// a queued release is performed exactly once. Called after every locked section that can
+    /// queue a release; loop() also calls it as a backstop.
+    void flush_deferred_releases();
 
     // ========================================
     // Hello handshake
@@ -195,50 +248,64 @@ private:
     // ========================================
     // Connection lifecycle
     // ========================================
-    /// @brief Tears down a lost connection and promotes the pending connection if one exists.
-    /// Caller must hold conn_ptr_mutex_.
+    /// @brief Tears down a lost connection (current or nursery). Caller must hold conn_ptr_mutex_.
     /// @param conn The connection that was lost.
     void on_connection_lost(SendspinConnection* conn);
     /// @brief Decides whether to switch from the current connection to the new one.
-    /// @param current The existing active connection.
-    /// @param new_conn The newly connected candidate connection.
+    /// @param current The existing active connection. Must not be null.
+    /// @param new_conn The newly connected candidate connection. Must not be null.
     /// @return True if the new connection should become current, false to keep the existing one.
     bool should_switch_to_new_server(SendspinConnection* current,
                                      SendspinConnection* new_conn) const;
-    /// @brief Completes a server handoff by promoting or discarding the pending connection.
-    /// @param switch_to_new True to promote the pending connection, false to discard it.
-    void complete_handoff(bool switch_to_new);
     /// @brief Sends a goodbye and takes ownership of the caller's shared_ptr so it drops at
     /// function exit.
     /// @param conn The connection to disconnect and release. Caller's shared_ptr is left empty.
     /// @param reason The goodbye reason to send before closing.
     void disconnect_and_release(std::shared_ptr<SendspinConnection>&& conn,
                                 SendspinGoodbyeReason reason);
-    /// @brief Single teardown path: releases a managed connection's slot, cleans up client state
-    /// (current slot only), promotes the pending connection, and optionally sends a goodbye.
+    /// @brief Single teardown path: removes a managed connection (the current slot or a nursery
+    /// entry), cleans up client state (current slot only), and queues the goodbye+release on
+    /// deferred_releases_. The current slot stays empty after a drop; the next nursery
+    /// establishment promotes into it.
     ///
     /// No-op if conn is null. If conn is not a managed connection (already released by an
     /// earlier event in the same loop() pass), only its stale hello-retry entry, if any, is
-    /// pruned. Caller must hold conn_ptr_mutex_.
+    /// pruned. Caller must hold conn_ptr_mutex_ and call flush_deferred_releases() after
+    /// dropping it.
     ///
-    /// @param conn The connection to drop; must be current_connection_ or pending_connection_.
+    /// @param conn The connection to drop; must be current_connection_ or a nursery entry.
     /// @param goodbye Goodbye reason to send before closing, or nullopt when the transport is
     ///        already gone (connection-lost path) so no goodbye should be attempted.
     void drop_connection(SendspinConnection* conn, std::optional<SendspinGoodbyeReason> goodbye);
 
+    /// @brief Maximum number of unproven inbound connections held at once
+    ///
+    /// The platform ws_server delivers only WS-upgraded sessions, so nursery slots are only ever
+    /// occupied by peers that speak WebSocket; raw-TCP junk never reaches the nursery. Outbound
+    /// entries do not count against the capacity in either direction: a user-initiated connect_to()
+    /// is admitted even against full inbound slots, and an in-flight connect_to() never causes an
+    /// inbound peer to be rejected. An outbound entry always replaces any previous one, so the
+    /// bound on the whole nursery is NURSERY_CAPACITY + 1.
+    ///
+    /// Socket-budget invariant: gracefully rejecting a surplus inbound peer requires the transport
+    /// to accept NURSERY_CAPACITY + 2 sockets (1 established + the nursery + the surplus peer,
+    /// which must be connected to receive its goodbye). The default server_max_connections
+    /// satisfies this; init_server warns when a configured value does not.
+    static constexpr size_t NURSERY_CAPACITY = 2;
+
     // Struct fields
-    std::mutex conn_mutex_;              // Protects deferred lifecycle event queues
-    mutable std::mutex conn_ptr_mutex_;  // Protects current_connection_ and pending_connection_
-    std::vector<HelloRetryState> hello_retries_;  // One entry per connection awaiting its hello
-    std::vector<int> pending_close_events_;
+    std::mutex conn_mutex_;                           // Protects deferred lifecycle event queues
+    mutable std::mutex conn_ptr_mutex_;               // Protects current_connection_, nursery_, and
+                                                      // deferred_releases_
+    std::vector<DeferredRelease> deferred_releases_;  // Queued releases; see DeferredRelease
+    std::vector<NurseryEntry> nursery_;               // Unproven connections awaiting establishment
+    std::vector<HelloRetryState> hello_retries_;      // One entry per connection awaiting its hello
     std::vector<std::shared_ptr<SendspinConnection>> pending_connected_events_;
     std::vector<std::shared_ptr<SendspinConnection>> pending_disconnect_events_;
-    std::vector<ServerHelloEvent> pending_hello_events_;
 
     // Pointer fields
     SendspinClient* client_;
     std::shared_ptr<SendspinConnection> current_connection_;
-    std::shared_ptr<SendspinConnection> pending_connection_;
     std::unique_ptr<SendspinWsServer> ws_server_;
 
     // 32-bit fields

--- a/src/esp/server_connection.cpp
+++ b/src/esp/server_connection.cpp
@@ -86,13 +86,12 @@ void SendspinServerConnection::disconnect(SendspinGoodbyeReason reason,
         return;
     }
 
-    // Send goodbye, then trigger close, then invoke the user callback. Capture a weak_ptr to
-    // self instead of raw `this`: the worker normally finds the conn via the session slot
-    // (keeping it alive through the completion), but a weak_ptr makes that invariant explicit
-    // and avoids any UAF if the worker ever runs after the slot has been freed (e.g., across
-    // ESP-IDF versions whose httpd drain-before-free_fn ordering differs from the version we
-    // designed against). Skipping trigger_close() when the conn is already gone is harmless --
-    // the session is gone too.
+    // Send goodbye, then trigger close, then invoke the user callback. Capture a weak_ptr to self
+    // instead of raw `this`: the worker normally finds the conn via the session slot (keeping it
+    // alive through the completion), but a weak_ptr makes that invariant explicit and avoids a UAF
+    // if the worker ever runs after the slot has been freed (e.g. across ESP-IDF versions whose
+    // httpd drain-before-free_fn ordering differs). Skipping trigger_close() when the conn is
+    // already gone is harmless; the session is gone too.
     std::weak_ptr<SendspinServerConnection> weak_self =
         std::static_pointer_cast<SendspinServerConnection>(this->shared_from_this());
     this->send_goodbye_reason(reason, [weak_self, on_complete](bool /*success*/) {
@@ -174,12 +173,21 @@ SsErr SendspinServerConnection::send_text_message(const std::string& message,
 }
 
 void SendspinServerConnection::trigger_close() {
-    if (this->sockfd_ >= 0) {
-        httpd_sess_trigger_close(this->server_, this->sockfd_);
+    // Gate on is_connected(): once close_callback has marked this connection closed, httpd may
+    // recycle the fd onto a freshly-accepted session, and closing by the stale fd would kill the
+    // wrong peer. A residual instruction-scale TOCTOU remains (the session could close between
+    // this check and the call below); eliminating it entirely would need an identity check on
+    // the httpd task itself, which is not worth the extra queue hop for a close-time race.
+    if (!this->is_connected()) {
+        return;
     }
+    httpd_sess_trigger_close(this->server_, this->sockfd_);
 }
 
 SS_HOT esp_err_t SendspinServerConnection::handle_data(httpd_req_t* req, int64_t receive_time) {
+    // The connection was delivered (and marked WS-upgraded) from the upgrade GET before any
+    // frame can arrive; frames on a never-delivered connection are dropped by the null guards
+    // in dispatch_completed_message.
     httpd_ws_frame_t ws_pkt;
     memset(&ws_pkt, 0, sizeof(httpd_ws_frame_t));
 
@@ -246,7 +254,7 @@ bool SendspinServerConnection::send_time_message() {
     // The worker resolves the originating connection via the weak_ptr below, so a recycled sockfd
     // cannot redirect the frame and a destroyed connection yields a clean no-op. The JSON is built
     // inside the worker so client_transmitted is captured as close to the wire send as possible.
-    // SessionLookup now holds a weak_ptr, so it is constructed with placement new and explicitly
+    // SessionLookup holds a weak_ptr, so it is constructed with placement new and explicitly
     // destroyed before free (matching the AsyncRespArg convention).
     auto* lookup = static_cast<SessionLookup*>(platform_malloc_internal(sizeof(SessionLookup)));
     if (lookup == nullptr) {
@@ -310,15 +318,13 @@ void SendspinServerConnection::async_send_text(void* arg) {
     ws_pkt.type = HTTPD_WS_TYPE_TEXT;
 
     // Resolve the originating connection. weak_ptr.lock() yields the exact conn that queued this
-    // work (or null if it has since been destroyed), so a recycled sockfd can never redirect the
-    // frame onto a different connection -- the lifetime-safe replacement for the old raw `this`
-    // pointer that caused the use-after-free crash. Non-handshake frames are additionally gated on
-    // client_hello_sent_ so nothing can precede the client/hello; allow_before_hello opts the hello
-    // and goodbye out of that gate. The completion callback fires only when the frame is actually
-    // sent: it is skipped both when the gate blocks the frame AND when the connection is already
-    // gone (lock() is null) -- allow_before_hello bypasses the gate but not the conn-alive
-    // requirement, so callers must not rely on the callback as an unconditional "send finished"
-    // signal.
+    // work (or null if it has been destroyed), so a recycled sockfd can never redirect the frame
+    // onto a different connection. Non-handshake frames are gated on client_hello_sent_ so nothing
+    // can precede the client/hello; allow_before_hello opts the hello and goodbye out of that gate.
+    // The completion callback fires only when the frame is sent: it is skipped both when the gate
+    // blocks the frame and when the connection is already gone (lock() is null).
+    // allow_before_hello bypasses the gate but not the conn-alive requirement, so callers must not
+    // rely on the callback as an unconditional "send finished" signal.
     auto conn = resp_arg->conn.lock();
     if (conn && conn->is_connected() &&
         (resp_arg->allow_before_hello || conn->client_hello_sent_)) {

--- a/src/esp/ws_server.cpp
+++ b/src/esp/ws_server.cpp
@@ -19,6 +19,7 @@
 #include "platform/compiler.h"
 #include "platform/logging.h"
 #include "server_connection.h"
+#include <esp_idf_version.h>
 #include <esp_timer.h>
 
 namespace sendspin {
@@ -27,27 +28,22 @@ namespace sendspin {
 // SendspinWsServer
 // ============================================================================
 //
-// Manages the HTTP server (httpd) that accepts incoming WebSocket connections.
-//
-// Key Design Points:
-// - The server listener ACCEPTS connections but doesn't OWN them long-term
-// - When a client connects, it creates a SendspinServerConnection and hands it to the
-//   SendspinClient
-// - The SendspinClient decides whether to keep or reject the connection (for handoff logic)
-// - Supports max_connections=2 by default to enable handoff protocol:
-//   - One active connection is managed by the client
-//   - A second connection can be accepted temporarily during handoff
-//   - The client completes the handshake and decides which to keep
-//
-// Lifecycle:
-// 1. SendspinClient calls start() with callbacks and configuration
-// 2. Server listens on the configured port at /sendspin
-// 3. open_callback() creates SendspinServerConnection instances
-// 4. SendspinClient receives connection via new_connection_callback
-// 5. SendspinClient manages connection ownership and handoff logic
-// 6. close_callback() handles socket cleanup
+// httpd server that accepts incoming WebSocket connections. open_callback() creates each
+// SendspinServerConnection and parks it in the pending table; it is delivered to the
+// SendspinClient only once its WebSocket upgrade is observed (see the delivery contract in
+// ws_server.h). close_callback() cleans up the socket and drops a still-pending entry; tick()
+// closes sessions still undelivered after WS_UPGRADE_TIMEOUT_US.
 
 static const char* const TAG = "sendspin.ws_server";
+
+/// @brief Deadline for an accepted session to complete its WebSocket upgrade
+///
+/// httpd has no handshake timeout of its own and max_open_sockets is small, so a raw TCP probe
+/// held open without ever speaking WebSocket would pin a socket slot indefinitely (the ESP variant
+/// of issue #75). Pre-upgrade sockets are a transport concern the manager never sees, so the bound
+/// lives here. The host build has no equivalent: IXWebSocket applies its own 3 s server-side
+/// handshake timeout.
+static constexpr int64_t WS_UPGRADE_TIMEOUT_US = 5LL * 1000 * 1000;
 
 SendspinWsServer::~SendspinWsServer() {
     this->stop();
@@ -88,14 +84,24 @@ bool SendspinWsServer::start(SendspinClient* client, bool task_stack_in_psram,
         return false;
     }
 
-    // Register the WebSocket handler
+    // Register the WebSocket handler. IDF >= 5.5.5 / 6.0.1 does not dispatch the upgrade GET to
+    // the handler (issue #70); registering the handler itself as the post-handshake callback
+    // restores that dispatch, so httpd invokes it with the same GET request at the same lifecycle
+    // position and the handler's HTTP_GET branch is the single upgrade signal on every IDF version.
+    // There is no fallback path: no version fires both (skip-GET builds return before invoking the
+    // handler), and delivery is idempotent regardless. The component's Kconfig selects the option
+    // wherever it exists, and the version-gated error below trips if a future IDF breaks that.
     const httpd_uri_t sendspin_ws_uri = {.uri = "/sendspin",
                                          .method = HTTP_GET,
                                          .handler = SendspinWsServer::websocket_handler,
                                          .user_ctx = (void*)this,
                                          .is_websocket = true,
                                          .handle_ws_control_frames = false,
-                                         .supported_subprotocol = nullptr};
+                                         .supported_subprotocol = nullptr,
+#ifdef CONFIG_HTTPD_WS_POST_HANDSHAKE_CB_SUPPORT
+                                         .ws_post_handshake_cb = SendspinWsServer::websocket_handler
+#endif
+    };
 
     err = httpd_register_uri_handler(this->server_, &sendspin_ws_uri);
     if (err != ESP_OK) {
@@ -114,6 +120,80 @@ void SendspinWsServer::stop() {
         httpd_stop(this->server_);
         this->server_ = nullptr;
     }
+
+    // httpd_stop tore down every session (each close_callback dropped its pending entry), so
+    // this is normally already empty; clear defensively so a restart begins from a clean table.
+    std::vector<PendingUpgrade> stale;
+    {
+        std::lock_guard<std::mutex> lock(this->pending_mutex_);
+        stale.swap(this->pending_);
+    }
+}
+
+void SendspinWsServer::tick() {
+    if (this->server_ == nullptr) {
+        return;
+    }
+
+    // Pure age-based reap: any session still undelivered past the deadline is closed, whether it
+    // never spoke WebSocket (a raw probe) or its upgrade signal failed to fire (only possible if a
+    // future IDF breaks the post-handshake callback; see the tripwire in start()). Sparing
+    // "upgraded but undelivered" sessions here would turn that failure into a silent permanent
+    // wedge of httpd's small socket pool; closing them makes it a visible close-and-retry loop
+    // instead. Pop under the lock, close outside it; the pop also means a delivery racing this reap
+    // resolves exactly-once (the loser finds no entry and no-ops).
+    std::vector<std::shared_ptr<SendspinServerConnection>> to_reap;
+    const int64_t now_us = esp_timer_get_time();
+    {
+        std::lock_guard<std::mutex> lock(this->pending_mutex_);
+        for (auto it = this->pending_.begin(); it != this->pending_.end();) {
+            // A closing session is skipped, not reaped: close_callback pops its entry.
+            if (it->conn->is_connected() && now_us - it->accept_time_us >= WS_UPGRADE_TIMEOUT_US) {
+                to_reap.push_back(std::move(it->conn));
+                it = this->pending_.erase(it);
+                continue;
+            }
+            ++it;
+        }
+    }
+
+    for (auto& conn : to_reap) {
+        SS_LOGW(TAG, "Session did not complete a WebSocket upgrade within %d s, closing",
+                static_cast<int>(WS_UPGRADE_TIMEOUT_US / (1000 * 1000)));
+        conn->trigger_close();
+    }
+}
+
+void SendspinWsServer::deliver_upgraded(int sockfd) {
+    auto conn = this->pop_pending(sockfd);
+    if (conn == nullptr) {
+        return;  // Already closed or reaped (a duplicate delivery cannot happen: the GET branch
+                 // fires once per session)
+    }
+
+    if (!this->new_connection_callback_) {
+        // Normally unreachable (open_callback rejects sessions when no callback is set), but an
+        // unset consumer must close the session, not throw bad_function_call on the httpd task.
+        SS_LOGW(TAG, "No new connection callback set, closing upgraded session");
+        conn->trigger_close();
+        return;
+    }
+
+    SS_LOGD(TAG, "WebSocket upgrade complete on socket %d, delivering connection", sockfd);
+    conn->mark_ws_upgraded();
+    this->new_connection_callback_(std::move(conn));
+}
+
+std::shared_ptr<SendspinServerConnection> SendspinWsServer::pop_pending(int sockfd) {
+    std::lock_guard<std::mutex> lock(this->pending_mutex_);
+    for (auto it = this->pending_.begin(); it != this->pending_.end(); ++it) {
+        if (it->sockfd == sockfd) {
+            auto conn = std::move(it->conn);
+            this->pending_.erase(it);
+            return conn;
+        }
+    }
+    return nullptr;
 }
 
 esp_err_t SendspinWsServer::open_callback(httpd_handle_t handle, int sockfd) {
@@ -144,7 +224,14 @@ esp_err_t SendspinWsServer::open_callback(httpd_handle_t handle, int sockfd) {
         delete static_cast<std::shared_ptr<SendspinServerConnection>*>(p);
     });
 
-    server->new_connection_callback_(std::move(conn));
+    // Park it as pending rather than delivering: the rest of the library only ever learns about
+    // connections whose WebSocket upgrade has been observed (see the delivery contract in
+    // ws_server.h). A session that never upgrades is closed by tick() without the manager ever
+    // knowing it existed.
+    {
+        std::lock_guard<std::mutex> lock(server->pending_mutex_);
+        server->pending_.push_back(PendingUpgrade{std::move(conn), esp_timer_get_time(), sockfd});
+    }
     return ESP_OK;
 }
 
@@ -161,12 +248,22 @@ void SendspinWsServer::close_callback(httpd_handle_t handle, int sockfd) {
 
     SendspinWsServer* server = (SendspinWsServer*)httpd_get_global_user_ctx(handle);
 
-    // Notify ConnectionManager so it can drop its observer shared_ptr. The session slot (set in
-    // open_callback) keeps the connection alive until httpd invokes the slot's free_fn next, which
-    // ensures any in-flight workers that are still looking it up via httpd_sess_get_ctx see a
-    // valid object.
-    if (server != nullptr && server->connection_closed_callback_) {
-        server->connection_closed_callback_(sockfd);
+    if (server != nullptr) {
+        // Drop a still-pending entry: this session closed before its upgrade was ever observed,
+        // so it must not be delivered. Popping here (before the fd can be recycled) also keeps
+        // sockfd unique as a pending-table key.
+        server->pop_pending(sockfd);
+    }
+
+    // Notify ConnectionManager so it can drop its observer shared_ptr. Passing the connection
+    // (from the session slot) rather than the sockfd keys the event on identity: by the time the
+    // manager drains it on the main loop the fd may already be recycled onto a new session. The
+    // slot keeps the connection alive until httpd invokes its free_fn next, so any in-flight
+    // workers still looking it up via httpd_sess_get_ctx see a valid object. For a never-delivered
+    // session the manager finds no managed match and no-ops.
+    if (server != nullptr && server->connection_closed_callback_ && slot != nullptr &&
+        *slot != nullptr) {
+        server->connection_closed_callback_(*slot);
     }
 
     // Shut down the receive side before close() to stop lwIP from delivering more packets
@@ -184,8 +281,7 @@ SS_HOT esp_err_t SendspinWsServer::websocket_handler(httpd_req_t* req) {
     // Look up the connection via httpd's per-session ctx. The slot was pinned in open_callback and
     // is freed only after this handler unwinds for a given session, so the shared_ptr copy below
     // is always valid. Copying the shared_ptr keeps the conn alive for the duration of dispatch
-    // even if a teardown is racing on another thread. This replaces the previous cross-thread
-    // find_connection_callback + mutex.
+    // even if a teardown is racing on another thread.
     int sockfd = httpd_req_to_sockfd(req);
     auto* slot = static_cast<std::shared_ptr<SendspinServerConnection>*>(
         httpd_sess_get_ctx(req->handle, sockfd));
@@ -196,10 +292,17 @@ SS_HOT esp_err_t SendspinWsServer::websocket_handler(httpd_req_t* req) {
     std::shared_ptr<SendspinServerConnection> conn_holder = *slot;
     SendspinServerConnection* conn = conn_holder.get();
 
-    // Handle WebSocket handshake (HTTP_GET)
+    SendspinWsServer* server =
+        static_cast<SendspinWsServer*>(httpd_get_global_user_ctx(req->handle));
+
+    // Upgrade GET: the sole upgrade signal, on every IDF version. Old IDF (<= 5.5.4 / 6.0.0)
+    // dispatches the initial GET here natively after completing the handshake; new IDF reaches
+    // this branch via ws_post_handshake_cb, which is registered as this same function and
+    // invoked with the same GET request. Frames are processed strictly after this request cycle
+    // on the same httpd task, so delivery always precedes the first frame.
     if (req->method == HTTP_GET) {
-        if (conn->on_connected_cb) {
-            conn->on_connected_cb(conn);
+        if (server != nullptr) {
+            server->deliver_upgraded(sockfd);
         }
         return ESP_OK;
     }
@@ -207,7 +310,9 @@ SS_HOT esp_err_t SendspinWsServer::websocket_handler(httpd_req_t* req) {
     // Delegate to connection's handle_data. Stale messages (i.e., after the connection has been
     // dropped from ConnectionManager's observer slots) are short-circuited inside the connection
     // via disable_message_dispatch(), so a still-alive session-pinned conn does not leak messages
-    // into freshly-reset role queues.
+    // into freshly-reset role queues. A frame on a never-delivered connection (its session
+    // outliving a tick() reap by a moment) dispatches into unwired callbacks and is dropped by
+    // their null guards.
     return conn->handle_data(req, receive_time);
 }
 

--- a/src/esp/ws_server.h
+++ b/src/esp/ws_server.h
@@ -20,8 +20,11 @@
 #include "sendspin/config.h"
 #include <esp_http_server.h>
 
+#include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
+#include <vector>
 
 namespace sendspin {
 
@@ -29,6 +32,16 @@ namespace sendspin {
 class SendspinClient;
 class SendspinConnection;
 class SendspinServerConnection;
+
+/// @brief An accepted httpd session whose WebSocket upgrade has not yet been observed.
+///
+/// The session slot (httpd_sess_set_ctx) remains the authoritative owner of the connection;
+/// this entry's shared_ptr is dropped when the session is delivered, closed, or reaped.
+struct PendingUpgrade {
+    std::shared_ptr<SendspinServerConnection> conn;  ///< Parallel refcount to the session slot
+    int64_t accept_time_us;                          ///< Accept stamp for the upgrade deadline
+    int sockfd;                                      ///< httpd socket fd, the lookup key
+};
 
 /**
  * @brief WebSocket server listener for Sendspin
@@ -41,28 +54,43 @@ class SendspinServerConnection;
  * httpd_sess_get_ctx. ConnectionManager receives the same shared_ptr as a secondary
  * observer for routing and handoff decisions.
  *
+ * Delivery contract: a connection is delivered to the NewConnectionCallback only once its
+ * WebSocket upgrade has been observed, so the rest of the library never sees sockets that might
+ * not speak WebSocket. Accepted-but-not-yet-upgraded sessions wait in a pending table until the
+ * upgrade signal fires: the HTTP_GET branch of websocket_handler. IDF <= 5.5.4 / 6.0.0 dispatches
+ * the upgrade GET to the handler natively; IDF >= 5.5.5 / 6.0.1 reaches the same branch through
+ * ws_post_handshake_cb, which is registered as websocket_handler itself and invoked with the same
+ * GET request at the same lifecycle position. The component's Kconfig selects
+ * CONFIG_HTTPD_WS_POST_HANDSHAKE_CB_SUPPORT wherever it exists. tick() reaps sessions still
+ * undelivered after WS_UPGRADE_TIMEOUT_US; httpd has no handshake timeout of its own and
+ * max_open_sockets is small, so a held-open raw TCP probe would otherwise pin a socket slot
+ * indefinitely (the ESP variant of issue #75).
+ *
  * Capabilities:
  * - Accepts incoming WebSocket connections on a configurable dedicated port
  * - Routes WebSocket messages directly via the session-pinned shared_ptr (no cross-thread
  *   find-by-sockfd lookup is needed)
  * - Manages open/close callbacks to notify the client of connection lifecycle events
- * - Supports up to max_connections simultaneous sockets (default: 2) to enable the
- *   handoff protocol where a second server can connect while one is already active
+ * - Supports up to max_connections simultaneous sockets (default:
+ *   SendspinClientConfig::DEFAULT_SERVER_MAX_CONNECTIONS) so a second server can connect while
+ *   one is already active (handoff) and a surplus peer can still be greeted with a goodbye
  *
  * Usage:
  * 1. Construct with a SendspinClient pointer (passed to start())
  * 2. Register callbacks via set_new_connection_callback() and set_connection_closed_callback()
  *    (set_find_connection_callback() is a no-op stub on ESP, kept for symmetry with the host build)
  * 3. Call start() to begin listening for incoming connections
- * 4. Call stop() to shut down the server
+ * 4. Call tick() periodically (the ConnectionManager loop does this) to reap sessions whose
+ *    upgrade never completed
+ * 5. Call stop() to shut down the server
  *
  * @code
  * SendspinWsServer ws_server;
  * ws_server.set_new_connection_callback([&](std::shared_ptr<SendspinServerConnection> conn) {
  *     client.on_new_server_connection(std::move(conn));
  * });
- * ws_server.set_connection_closed_callback([&](int sockfd) {
- *     client.on_server_connection_closed(sockfd);
+ * ws_server.set_connection_closed_callback([&](std::shared_ptr<SendspinServerConnection> conn) {
+ *     client.on_server_connection_closed(std::move(conn));
  * });
  * ws_server.start(&client, true, 5);
  * @endcode
@@ -77,9 +105,11 @@ public:
     /// httpd_sess_set_ctx, which acts as the authoritative owner for the connection's lifetime.
     using NewConnectionCallback = std::function<void(std::shared_ptr<SendspinServerConnection>)>;
 
-    /// @brief Callback type for notifying the client when a socket closes
-    /// The client needs to identify which connection owns this sockfd and clean it up.
-    using ConnectionClosedCallback = std::function<void(int sockfd)>;
+    /// @brief Callback type for notifying the client when a session closes
+    /// Passes the closed connection itself rather than its sockfd: the OS recycles fds after
+    /// close(), so an fd-keyed event drained later (on the manager loop) could be mis-routed to
+    /// a new connection that was accepted onto the recycled fd in the meantime.
+    using ConnectionClosedCallback = std::function<void(std::shared_ptr<SendspinServerConnection>)>;
 
     /// @brief Callback type for looking up a connection by sockfd.
     /// Returns a shared_ptr to keep the connection alive during message dispatch.
@@ -94,6 +124,11 @@ public:
 
     /// @brief Stops the HTTP server
     void stop();
+
+    /// @brief Closes sessions still undelivered after WS_UPGRADE_TIMEOUT_US (raw TCP probes that
+    /// never speak WebSocket; httpd has no handshake timeout of its own). Called from the
+    /// ConnectionManager loop.
+    void tick();
 
     /// @brief Sets the callback to invoke when a socket closes
     /// @param callback The callback function.
@@ -110,7 +145,9 @@ public:
     void set_find_connection_callback(FindConnectionCallback&& /*callback*/) {}
 
     /// @brief Configures the maximum number of simultaneous connections
-    /// Default is 2 to support the handoff protocol (one active + one pending).
+    /// The default supports handoff plus graceful rejection: one established connection, the
+    /// manager's nursery, and one spare socket so a surplus peer can receive a goodbye (see
+    /// ConnectionManager::NURSERY_CAPACITY's socket-budget invariant).
     /// @param max_connections Maximum number of open sockets (1-7).
     void set_max_connections(uint8_t max_connections) {
         this->max_connections_ = max_connections;
@@ -160,10 +197,31 @@ protected:
     /// @param sockfd The socket file descriptor being closed.
     static void close_callback(httpd_handle_t handle, int sockfd);
 
-    /// @brief WebSocket message handler registered with httpd
+    /// @brief WebSocket message handler registered with httpd. Doubles as the
+    /// ws_post_handshake_cb on IDF versions that provide it: httpd then invokes it with the
+    /// upgrade GET request, restoring the pre-6.0.1 dispatch so the HTTP_GET branch is the
+    /// single handshake-time upgrade signal on every version.
     static esp_err_t websocket_handler(httpd_req_t* req);
 
+    /// @brief Pops the pending entry for @p sockfd and delivers its connection, marked
+    /// WS-upgraded, to the new-connection callback. No-op if the session was already closed or
+    /// reaped; the pending-table pop resolves a delivery racing the tick() reap exactly-once.
+    /// @param sockfd The socket file descriptor whose upgrade was observed.
+    void deliver_upgraded(int sockfd);
+
+    /// @brief Removes the pending entry for @p sockfd and returns its connection.
+    /// @param sockfd The socket file descriptor to look up.
+    /// @return The pending connection, or nullptr if the session was not pending.
+    std::shared_ptr<SendspinServerConnection> pop_pending(int sockfd);
+
     // Struct fields
+
+    /// @brief Guards pending_. Held only for table mutation/scan; delivery and closing happen
+    /// outside it (the new-connection callback takes the manager's locks).
+    std::mutex pending_mutex_;
+
+    /// @brief Accepted sessions whose WebSocket upgrade has not yet been observed
+    std::vector<PendingUpgrade> pending_;
 
     /// @brief Callback to notify the client when a socket closes
     ConnectionClosedCallback connection_closed_callback_;
@@ -181,8 +239,8 @@ protected:
 
     // Numeric fields
 
-    /// @brief Maximum number of simultaneous connections (default: 2 for handoff)
-    uint8_t max_connections_{2};
+    /// @brief Maximum number of simultaneous connections (see set_max_connections)
+    uint8_t max_connections_{SendspinClientConfig::DEFAULT_SERVER_MAX_CONNECTIONS};
 
     /// @brief TCP port the WebSocket server listens on
     uint16_t server_port_{SendspinClientConfig::DEFAULT_SERVER_PORT};

--- a/src/host/server_connection.cpp
+++ b/src/host/server_connection.cpp
@@ -34,9 +34,8 @@ SendspinServerConnection::SendspinServerConnection(std::shared_ptr<ix::WebSocket
 }
 
 void SendspinServerConnection::start() {
-    // Connection is already established by the server; no action needed.
-    // The on_connected_cb callback is invoked from the ws_server message handler
-    // when the WebSocket Open message arrives.
+    // No action needed: the connection is constructed by the ws_server only after the WebSocket
+    // Open event, so the transport is already established and upgraded by the time it exists.
 }
 
 void SendspinServerConnection::loop() {

--- a/src/host/ws_server.cpp
+++ b/src/host/ws_server.cpp
@@ -25,6 +25,15 @@ namespace sendspin {
 
 static const char* const TAG = "sendspin.ws_server";
 
+/// @brief Deadline (seconds) for an accepted socket to complete its WebSocket handshake.
+///
+/// This is the host counterpart of the ESP build's WS_UPGRADE_TIMEOUT_US: sockets that never
+/// speak WebSocket are closed inside the transport layer and stay invisible to the manager.
+/// IXWebSocket's own server default happens to be the same 3 s, but the delivery contract in
+/// ws_server.h depends on the bound existing, so it is pinned here explicitly rather than
+/// inherited from a dependency default an IXWebSocket upgrade could silently rescope.
+static constexpr int WS_HANDSHAKE_TIMEOUT_SECS = 3;
+
 SendspinWsServer::~SendspinWsServer() {
     this->stop();
 }
@@ -38,8 +47,12 @@ bool SendspinWsServer::start(SendspinClient* client, bool /*task_stack_in_psram*
 
     this->client_ = client;
 
-    // Create IXWebSocket server on the configured port
-    this->server_ = std::make_unique<ix::WebSocketServer>(this->server_port_, "0.0.0.0");
+    // Create IXWebSocket server on the configured port. max_connections_ is enforced here (IX
+    // closes surplus sockets at accept), so the configured budget is real on host, matching the
+    // ESP build's httpd max_open_sockets.
+    this->server_ = std::make_unique<ix::WebSocketServer>(
+        this->server_port_, "0.0.0.0", ix::SocketServer::kDefaultTcpBacklog, this->max_connections_,
+        WS_HANDSHAKE_TIMEOUT_SECS);
 
     this->server_->setOnConnectionCallback(
         [this](const std::weak_ptr<ix::WebSocket>& weak_ws,
@@ -60,27 +73,36 @@ bool SendspinWsServer::start(SendspinClient* client, bool /*task_stack_in_psram*
                 synthetic_sockfd = next_synthetic_sockfd.fetch_add(1);
             }
 
-            SS_LOGD(TAG, "New client connection (synthetic sockfd %d)", synthetic_sockfd);
+            SS_LOGD(TAG, "Accepted connection (synthetic sockfd %d), awaiting WS upgrade",
+                    synthetic_sockfd);
 
-            // Create the server connection
-            auto connection = std::make_shared<SendspinServerConnection>(ws, synthetic_sockfd);
-
-            // Set up the message callback on the websocket to route data through the connection
-            ws->setOnMessageCallback([this, synthetic_sockfd](const ix::WebSocketMessagePtr& msg) {
+            // This callback fires at TCP accept, before the WebSocket handshake. Nothing is
+            // created or delivered here: a socket that never completes the handshake (port scan,
+            // health check, plain HTTP) is IXWebSocket's problem; its server-side handshake timeout
+            // (3 s) closes such sockets without ever surfacing an event. The manager only ever
+            // learns about connections that reach Open.
+            //
+            // Filled at Open so the Close event can report the connection by identity. A
+            // never-delivered socket leaves it empty, and its Close is not reported (the manager
+            // never knew the connection existed).
+            auto delivered = std::make_shared<std::weak_ptr<SendspinServerConnection>>();
+            ws->setOnMessageCallback([this, synthetic_sockfd, weak_ws,
+                                      delivered](const ix::WebSocketMessagePtr& msg) {
                 int64_t receive_time = platform_time_us();
 
-                // Find the connection by sockfd; hold shared_ptr to keep it alive during dispatch
-                std::shared_ptr<SendspinConnection> conn_holder;
-                SendspinServerConnection* conn = nullptr;
-                if (this->find_connection_callback_) {
-                    conn_holder = this->find_connection_callback_(synthetic_sockfd);
-                    conn = static_cast<SendspinServerConnection*>(conn_holder.get());
-                }
-
                 if (msg->type == ix::WebSocketMessageType::Message) {
+                    // Find the connection by sockfd; hold shared_ptr to keep it alive
+                    // during dispatch
+                    std::shared_ptr<SendspinConnection> conn_holder;
+                    if (this->find_connection_callback_) {
+                        conn_holder = this->find_connection_callback_(synthetic_sockfd);
+                    }
+                    auto* conn = static_cast<SendspinServerConnection*>(conn_holder.get());
                     if (conn == nullptr) {
-                        SS_LOGE(TAG, "No connection found for synthetic sockfd %d",
-                                synthetic_sockfd);
+                        // Not managed: the manager rejected it at delivery (goodbye + close
+                        // already sent) or has since released it. Frames racing that close
+                        // are dropped here.
+                        SS_LOGD(TAG, "Dropping message for unmanaged sockfd %d", synthetic_sockfd);
                         return;
                     }
 
@@ -88,26 +110,39 @@ bool SendspinWsServer::start(SendspinClient* client, bool /*task_stack_in_psram*
                     conn->handle_message(msg->str, msg->binary, receive_time);
 
                 } else if (msg->type == ix::WebSocketMessageType::Open) {
-                    if (conn != nullptr && conn->on_connected_cb) {
-                        conn->on_connected_cb(conn);
+                    // The WebSocket upgrade completed: this is where the connection comes
+                    // into existence for the rest of the library. Delivering here (rather
+                    // than at accept) means the manager never has to reason about sockets
+                    // that might not speak WebSocket, and a rejection's goodbye reaches the
+                    // peer because the session is already Open.
+                    auto self_ws = weak_ws.lock();
+                    if (!self_ws) {
+                        return;
                     }
+                    if (!this->new_connection_callback_) {
+                        SS_LOGW(TAG, "No new connection callback set, closing connection");
+                        self_ws->close();
+                        return;
+                    }
+                    auto connection = std::make_shared<SendspinServerConnection>(std::move(self_ws),
+                                                                                 synthetic_sockfd);
+                    connection->mark_ws_upgraded();
+                    *delivered = connection;
+                    this->new_connection_callback_(std::move(connection));
                 } else if (msg->type == ix::WebSocketMessageType::Close) {
                     SS_LOGD(TAG, "Client closed connection (synthetic sockfd %d)",
                             synthetic_sockfd);
-                    if (this->connection_closed_callback_) {
-                        this->connection_closed_callback_(synthetic_sockfd);
+                    // lock() fails once the manager (the sole long-term owner) has already
+                    // released the connection; there is nothing left to notify it about.
+                    if (auto conn = delivered->lock()) {
+                        if (this->connection_closed_callback_) {
+                            this->connection_closed_callback_(std::move(conn));
+                        }
                     }
                 } else if (msg->type == ix::WebSocketMessageType::Error) {
                     SS_LOGE(TAG, "WebSocket error: %s", msg->errorInfo.reason.c_str());
                 }
             });
-
-            // Notify the client of the new connection
-            if (this->new_connection_callback_) {
-                this->new_connection_callback_(std::move(connection));
-            } else {
-                SS_LOGW(TAG, "No new connection callback set, connection will be dropped");
-            }
         });
 
     SS_LOGI(TAG, "Starting server on port: %u (max connections: %d)",

--- a/src/host/ws_server.h
+++ b/src/host/ws_server.h
@@ -35,9 +35,12 @@ class SendspinServerConnection;
 /**
  * @brief WebSocket server that listens for incoming Sendspin client connections (host build)
  *
- * Wraps an IXWebSocket server listening on the configured port. When a client connects, a
- * SendspinServerConnection is created and delivered via the NewConnectionCallback. Connection
- * close events are reported via ConnectionClosedCallback.
+ * Wraps an IXWebSocket server listening on the configured port. A SendspinServerConnection is
+ * created and delivered via the NewConnectionCallback only once the peer completes the WebSocket
+ * upgrade (the Open event); sockets that never complete the handshake are closed by IXWebSocket's
+ * server-side handshake timeout, which start() pins explicitly (WS_HANDSHAKE_TIMEOUT_SECS, 3 s)
+ * so the bound cannot be silently rescoped by an IXWebSocket upgrade. Such sockets are invisible
+ * to the rest of the library. Connection close events are reported via ConnectionClosedCallback.
  *
  * Usage:
  * 1. Set the new_connection, connection_closed, and find_connection callbacks
@@ -50,8 +53,8 @@ class SendspinServerConnection;
  * server.set_new_connection_callback([&](auto conn) {
  *     store_connection(std::move(conn));
  * });
- * server.set_connection_closed_callback([&](int fd) {
- *     remove_connection(fd);
+ * server.set_connection_closed_callback([&](std::shared_ptr<SendspinServerConnection> conn) {
+ *     remove_connection(std::move(conn));
  * });
  * server.start(&client, false, 5);
  * @endcode
@@ -64,8 +67,10 @@ public:
     /// @brief Callback type for notifying the client of new connections
     using NewConnectionCallback = std::function<void(std::shared_ptr<SendspinServerConnection>)>;
 
-    /// @brief Callback type for notifying the client when a socket closes
-    using ConnectionClosedCallback = std::function<void(int sockfd)>;
+    /// @brief Callback type for notifying the client when a connection closes
+    /// Passes the closed connection itself rather than its sockfd, matching the ESP build (where
+    /// fd recycling makes fd-keyed close events ambiguous by the time the manager drains them).
+    using ConnectionClosedCallback = std::function<void(std::shared_ptr<SendspinServerConnection>)>;
 
     /// @brief Callback type for looking up a connection by sockfd.
     /// Returns a shared_ptr to keep the connection alive during message dispatch.
@@ -81,8 +86,13 @@ public:
     /// @brief Stops the WebSocket server and releases its resources
     void stop();
 
+    /// @brief No-op on host builds. On ESP the manager loop drives the pending-upgrade reap
+    /// through this; here IXWebSocket delivers Open events and times out stalled handshakes on
+    /// its own threads (bounded by WS_HANDSHAKE_TIMEOUT_SECS, pinned in start()).
+    void tick() {}
+
     /// @brief Sets the callback invoked when a client connection closes
-    /// @param callback Function called with the socket fd of the closed connection.
+    /// @param callback Function called with the closed connection.
     void set_connection_closed_callback(ConnectionClosedCallback&& callback) {
         this->connection_closed_callback_ = std::move(callback);
     }
@@ -94,6 +104,10 @@ public:
     }
 
     /// @brief Sets the maximum number of simultaneous client connections
+    /// The default supports handoff plus graceful rejection: one established connection, the
+    /// manager's nursery, and one spare socket so a surplus peer can receive a goodbye (see
+    /// ConnectionManager::NURSERY_CAPACITY's socket-budget invariant). Enforced by IXWebSocket
+    /// at accept.
     /// @param max_connections Maximum connection count.
     void set_max_connections(uint8_t max_connections) {
         this->max_connections_ = max_connections;
@@ -142,8 +156,8 @@ protected:
 
     // Numeric fields
 
-    /// @brief Maximum number of simultaneous connections (default: 2 for handoff)
-    uint8_t max_connections_{2};
+    /// @brief Maximum number of simultaneous connections (see set_max_connections)
+    uint8_t max_connections_{SendspinClientConfig::DEFAULT_SERVER_MAX_CONNECTIONS};
 
     /// @brief TCP port the WebSocket server listens on
     uint16_t server_port_{SendspinClientConfig::DEFAULT_SERVER_PORT};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ FetchContent_MakeAvailable(googletest)
 # registers the individual TEST() cases with CTest so failures are reported per case.
 add_executable(sendspin_tests
     test_audio_stream_info.cpp
+    test_connection_lifecycle.cpp
     test_time_filter.cpp
     test_protocol.cpp
     test_network_info.cpp

--- a/tests/test_connection_lifecycle.cpp
+++ b/tests/test_connection_lifecycle.cpp
@@ -1,0 +1,600 @@
+// Copyright 2026 Sendspin Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Integration tests for the connection nursery (prove-then-admit lifecycle). The manager is only
+// reachable through SendspinClient, so these drive a real client on loopback ports: raw TCP
+// sockets play the junk probes, IXWebSocket endpoints play the Sendspin servers, and the test
+// thread pumps client.loop() like a platform main loop. Each scenario guards one lifecycle
+// property or the delivery-at-upgrade contract (connections reach the manager only after their
+// WebSocket upgrade; raw-TCP junk is closed inside the transport layer and never occupies a slot).
+
+#include "connection_manager.h"  // fnv1_hash for the last-played preference
+#include "sendspin/client.h"
+#include "sendspin/config.h"
+#include <gtest/gtest.h>
+#include <ixwebsocket/IXWebSocket.h>
+#include <ixwebsocket/IXWebSocketServer.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <thread>
+#include <utility>
+
+using namespace sendspin;  // NOLINT(google-build-using-namespace): test-local convenience
+
+namespace {
+
+// Distinct ports per test so a lingering socket from one scenario cannot bleed into the next.
+constexpr uint16_t PROBE_TEST_PORT = 18941;
+constexpr uint16_t OUTBOUND_TEST_PORT = 18942;
+constexpr uint16_t PROXY_LISTEN_PORT = 18951;
+constexpr uint16_t PROXY_BACKEND_PORT = 18952;
+constexpr uint16_t RACE_TEST_PORT = 18961;
+constexpr uint16_t EARLY_HELLO_TEST_PORT = 18971;
+constexpr uint16_t EVICT_TEST_PORT = 18972;
+constexpr uint16_t REJECT_TEST_PORT = 18973;
+constexpr uint16_t STALL_LISTEN_PORT = 18981;
+constexpr uint16_t ADMIT_TEST_PORT = 18982;
+
+std::string server_url(uint16_t port) {
+    return "ws://127.0.0.1:" + std::to_string(port) + "/sendspin";
+}
+
+std::string server_hello_json(const std::string& server_id, const std::string& reason) {
+    return std::string(R"({"type":"server/hello","payload":{"server_id":")") + server_id +
+           R"(","name":"Fake Server","version":1,"active_roles":["player"],)" +
+           R"("connection_reason":")" + reason + R"("}})";
+}
+
+SendspinClientConfig make_config(uint16_t port) {
+    SendspinClientConfig config;
+    config.client_id = "lifecycle-test-client";
+    config.name = "Lifecycle Test Client";
+    config.server_port = port;
+    return config;
+}
+
+class TestNetworkProvider : public SendspinNetworkProvider {
+public:
+    bool is_network_ready() override {
+        return true;
+    }
+};
+
+class TestPersistenceProvider : public SendspinPersistenceProvider {
+public:
+    explicit TestPersistenceProvider(uint32_t hash) : hash_(hash) {}
+
+    std::optional<uint32_t> load_last_server_hash() override {
+        return this->hash_;
+    }
+
+private:
+    uint32_t hash_;
+};
+
+/// Pumps client.loop() (like a platform main loop would) until the predicate returns true or the
+/// timeout elapses. Returns true if the predicate was satisfied.
+bool pump_until(SendspinClient& client, const std::function<bool()>& pred, int timeout_ms) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+    while (std::chrono::steady_clock::now() < deadline) {
+        client.loop();
+        if (pred()) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    return false;
+}
+
+void pump_for(SendspinClient& client, int duration_ms) {
+    pump_until(
+        client, [] { return false; }, duration_ms);
+}
+
+int connect_loopback(uint16_t port) {
+    int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = htons(port);
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        ::close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+/// Non-blocking check for EOF/reset on a raw socket. Drains any pending bytes (a goodbye frame
+/// sent to the "probe" is not a close) and reports true only once the peer has closed.
+bool socket_closed(int fd) {
+    char buf[256];
+    while (true) {
+        ssize_t n = ::recv(fd, buf, sizeof(buf), MSG_DONTWAIT);
+        if (n == 0) {
+            return true;  // orderly EOF
+        }
+        if (n < 0) {
+            return errno != EAGAIN && errno != EWOULDBLOCK;  // reset counts as closed
+        }
+        // n > 0: bytes to discard; loop and look again
+    }
+}
+
+/// Behavior knobs for FakeServer.
+struct FakeServerOptions {
+    bool hello_on_open{false};  ///< Send server/hello immediately on Open, before any
+                                ///< client/hello arrives (a nonconforming peer)
+    bool answer_hello{true};    ///< Reply to client/hello with server/hello (false: mute peer
+                                ///< that upgrades and then never establishes)
+};
+
+/// A minimal Sendspin "server": an IXWebSocket client that connects to the SendspinClient's WS
+/// server (the server-initiated discovery direction) and answers client/hello with server/hello,
+/// per the given options.
+class FakeServer {
+public:
+    FakeServer(const std::string& url, std::string server_id, FakeServerOptions options = {})
+        : server_id_(std::move(server_id)) {
+        this->ws_.setUrl(url);
+        this->ws_.disableAutomaticReconnection();
+        this->ws_.setOnMessageCallback([this, options](const ix::WebSocketMessagePtr& msg) {
+            if (msg->type == ix::WebSocketMessageType::Open) {
+                if (options.hello_on_open) {
+                    this->ws_.send(server_hello_json(this->server_id_, "discovery"));
+                }
+            } else if (msg->type == ix::WebSocketMessageType::Message &&
+                       msg->str.find("client/hello") != std::string::npos) {
+                this->got_client_hello_.store(true);
+                if (options.answer_hello) {
+                    this->ws_.send(server_hello_json(this->server_id_, "discovery"));
+                }
+            } else if (msg->type == ix::WebSocketMessageType::Message &&
+                       msg->str.find("client/goodbye") != std::string::npos) {
+                this->got_goodbye_.store(true);
+            } else if (msg->type == ix::WebSocketMessageType::Close ||
+                       msg->type == ix::WebSocketMessageType::Error) {
+                this->closed_.store(true);
+            }
+        });
+        this->ws_.start();
+    }
+
+    ~FakeServer() {
+        this->ws_.stop();
+    }
+
+    bool closed() const {
+        return this->closed_.load();
+    }
+
+    bool got_client_hello() const {
+        return this->got_client_hello_.load();
+    }
+
+    bool got_goodbye() const {
+        return this->got_goodbye_.load();
+    }
+
+private:
+    ix::WebSocket ws_;
+    std::string server_id_;
+    std::atomic<bool> closed_{false};
+    std::atomic<bool> got_client_hello_{false};
+    std::atomic<bool> got_goodbye_{false};
+};
+
+/// TCP relay that accepts one connection, sits on it without reading for delay_ms (the peer's
+/// WebSocket upgrade request waits in the kernel buffer), then connects to the backend and pumps
+/// bytes both ways. Simulates a slow network path in front of a real Sendspin server.
+class DelayProxy {
+public:
+    DelayProxy(uint16_t listen_port, uint16_t backend_port, int delay_ms)
+        : backend_port_(backend_port), delay_ms_(delay_ms) {
+        this->listen_fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
+        if (this->listen_fd_ < 0) {
+            return;
+        }
+        int one = 1;
+        ::setsockopt(this->listen_fd_, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        addr.sin_port = htons(listen_port);
+        if (::bind(this->listen_fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0 ||
+            ::listen(this->listen_fd_, 1) != 0) {
+            ::close(this->listen_fd_);
+            this->listen_fd_ = -1;
+            return;
+        }
+        this->ok_ = true;
+        this->thread_ = std::thread([this] { this->run(); });
+    }
+
+    ~DelayProxy() {
+        this->stop_.store(true);
+        if (this->ok_) {
+            // Unblock a still-pending accept() by connecting to ourselves.
+            int poke = connect_loopback(this->listen_port());
+            if (this->thread_.joinable()) {
+                this->thread_.join();
+            }
+            if (poke >= 0) {
+                ::close(poke);
+            }
+        }
+        if (this->listen_fd_ >= 0) {
+            ::close(this->listen_fd_);
+        }
+    }
+
+    /// True once the listening socket is bound and the pump thread is running. Tests must
+    /// ASSERT this before using the proxy: a setup failure recorded non-fatally inside a
+    /// constructor would not abort the test, which would then hang out its full timeout
+    /// budget on a connection that can never be accepted.
+    bool ok() const {
+        return this->ok_;
+    }
+
+private:
+    uint16_t listen_port() const {
+        sockaddr_in addr{};
+        socklen_t len = sizeof(addr);
+        ::getsockname(this->listen_fd_, reinterpret_cast<sockaddr*>(&addr), &len);
+        return ntohs(addr.sin_port);
+    }
+
+    static bool send_all(int fd, const char* data, size_t len) {
+        size_t sent = 0;
+        while (sent < len) {
+            ssize_t n = ::send(fd, data + sent, len - sent, 0);
+            if (n <= 0) {
+                return false;
+            }
+            sent += static_cast<size_t>(n);
+        }
+        return true;
+    }
+
+    void run() {
+        int client_fd = ::accept(this->listen_fd_, nullptr, nullptr);
+        if (client_fd < 0 || this->stop_.load()) {
+            if (client_fd >= 0) {
+                ::close(client_fd);
+            }
+            return;
+        }
+
+        // The stall: hold the accepted connection without reading until the delay elapses.
+        const auto resume =
+            std::chrono::steady_clock::now() + std::chrono::milliseconds(this->delay_ms_);
+        while (!this->stop_.load() && std::chrono::steady_clock::now() < resume) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+
+        int backend_fd = connect_loopback(this->backend_port_);
+        if (backend_fd < 0) {
+            ::close(client_fd);
+            return;
+        }
+
+        while (!this->stop_.load()) {
+            pollfd fds[2] = {{client_fd, POLLIN, 0}, {backend_fd, POLLIN, 0}};
+            int rc = ::poll(fds, 2, 50);
+            if (rc < 0) {
+                break;
+            }
+            if (rc == 0) {
+                continue;
+            }
+            char buf[4096];
+            bool alive = true;
+            if (fds[0].revents != 0) {
+                ssize_t n = ::recv(client_fd, buf, sizeof(buf), 0);
+                alive = n > 0 && send_all(backend_fd, buf, static_cast<size_t>(n));
+            }
+            if (alive && fds[1].revents != 0) {
+                ssize_t n = ::recv(backend_fd, buf, sizeof(buf), 0);
+                alive = n > 0 && send_all(client_fd, buf, static_cast<size_t>(n));
+            }
+            if (!alive) {
+                break;
+            }
+        }
+        ::close(client_fd);
+        ::close(backend_fd);
+    }
+
+    std::thread thread_;
+    std::atomic<bool> stop_{false};
+    int listen_fd_{-1};
+    uint16_t backend_port_;
+    int delay_ms_;
+    bool ok_{false};
+};
+
+}  // namespace
+
+// A raw TCP probe (port scan / health check) held open against the client's WS server must not
+// keep a real server from connecting and establishing immediately, and the probe socket must be
+// closed within roughly the nursery upgrade deadline.
+TEST(ConnectionLifecycle, JunkProbeDoesNotBlockRealServer) {
+    TestNetworkProvider network;
+    SendspinClient client(make_config(PROBE_TEST_PORT));
+    client.set_network_provider(&network);
+    ASSERT_TRUE(client.start_server());
+    // The WS server starts synchronously on the first loop() once the network reports ready.
+    pump_for(client, 50);
+
+    // Hold a raw TCP connection open without ever speaking WebSocket.
+    int probe_fd = connect_loopback(PROBE_TEST_PORT);
+    ASSERT_GE(probe_fd, 0);
+    pump_for(client, 200);  // give the transport time to accept it; the probe never reaches the
+                            // manager (junk is closed inside the transport layer)
+    EXPECT_FALSE(client.is_connected());
+
+    // A real server connects while the probe is held: it must establish promptly, not after the
+    // probe's deadline.
+    FakeServer real_server(server_url(PROBE_TEST_PORT), "server-a");
+    EXPECT_TRUE(pump_until(
+        client, [&] { return client.is_connected(); }, 4000));
+    auto info = client.get_server_information();
+    ASSERT_TRUE(info.has_value());
+    EXPECT_EQ(info->server_id, "server-a");
+
+    // The probe never completes a WebSocket handshake, so the transport layer closes it without
+    // it ever reaching the manager (host: IXWebSocket's 3 s server-side handshake timeout; on
+    // ESP the ws_server tick would reap it at 5 s). Budget covers either bound plus margin.
+    EXPECT_TRUE(pump_until(
+        client, [&] { return socket_closed(probe_fd); }, 6500));
+    ::close(probe_fd);
+
+    // The established connection must have been untouched by the probe reap.
+    EXPECT_TRUE(client.is_connected());
+}
+
+// An outbound connect_to() through a slow network (upgrade stalled ~8 s, past every short
+// inbound-side upgrade deadline) must keep its full 30 s establish budget and connect. Short
+// upgrade deadlines exist only in the transport layer for inbound accepts (ESP ws_server reap, IX
+// handshake timeout); an outbound connect's clock predates DNS/TCP resolve and must never be cut
+// short by them.
+TEST(ConnectionLifecycle, SlowOutboundSurvivesUpgradeTier) {
+    // Real Sendspin-speaking endpoint the proxy forwards to.
+    ix::WebSocketServer backend(PROXY_BACKEND_PORT, "127.0.0.1");
+    backend.setOnConnectionCallback([](const std::weak_ptr<ix::WebSocket>& weak_ws,
+                                       const std::shared_ptr<ix::ConnectionState>& /*state*/) {
+        auto ws = weak_ws.lock();
+        if (!ws) {
+            return;
+        }
+        ws->setOnMessageCallback([weak_ws](const ix::WebSocketMessagePtr& msg) {
+            if (msg->type == ix::WebSocketMessageType::Message &&
+                msg->str.find("client/hello") != std::string::npos) {
+                if (auto locked = weak_ws.lock()) {
+                    locked->send(server_hello_json("server-slow", "discovery"));
+                }
+            }
+        });
+    });
+    ASSERT_TRUE(backend.listen().first);
+    backend.start();
+
+    DelayProxy proxy(PROXY_LISTEN_PORT, PROXY_BACKEND_PORT, 8000);
+    ASSERT_TRUE(proxy.ok());
+
+    TestNetworkProvider network;
+    SendspinClient client(make_config(OUTBOUND_TEST_PORT));
+    client.set_network_provider(&network);
+    ASSERT_TRUE(client.start_server());
+    pump_for(client, 50);
+
+    client.connect_to(server_url(PROXY_LISTEN_PORT));
+
+    // Nothing can establish before the proxy forwards the upgrade at ~8 s; the connection must
+    // still be alive past the 5 s mark, well beyond any inbound-side upgrade deadline.
+    EXPECT_FALSE(pump_until(
+        client, [&] { return client.is_connected(); }, 6500));
+
+    EXPECT_TRUE(pump_until(
+        client, [&] { return client.is_connected(); }, 7500));
+    auto info = client.get_server_information();
+    ASSERT_TRUE(info.has_value());
+    EXPECT_EQ(info->server_id, "server-slow");
+
+    client.disconnect(SendspinGoodbyeReason::SHUTDOWN);
+    pump_for(client, 100);
+    backend.stop();
+}
+
+// An in-flight outbound connect_to() must not count against the inbound nursery capacity: with
+// one mute inbound peer holding a slot and an outbound attempt stalled mid-upgrade, a real server
+// connecting inbound must still be admitted and establish, not be rejected with ANOTHER_SERVER
+// for up to the outbound's 30 s establish budget.
+TEST(ConnectionLifecycle, InFlightOutboundDoesNotBlockInboundAdmission) {
+    // A listener that accepts TCP (via the backlog) but never reads or replies: connect_to()
+    // through it succeeds at the TCP layer and then stalls awaiting the WebSocket upgrade,
+    // pinning the outbound nursery entry for the duration of the test.
+    int stall_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(stall_fd, 0);
+    int one = 1;
+    ::setsockopt(stall_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = htons(STALL_LISTEN_PORT);
+    ASSERT_EQ(::bind(stall_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)), 0);
+    ASSERT_EQ(::listen(stall_fd, 1), 0);
+
+    TestNetworkProvider network;
+    SendspinClient client(make_config(ADMIT_TEST_PORT));
+    client.set_network_provider(&network);
+    ASSERT_TRUE(client.start_server());
+    pump_for(client, 50);
+
+    client.connect_to(server_url(STALL_LISTEN_PORT));
+
+    // A mute inbound peer occupies one inbound slot past TCP_OPEN.
+    FakeServer mute(server_url(ADMIT_TEST_PORT), "mute", {.answer_hello = false});
+    ASSERT_TRUE(pump_until(
+        client, [&] { return mute.got_client_hello(); }, 3000));
+
+    // The real server takes the second inbound slot; the stalled outbound must not consume it.
+    FakeServer real_server(server_url(ADMIT_TEST_PORT), "server-real");
+    EXPECT_TRUE(pump_until(
+        client, [&] { return client.is_connected(); }, 4000));
+    auto info = client.get_server_information();
+    ASSERT_TRUE(info.has_value());
+    EXPECT_EQ(info->server_id, "server-real");
+    EXPECT_FALSE(real_server.closed());
+
+    client.disconnect(SendspinGoodbyeReason::SHUTDOWN);
+    pump_for(client, 100);
+    ::close(stall_fd);
+}
+
+// A peer that sends server/hello immediately on connect, before our client/hello has gone out,
+// must not be promoted with an incomplete handshake (that would wedge the current slot forever:
+// out of the nursery, no deadline, is_connected() false, hello retry cancelled). Establishment
+// must instead complete once the client/hello send lands.
+TEST(ConnectionLifecycle, EarlyServerHelloDoesNotWedge) {
+    TestNetworkProvider network;
+    SendspinClient client(make_config(EARLY_HELLO_TEST_PORT));
+    client.set_network_provider(&network);
+    ASSERT_TRUE(client.start_server());
+    pump_for(client, 50);
+
+    FakeServer eager(server_url(EARLY_HELLO_TEST_PORT), "server-eager", {.hello_on_open = true});
+    EXPECT_TRUE(pump_until(
+        client, [&] { return client.is_connected(); }, 4000));
+    auto info = client.get_server_information();
+    ASSERT_TRUE(info.has_value());
+    EXPECT_EQ(info->server_id, "server-eager");
+    EXPECT_FALSE(eager.closed());
+}
+
+// Two real servers connecting back to back resolve by the fair comparison, not by handshake
+// timing. Sequenced deterministically (not a timed race): server-a is asserted to be current
+// before server-b connects, so the second establishment provably exercises the handoff comparison
+// rather than the empty-slot promotion.
+TEST(ConnectionLifecycle, TwoServerRaceResolvedByPreference) {
+    TestNetworkProvider network;
+    TestPersistenceProvider persistence(ConnectionManager::fnv1_hash("server-b"));
+    SendspinClient client(make_config(RACE_TEST_PORT));
+    client.set_network_provider(&network);
+    client.set_persistence_provider(&persistence);
+    ASSERT_TRUE(client.start_server());
+    pump_for(client, 50);
+
+    // server-a establishes and is promoted into the empty slot first...
+    FakeServer server_a(server_url(RACE_TEST_PORT), "server-a");
+    ASSERT_TRUE(pump_until(
+        client,
+        [&] {
+            auto info = client.get_server_information();
+            return info.has_value() && info->server_id == "server-a";
+        },
+        3000));
+
+    // ...then server-b establishes against the incumbent. Both sides of the comparison are
+    // established; the last-played preference (server-b) must win the handoff, and the later
+    // arrival must not be evicted for finishing second.
+    FakeServer server_b(server_url(RACE_TEST_PORT), "server-b");
+    EXPECT_TRUE(pump_until(
+        client,
+        [&] {
+            auto info = client.get_server_information();
+            return info.has_value() && info->server_id == "server-b";
+        },
+        3000));
+
+    // The displaced incumbent is released with a goodbye, not left dangling.
+    EXPECT_TRUE(pump_until(
+        client, [&] { return server_a.closed(); }, 3000));
+    EXPECT_FALSE(server_b.closed());
+    EXPECT_TRUE(client.is_connected());
+}
+
+// Delivery-at-upgrade contract: raw TCP probes never reach the manager, so even enough of them to
+// fill the nursery capacity cannot occupy a slot or delay a real server.
+TEST(ConnectionLifecycle, HeldProbesNeverOccupyNursery) {
+    TestNetworkProvider network;
+    SendspinClient client(make_config(EVICT_TEST_PORT));
+    client.set_network_provider(&network);
+    ASSERT_TRUE(client.start_server());
+    pump_for(client, 50);
+
+    // Two held raw probes, enough to fill every nursery slot if they were admitted at accept.
+    int probe1 = connect_loopback(EVICT_TEST_PORT);
+    ASSERT_GE(probe1, 0);
+    pump_for(client, 100);
+    int probe2 = connect_loopback(EVICT_TEST_PORT);
+    ASSERT_GE(probe2, 0);
+    pump_for(client, 100);
+
+    // The real server must establish promptly: the probes hold no nursery slots, so nothing
+    // needs evicting and nothing is rejected.
+    FakeServer real_server(server_url(EVICT_TEST_PORT), "server-real");
+    EXPECT_TRUE(pump_until(
+        client, [&] { return client.is_connected(); }, 4000));
+    auto info = client.get_server_information();
+    ASSERT_TRUE(info.has_value());
+    EXPECT_EQ(info->server_id, "server-real");
+
+    // The transport layer closes the probes on its own (host: IX 3 s handshake timeout).
+    EXPECT_TRUE(pump_until(
+        client, [&] { return socket_closed(probe1) && socket_closed(probe2); }, 6500));
+    EXPECT_TRUE(client.is_connected());
+
+    ::close(probe1);
+    ::close(probe2);
+}
+
+// Rejection path: with the nursery full of peers that have proven they speak WebSocket (they
+// received client/hello but never establish), a newcomer is rejected. Because rejection happens on
+// an already-upgraded session, the goodbye must reach the peer before the close.
+TEST(ConnectionLifecycle, FullNurseryOfLivePeersRejectsNewcomer) {
+    TestNetworkProvider network;
+    SendspinClient client(make_config(REJECT_TEST_PORT));
+    client.set_network_provider(&network);
+    ASSERT_TRUE(client.start_server());
+    pump_for(client, 50);
+
+    // Two mute peers: they upgrade and receive client/hello but never answer it, occupying both
+    // nursery slots past TCP_OPEN until the establish deadline.
+    FakeServer mute_a(server_url(REJECT_TEST_PORT), "mute-a", {.answer_hello = false});
+    FakeServer mute_b(server_url(REJECT_TEST_PORT), "mute-b", {.answer_hello = false});
+    ASSERT_TRUE(pump_until(
+        client, [&] { return mute_a.got_client_hello() && mute_b.got_client_hello(); }, 3000));
+
+    FakeServer late(server_url(REJECT_TEST_PORT), "server-late");
+    EXPECT_TRUE(pump_until(
+        client, [&] { return late.closed(); }, 3000));
+    EXPECT_TRUE(late.got_goodbye());
+    EXPECT_FALSE(client.is_connected());
+    EXPECT_FALSE(mute_a.closed());
+    EXPECT_FALSE(mute_b.closed());
+}


### PR DESCRIPTION
Connections previously moved into a manager slot at TCP accept and were trusted before proving anything. A raw TCP probe (port scan, health check) that never spoke WebSocket could pin a connection slot indefinitely and wedge the client (#75), and handoff decisions could run against peers that had never completed a handshake. This was mitigated in #80 by reaping connections after a timeout. This PR restructures the connection lifecycle so that nothing reaches the manager without speaking WebSocket, and nothing becomes the active connection without completing the hello handshake.

## Procedures

- Delivery at WS-upgrade. The platform ws_servers hand connections to the manager only after observing the WebSocket upgrade. On ESP, accepted sessions park in a pending table and are delivered from the upgrade `GET` (dispatched natively on IDF <= 5.5.4 / 6.0.0 and via `ws_post_handshake_cb` on newer IDF, fixing the issue identified in #70). Sessions that never upgrade are reaped after 5 s. On host, delivery happens at IXWebSocket's Open event, with the server-side handshake timeout (3 s) pinned explicitly rather than inherited from the dependency default. Raw probes are invisible to the rest of the library.
- A bounded nursery instead of a pending slot. New connections (inbound and outbound) enter a nursery capped at 2 inbound + 1 outbound. Establishment is level-triggered: each loop() tick promotes any nursery connection whose hello handshake has completed, so the order in which client/hello and server/hello land is irrelevant. Connections that stall are reaped at a 30 s establish deadline. Invariant: the current slot only ever holds an established connection, so handoff preference logic (`PLAYBACK` over `DISCOVERY`, last-played server) always runs on real data and no incumbent is evicted on timing alone.
- Graceful rejection. When the nursery is full, a newcomer receives client/goodbye on its already-upgraded session instead of silence. The default `server_max_connections` rises from 2 to 4 (1 established + 2 nursery + 1 spare socket for the goodbye) so the transport can actually accept the surplus peer; the limit is now also enforced on host, and a warning fires if a configured value can't support graceful rejection. **(Potential breaking change)**
- Lifecycle robustness. Close events are routed by connection identity rather than `sockfd` (immune to `fd` recycling), goodbye sends and connection destruction are deferred until the manager lock is dropped (a connection teardown can block or join a transport thread), message dispatch is disabled on every release path so a departing peer can't inject state into live role queues during its goodbye window, and each connection carries its own hello-retry state. `connect_to()`/`disconnect()` are documented as main-loop-thread-only.

## Tests

New integration suite (`tests/test_connection_lifecycle.cpp`, fake servers over real sockets) covering: a held raw probe not blocking a real server, slow outbound connections surviving the upgrade tier, inbound admission during an in-flight outbound, server/hello arriving before client/hello, two-server races resolved by preference, and full-nursery rejection delivering the goodbye.

## Breaking change

The http server on an ESP32 now requires one additional socket to be available, so if the number of sockets are specifically limited, then it will need an adjustment.