### PR TITLE
Migrate client-level cross-thread state onto the Inbox

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -94,7 +94,6 @@ Fixed-depth FIFO queue with timed send/receive. Used to defer events from networ
 |-------|-------|------|----------|----------|
 | `PlayerRole::Impl::stream_queue` | 8 | `PlayerStreamCallbackType` | Network thread | Main loop (`drain_events`) |
 | `PlayerRole::Impl::state_queue` | 4 | `SendspinClientState` | Sync task thread | Main loop (`drain_events`) |
-| `Client::time_queue` | 16 | `TimeResponseEvent` | Network thread | Main loop (`loop`) |
 | `ArtworkRole::Impl::notify_queue` | 8 | `ArtworkNotification` | Network thread | Artwork decode thread |
 | `ArtworkRole::Impl::queue` | 8 | `ArtworkEventType` | Network thread | Main loop (`drain_events`) |
 | `VisualizerRole::Impl::queue` | 8 | `VisualizerEventType` | Network thread | Main loop (`drain_events`) |
@@ -105,7 +104,6 @@ Single-slot state container with "latest wins" or custom merge semantics. The ne
 
 | Shadow Slot | Data | Merge Strategy |
 |-------------|------|----------------|
-| `Client::shadow_group` | `GroupUpdateObject` | Field-by-field delta merge |
 | `PlayerRole::Impl::shadow_stream_params` | `ServerPlayerStreamObject` | Latest wins |
 | `PlayerRole::Impl::shadow_command` | `ServerCommandMessage` | Field-by-field merge (volume, mute, delay independent) |
 | `ControllerRole::Impl::shadow` | `ServerStateControllerObject` | Latest wins |
@@ -116,6 +114,24 @@ Single-slot state container with "latest wins" or custom merge semantics. The ne
 | `SyncTask::playback_progress_slot_` | `PlaybackProgress` | Sum `frames_played`, keep latest `finish_timestamp` |
 
 The merge strategy for `shadow_command` is important: if a volume change and a mute change arrive between two drain ticks, both are preserved because the merge function only overwrites fields that have values in the delta.
+
+### Inbox (`src/inbox.h`)
+
+Shared main-loop mailbox that consolidates client-level cross-thread traffic behind a single mutex and a lock-free dirty-topic bitmask. It provides two endpoint styles:
+
+- A fixed-capacity event ring (`push_event` / `take_events`) for lifecycle events, discriminated by `InboxEventType`. The ring drops on full (matching the old queue behavior) and the producer logs the drop.
+- `InboxSlot<T>`, a latest-value slot (`write` / `merge` / `take`) that replaces `ShadowSlot` for a single topic. Each slot exclusively owns one `INBOX_TOPIC_*` bit.
+
+The main loop calls `poll()` once per tick to read the bitmask lock-free and only locks the mutex to drain topics whose bit is set. A bit set by a producer just after the snapshot is never lost: it stays set until a consumer drains it, so the next tick observes it. The Inbox is a leaf in the lock order, and merge functors must be pure data operations (no callbacks into application code while the mutex is held).
+
+Client-level state currently on the Inbox:
+
+| Endpoint | Topic bit | Data | Producer |
+|----------|-----------|------|----------|
+| Event ring | `INBOX_TOPIC_EVENTS` | `TimeResponsePayload` (via `InboxEvent`) | Network thread |
+| `Client::group_slot` | `INBOX_TOPIC_GROUP` | `GroupUpdateObject` (field-by-field delta merge) | Network thread |
+
+Role-level state (player, controller, metadata, color, artwork, visualizer) still uses the per-role `ThreadSafeQueue`/`ShadowSlot` endpoints above; migrating those onto the Inbox is a later phase.
 
 ### SpscRingBuffer (`src/platform/spsc_ring_buffer.h`)
 
@@ -162,10 +178,10 @@ Network thread (IXWebSocket / esp_http_server)
 | Message | Action on Network Thread |
 |---------|------------------------|
 | `SERVER_HELLO` | Stores server info and connection reason on the connection, then sets `server_hello_received_` (an atomic store that publishes the fields to the main loop; the manager's promotion scan observes `is_handshake_complete()` on its next tick) |
-| `SERVER_TIME` | Enqueues `TimeResponseEvent` into `time_queue` |
+| `SERVER_TIME` | Pushes a `TIME_RESPONSE` `InboxEvent` onto the shared inbox ring |
 | `SERVER_STATE` | Writes to `ControllerRole::Impl::shadow`, `MetadataRole::Impl::shadow`, and `ColorRole::Impl::shadow` |
 | `SERVER_COMMAND` | Merges into `PlayerRole::Impl::shadow_command` |
-| `GROUP_UPDATE` | Merges into `Client::shadow_group` |
+| `GROUP_UPDATE` | Merges into `Client::group_slot` (`InboxSlot<GroupUpdateObject>`) |
 | `STREAM_START` | Writes to `PlayerRole::Impl::shadow_stream_params`, enqueues `STREAM_START` into `stream_queue`. Marks the artwork stream active, flushes the decode thread's notification queue, and resets any pending per-slot display timestamps. Writes to `VisualizerRole::Impl::shadow_config`, enqueues a start event. |
 | `STREAM_END` | Enqueues `STREAM_END` into player/artwork/visualizer queues, signals sync task `COMMAND_STREAM_END` |
 | `STREAM_CLEAR` | Enqueues `STREAM_CLEAR` into artwork/visualizer queues; for the player, signals sync task `COMMAND_STREAM_CLEAR` and enqueues a `CHUNK_TYPE_STREAM_CLEAR_MARKER` chunk into the encoded ring buffer (no player listener callback — a seek is not a stream lifecycle event) |
@@ -206,8 +222,8 @@ The bump arena suits ArduinoJson's allocation pattern: during a parse the varian
    ├─ Acquire/release high-performance networking around burst
    └─ Notify listener of sync error when burst completes
 
-3. Drain time_queue
-   └─ Feed time responses into time_burst_->on_time_response()
+3. Drain inbox event ring (when INBOX_TOPIC_EVENTS is set)
+   └─ Feed TIME_RESPONSE events into time_burst_->on_time_response()
 
 4. Role event draining (each role's impl_->drain_events())
    ├─ player_->impl_->drain_events()
@@ -217,7 +233,7 @@ The bump arena suits ArduinoJson's allocation pattern: during a parse the varian
    ├─ artwork_->impl_->drain_events()
    └─ visualizer_->impl_->drain_events()
 
-5. Drain shadow_group
+5. Drain group_slot (when INBOX_TOPIC_GROUP is set)
    └─ Apply group deltas, fire on_group_update, persist last played server
 ```
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -16,13 +16,12 @@
 
 #include "connection.h"
 #include "connection_manager.h"
+#include "inbox.h"
 #include "platform/compiler.h"
 #include "platform/json_arena.h"
 #include "platform/logging.h"
 #include "platform/memory.h"
 #include "platform/network_info.h"
-#include "platform/shadow_slot.h"
-#include "platform/thread_safe_queue.h"
 #include "platform/time.h"
 #ifdef SENDSPIN_ENABLE_ARTWORK
 #include "artwork_role_impl.h"
@@ -53,23 +52,10 @@ static const char* const TAG = "sendspin.client";
 
 namespace sendspin {
 
-/// @brief Deferred event from the network thread, processed in loop()
-struct TimeResponseEvent {
-    int64_t offset;
-    int64_t max_error;
-    int64_t timestamp;
-    /// Instance id of the connection the response arrived on, compared against the current
-    /// connection at drain time so a measurement from a displaced or pending server cannot
-    /// contaminate the current connection's time filter. An id (not a pointer) so a since-freed
-    /// connection cannot ABA-match a later connection reusing its address; 0 never matches a live
-    /// connection (ids start at 1).
-    uint64_t source_id;
-};
-
 /// @brief Deferred event state for time responses and group updates on the main thread
 struct SendspinClient::EventState {
-    ThreadSafeQueue<TimeResponseEvent> time_queue;
-    ShadowSlot<GroupUpdateObject> shadow_group;
+    Inbox inbox;
+    InboxSlot<GroupUpdateObject> group_slot{inbox, INBOX_TOPIC_GROUP};
 };
 
 // ============================================================================
@@ -84,7 +70,6 @@ SendspinClient::SendspinClient(SendspinClientConfig config)
     if (this->config_.json_arena_size > 0) {
         this->json_arena_ = std::make_unique<SendspinArenaAllocator>(this->config_.json_arena_size);
     }
-    this->event_state_->time_queue.create(16);
     this->time_burst_->configure(this->config_.time_burst_size,
                                  this->config_.time_burst_interval_ms,
                                  this->config_.time_burst_response_timeout_ms);
@@ -186,20 +171,43 @@ void SendspinClient::loop() {
     // Process deferred events: all state mutations and user callbacks happen here, on the main
     // loop thread, to avoid cross-thread data races. Each role drains its own queues/shadows
     // internally.
+    const uint32_t inbox_bits = this->event_state_->inbox.poll();
 
     // --- Time sync events ---
-    {
-        TimeResponseEvent time_event{};
-        while (this->event_state_->time_queue.receive(time_event, 0)) {
-            auto* current = this->connection_manager_->current();
-            // Apply only measurements from the connection that is still current; a response queued
-            // by a since-displaced (or pending) server carries that server's clock and would
-            // contaminate this connection's Kalman filter.
-            if (current != nullptr && current->get_instance_id() == time_event.source_id) {
-                this->time_burst_->on_time_response(current, time_event.offset,
-                                                    time_event.max_error, time_event.timestamp);
+    if (inbox_bits & INBOX_TOPIC_EVENTS) {
+        // Drain in small batches to bound the stack cost on the shared main-loop task (the ring
+        // holds up to EVENT_CAPACITY entries of ~40 bytes each). A batch that comes back partial
+        // means the ring is empty, ending the loop; events pushed mid-drain are still delivered
+        // this tick as long as full batches keep arriving.
+        InboxEvent events[8];
+        size_t event_count = 0;
+        do {
+            event_count = this->event_state_->inbox.take_events(events, 8);
+            for (size_t i = 0; i < event_count; ++i) {
+                const InboxEvent& event = events[i];
+                switch (event.type) {
+                    case InboxEventType::TIME_RESPONSE: {
+                        auto* current = this->connection_manager_->current();
+                        // Apply only measurements from the connection that is still current; a
+                        // response queued by a since-displaced (or pending) server carries that
+                        // server's clock and would contaminate this connection's Kalman filter.
+                        if (current != nullptr &&
+                            current->get_instance_id() == event.time.source_id) {
+                            this->time_burst_->on_time_response(current, event.time.offset,
+                                                                event.time.max_error,
+                                                                event.time.timestamp);
+                        }
+                        break;
+                    }
+                    default: {
+                        // Role event types are not produced yet; later phases add drains here.
+                        SS_LOGD(TAG, "Unhandled inbox event type: %d",
+                                static_cast<int>(event.type));
+                        break;
+                    }
+                }
             }
-        }
+        } while (event_count == 8);
     }
 
     // --- Role events (each role handles its own synchronization) ---
@@ -235,9 +243,9 @@ void SendspinClient::loop() {
 #endif
 
     // --- Group update events ---
-    {
+    if (inbox_bits & INBOX_TOPIC_GROUP) {
         GroupUpdateObject group_delta;
-        if (this->event_state_->shadow_group.take(group_delta)) {
+        if (this->event_state_->group_slot.take(group_delta)) {
             apply_group_update_deltas(&this->group_state_, group_delta);
 
             if (this->listener_) {
@@ -417,8 +425,8 @@ void SendspinClient::cleanup_connection_state() {
     this->time_burst_->reset();
 
     // Reset client event state
-    this->event_state_->time_queue.reset();
-    this->event_state_->shadow_group.reset();
+    this->event_state_->inbox.reset_events();
+    this->event_state_->group_slot.reset();
 
 #ifdef SENDSPIN_ENABLE_PLAYER
     if (this->player_) {
@@ -687,9 +695,12 @@ void SendspinClient::process_json_message(SendspinConnection* conn, const char* 
             int64_t offset{0};
             int64_t max_error{0};
             if (process_server_time_message(root, timestamp, &offset, &max_error)) {
-                if (!this->event_state_->time_queue.send(
-                        {offset, max_error, timestamp, conn->get_instance_id()}, 0)) {
-                    SS_LOGW(TAG, "Time response queue full; dropping measurement");
+                InboxEvent event{};
+                event.type = InboxEventType::TIME_RESPONSE;
+                event.time =
+                    TimeResponsePayload{offset, max_error, timestamp, conn->get_instance_id()};
+                if (!this->event_state_->inbox.push_event(event)) {
+                    SS_LOGW(TAG, "Inbox event ring full; dropping time response measurement");
                 }
             }
             break;
@@ -733,7 +744,7 @@ void SendspinClient::process_json_message(SendspinConnection* conn, const char* 
         case SendspinServerToClientMessageType::GROUP_UPDATE: {
             GroupUpdateMessage group_msg;
             if (process_group_update_message(root, &group_msg)) {
-                this->event_state_->shadow_group.merge(
+                this->event_state_->group_slot.merge(
                     [](GroupUpdateObject& current, GroupUpdateObject&& delta) {
                         apply_group_update_deltas(&current, delta);
                     },

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -178,11 +178,13 @@ void SendspinClient::loop() {
         // Drain in small batches to bound the stack cost on the shared main-loop task (the ring
         // holds up to EVENT_CAPACITY entries of ~40 bytes each). A batch that comes back partial
         // means the ring is empty, ending the loop; events pushed mid-drain are still delivered
-        // this tick as long as full batches keep arriving.
-        InboxEvent events[8];
+        // this tick as long as full batches keep arriving. Sized as a fraction of the ring so the
+        // batch/ring ratio (and the stack cost above) tracks EVENT_CAPACITY automatically.
+        constexpr size_t EVENT_DRAIN_BATCH_SIZE = Inbox::EVENT_CAPACITY / 4;
+        InboxEvent events[EVENT_DRAIN_BATCH_SIZE];
         size_t event_count = 0;
         do {
-            event_count = this->event_state_->inbox.take_events(events, 8);
+            event_count = this->event_state_->inbox.take_events(events, EVENT_DRAIN_BATCH_SIZE);
             for (size_t i = 0; i < event_count; ++i) {
                 const InboxEvent& event = events[i];
                 switch (event.type) {
@@ -200,14 +202,15 @@ void SendspinClient::loop() {
                         break;
                     }
                     default: {
-                        // Role event types are not produced yet; later phases add drains here.
+                        // No role event types are produced yet; unhandled types are logged and
+                        // dropped.
                         SS_LOGD(TAG, "Unhandled inbox event type: %d",
                                 static_cast<int>(event.type));
                         break;
                     }
                 }
             }
-        } while (event_count == 8);
+        } while (event_count == EVENT_DRAIN_BATCH_SIZE);
     }
 
     // --- Role events (each role handles its own synchronization) ---

--- a/src/inbox.h
+++ b/src/inbox.h
@@ -38,15 +38,15 @@ namespace sendspin {
 /// One bit per main-loop-drained endpoint. A bit is owned by exactly one InboxSlot
 /// (or by the event ring); it is set when that endpoint has pending content and
 /// cleared when the endpoint is drained, always under the Inbox mutex.
-static constexpr uint32_t INBOX_TOPIC_EVENTS = 1u << 0;                // Shared event ring
-static constexpr uint32_t INBOX_TOPIC_GROUP = 1u << 1;                 // Group update slot
-static constexpr uint32_t INBOX_TOPIC_CONTROLLER = 1u << 2;            // Controller state slot
-static constexpr uint32_t INBOX_TOPIC_METADATA = 1u << 3;              // Metadata delta slot
-static constexpr uint32_t INBOX_TOPIC_COLOR = 1u << 4;                 // Color delta slot
-static constexpr uint32_t INBOX_TOPIC_PLAYER_COMMAND = 1u << 5;        // Player command slot
-static constexpr uint32_t INBOX_TOPIC_PLAYER_STREAM_PARAMS = 1u << 6;  // Player stream params slot
-static constexpr uint32_t INBOX_TOPIC_VISUALIZER_CONFIG = 1u << 7;     // Visualizer config slot
-static constexpr uint32_t INBOX_TOPIC_ARTWORK_DISPLAY = 1u << 8;       // Artwork display slot
+static constexpr uint32_t INBOX_TOPIC_EVENTS = 1U << 0;                // Shared event ring
+static constexpr uint32_t INBOX_TOPIC_GROUP = 1U << 1;                 // Group update slot
+static constexpr uint32_t INBOX_TOPIC_CONTROLLER = 1U << 2;            // Controller state slot
+static constexpr uint32_t INBOX_TOPIC_METADATA = 1U << 3;              // Metadata delta slot
+static constexpr uint32_t INBOX_TOPIC_COLOR = 1U << 4;                 // Color delta slot
+static constexpr uint32_t INBOX_TOPIC_PLAYER_COMMAND = 1U << 5;        // Player command slot
+static constexpr uint32_t INBOX_TOPIC_PLAYER_STREAM_PARAMS = 1U << 6;  // Player stream params slot
+static constexpr uint32_t INBOX_TOPIC_VISUALIZER_CONFIG = 1U << 7;     // Visualizer config slot
+static constexpr uint32_t INBOX_TOPIC_ARTWORK_DISPLAY = 1U << 8;       // Artwork display slot
 
 // ============================================================================
 // Event ring types
@@ -68,13 +68,15 @@ enum class InboxEventType : uint8_t {
 };
 
 /// @brief Payload for TIME_RESPONSE events
-///
-/// Mirrors the fields of the current TimeResponseEvent in client.cpp; that struct migrates here
-/// in a later phase.
 struct TimeResponsePayload {
     int64_t offset{0};
     int64_t max_error{0};
     int64_t timestamp{0};
+    /// Instance id of the connection the response arrived on, compared against the current
+    /// connection at drain time so a measurement from a displaced or pending server cannot
+    /// contaminate the current connection's time filter. An id (not a pointer) so a since-freed
+    /// connection cannot ABA-match a later connection reusing its address; 0 never matches a live
+    /// connection (ids start at 1).
     uint64_t source_id{0};
 };
 


### PR DESCRIPTION
Part 2/6 of the inbox ITC refactor stack (based on #84; merge in order).

Replaces the client's `ThreadSafeQueue<TimeResponseEvent>` and the group-update `ShadowSlot` with the shared Inbox: time responses ride the event ring (source-id filtering at drain time unchanged), group deltas merge in an `InboxSlot`, and `loop()` gates both drains on a single lock-free `poll()`. The ring drain runs in batches of 8 to bound main-task stack cost on ESP32. Role drains are untouched and migrate in the next PRs.