### PR TITLE
Migrate controller, color, and metadata roles onto the Inbox

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -106,9 +106,6 @@ Single-slot state container with "latest wins" or custom merge semantics. The ne
 |-------------|------|----------------|
 | `PlayerRole::Impl::shadow_stream_params` | `ServerPlayerStreamObject` | Latest wins |
 | `PlayerRole::Impl::shadow_command` | `ServerCommandMessage` | Field-by-field merge (volume, mute, delay independent) |
-| `ControllerRole::Impl::shadow` | `ServerStateControllerObject` | Latest wins |
-| `MetadataRole::Impl::shadow` | `ServerMetadataStateDelta` | Field-by-field delta merge (preserves pending clears across rapid updates) |
-| `ColorRole::Impl::shadow` | `ServerColorStateDelta` | Field-by-field delta merge (preserves pending clears across rapid updates) |
 | `ArtworkRole::Impl::display_scheduler->pending[slot]` (×4) | `int64_t` (server display timestamp) | Latest wins |
 | `VisualizerRole::Impl::shadow_config` | `ServerVisualizerStreamObject` | Latest wins |
 | `SyncTask::playback_progress_slot_` | `PlaybackProgress` | Sum `frames_played`, keep latest `finish_timestamp` |
@@ -124,14 +121,17 @@ Shared main-loop mailbox that consolidates client-level cross-thread traffic beh
 
 The main loop calls `poll()` once per tick to read the bitmask lock-free and only locks the mutex to drain topics whose bit is set. A bit set by a producer just after the snapshot is never lost: it stays set until a consumer drains it, so the next tick observes it. The Inbox is a leaf in the lock order, and merge functors must be pure data operations (no callbacks into application code while the mutex is held).
 
-Client-level state currently on the Inbox:
+State currently on the Inbox:
 
 | Endpoint | Topic bit | Data | Producer |
 |----------|-----------|------|----------|
-| Event ring | `INBOX_TOPIC_EVENTS` | `TimeResponsePayload` (via `InboxEvent`) | Network thread |
+| Event ring | `INBOX_TOPIC_EVENTS` | Lifecycle events (`TimeResponsePayload`, plus `CONTROLLER_CLEARED` / `METADATA_CLEARED` / `COLOR_CLEARED`) via `InboxEvent` | Network thread / role `cleanup()` |
 | `Client::group_slot` | `INBOX_TOPIC_GROUP` | `GroupUpdateObject` (field-by-field delta merge) | Network thread |
+| `ControllerRole::Impl::slot` | `INBOX_TOPIC_CONTROLLER` | `ServerStateControllerObject` (latest wins) | Network thread |
+| `MetadataRole::Impl::slot` | `INBOX_TOPIC_METADATA` | `ServerMetadataStateDelta` (field-by-field delta merge) | Network thread |
+| `ColorRole::Impl::slot` | `INBOX_TOPIC_COLOR` | `ServerColorStateDelta` (field-by-field delta merge) | Network thread |
 
-Role-level state (player, controller, metadata, color, artwork, visualizer) still uses the per-role `ThreadSafeQueue`/`ShadowSlot` endpoints above; migrating those onto the Inbox is a later phase.
+The controller, metadata, and color roles have been migrated onto the Inbox: each `handle_server_state()` writes or merges into its `InboxSlot`, and the disconnect clear is delivered as a `*_CLEARED` lifecycle event on the shared ring rather than a per-role flag. The remaining role-level state (player, artwork, visualizer) still uses the per-role `ThreadSafeQueue`/`ShadowSlot` endpoints above; migrating those onto the Inbox is a later phase.
 
 ### SpscRingBuffer (`src/platform/spsc_ring_buffer.h`)
 
@@ -179,7 +179,7 @@ Network thread (IXWebSocket / esp_http_server)
 |---------|------------------------|
 | `SERVER_HELLO` | Stores server info and connection reason on the connection, then sets `server_hello_received_` (an atomic store that publishes the fields to the main loop; the manager's promotion scan observes `is_handshake_complete()` on its next tick) |
 | `SERVER_TIME` | Pushes a `TIME_RESPONSE` `InboxEvent` onto the shared inbox ring |
-| `SERVER_STATE` | Writes to `ControllerRole::Impl::shadow`, `MetadataRole::Impl::shadow`, and `ColorRole::Impl::shadow` |
+| `SERVER_STATE` | Writes/merges into the controller, metadata, and color `InboxSlot`s via each role's `handle_server_state()` |
 | `SERVER_COMMAND` | Merges into `PlayerRole::Impl::shadow_command` |
 | `GROUP_UPDATE` | Merges into `Client::group_slot` (`InboxSlot<GroupUpdateObject>`) |
 | `STREAM_START` | Writes to `PlayerRole::Impl::shadow_stream_params`, enqueues `STREAM_START` into `stream_queue`. Marks the artwork stream active, flushes the decode thread's notification queue, and resets any pending per-slot display timestamps. Writes to `VisualizerRole::Impl::shadow_config`, enqueues a start event. |
@@ -223,7 +223,8 @@ The bump arena suits ArduinoJson's allocation pattern: during a parse the varian
    └─ Notify listener of sync error when burst completes
 
 3. Drain inbox event ring (when INBOX_TOPIC_EVENTS is set)
-   └─ Feed TIME_RESPONSE events into time_burst_->on_time_response()
+   ├─ Feed TIME_RESPONSE events into time_burst_->on_time_response()
+   └─ Fire CONTROLLER/METADATA/COLOR_CLEARED via each role's handle_cleared_event()
 
 4. Role event draining (each role's impl_->drain_events())
    ├─ player_->impl_->drain_events()
@@ -272,9 +273,9 @@ The `awaiting_sync_idle_events` list (on `PlayerRole::Impl`) is the key ordering
 
 ### Other Roles
 
-- **ControllerRole**: Takes from shadow, fires `on_controller_state()`.
-- **MetadataRole**: Fires `on_metadata_clear()` first if a `pending_clear` flag is set (deferred from `cleanup()` to avoid invoking the listener while `ConnectionManager` holds `conn_ptr_mutex_`). Then takes from shadow when the pending update's `timestamp` has been reached on the synced client clock (or immediately if there is no active connection), applies deltas, fires `on_metadata()`.
-- **ColorRole**: Fires `on_color_clear()` first if a `pending_clear` flag is set (deferred from `cleanup()` to avoid invoking the listener while `ConnectionManager` holds `conn_ptr_mutex_`). Then takes from shadow when the pending update's `timestamp` has been reached on the synced client clock (or immediately if there is no active connection), applies deltas, fires `on_color()`.
+- **ControllerRole**: Takes the latest `ServerStateControllerObject` from its `InboxSlot`, fires `on_controller_state()`. The disconnect clear is not handled here; it arrives as a `CONTROLLER_CLEARED` event on the shared ring, whose `handle_cleared_event()` fires `on_controller_state_clear()` (deferred from `cleanup()` to avoid invoking the listener while `ConnectionManager` holds `conn_ptr_mutex_`).
+- **MetadataRole**: `InboxSlot` has no `take_if`, so the deadline gate that used to run under the shadow slot's mutex is split in two: `take()` unconditionally moves any pending delta into a main-thread-only `held_delta` (folding it into an already-held delta), then the server-clock deadline is evaluated with no lock held, applying deltas and firing `on_metadata()` once the `timestamp` is reached (or immediately if there is no active connection). A future-dated `held_delta` persists across ticks with no topic bit set, which is why this `drain_events()` must be called unconditionally every tick (see the warning in `SendspinClient::loop()`). The clear arrives separately as a `METADATA_CLEARED` ring event (`handle_cleared_event()` fires `on_metadata_clear()`), deferred from `cleanup()` for the same `conn_ptr_mutex_` reason.
+- **ColorRole**: Same structure as MetadataRole: `take()` into `held_delta`, a lock-free server-clock deadline gate firing `on_color()`, and a `COLOR_CLEARED` ring event driving `on_color_clear()`.
 - **ArtworkRole**: Drains event queue for stream end/clear lifecycle events first (resetting all per-slot pending display timestamps and firing `on_image_clear()` for each configured slot). Then iterates the per-slot `DisplayScheduler::pending` shadow slots and fires `on_image_display(slot)` for any slot whose pending timestamp is due on the synced client clock (or immediately if there is no active connection). `on_image_decode` still happens on the dedicated artwork decode thread.
 - **VisualizerRole**: Drains event queue, processes stream start/end/clear with shadow config.
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -125,7 +125,7 @@ State currently on the Inbox:
 
 | Endpoint | Topic bit | Data | Producer |
 |----------|-----------|------|----------|
-| Event ring | `INBOX_TOPIC_EVENTS` | Lifecycle events (`TimeResponsePayload`, plus `CONTROLLER_CLEARED` / `METADATA_CLEARED` / `COLOR_CLEARED`) via `InboxEvent` | Network thread / role `cleanup()` |
+| Event ring | `INBOX_TOPIC_EVENTS` | Lifecycle events (`TimeResponsePayload`, plus `CONTROLLER_CLEARED` / `METADATA_CLEARED` / `COLOR_CLEARED`) via `InboxEvent` | Network thread (`TimeResponsePayload`) / main-loop thread (`*_CLEARED` via role `cleanup()`) |
 | `Client::group_slot` | `INBOX_TOPIC_GROUP` | `GroupUpdateObject` (field-by-field delta merge) | Network thread |
 | `ControllerRole::Impl::slot` | `INBOX_TOPIC_CONTROLLER` | `ServerStateControllerObject` (latest wins) | Network thread |
 | `MetadataRole::Impl::slot` | `INBOX_TOPIC_METADATA` | `ServerMetadataStateDelta` (field-by-field delta merge) | Network thread |

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -201,6 +201,37 @@ void SendspinClient::loop() {
                         }
                         break;
                     }
+                    // CONTROLLER_CLEARED / METADATA_CLEARED / COLOR_CLEARED: pushed by each
+                    // role's cleanup() in place of the old boolean coalescing flag. Unlike that
+                    // flag, the ring does not coalesce repeats: a back-to-back disconnect/reconnect
+                    // within one tick can enqueue more than one CLEARED for the same role before
+                    // this drain runs, firing its clear callback more than once. That is safe
+                    // only because clear callbacks are idempotent by contract (see
+                    // on_controller_state_clear() / on_metadata_clear() / on_color_clear()).
+                    case InboxEventType::CONTROLLER_CLEARED: {
+#ifdef SENDSPIN_ENABLE_CONTROLLER
+                        if (this->controller_) {
+                            this->controller_->impl_->handle_cleared_event();
+                        }
+#endif
+                        break;
+                    }
+                    case InboxEventType::METADATA_CLEARED: {
+#ifdef SENDSPIN_ENABLE_METADATA
+                        if (this->metadata_) {
+                            this->metadata_->impl_->handle_cleared_event();
+                        }
+#endif
+                        break;
+                    }
+                    case InboxEventType::COLOR_CLEARED: {
+#ifdef SENDSPIN_ENABLE_COLOR
+                        if (this->color_) {
+                            this->color_->impl_->handle_cleared_event();
+                        }
+#endif
+                        break;
+                    }
                     default: {
                         // No role event types are produced yet; unhandled types are logged and
                         // dropped.
@@ -298,6 +329,7 @@ ControllerRole& SendspinClient::add_controller() {
         SS_LOGW(TAG, "add_controller() called after start_server()");
     }
     this->controller_ = std::make_unique<ControllerRole>(this);
+    this->controller_->impl_->attach_inbox(this->event_state_->inbox);
     return *this->controller_;
 }
 #endif
@@ -308,6 +340,7 @@ MetadataRole& SendspinClient::add_metadata() {
         SS_LOGW(TAG, "add_metadata() called after start_server()");
     }
     this->metadata_ = std::make_unique<MetadataRole>(this);
+    this->metadata_->impl_->attach_inbox(this->event_state_->inbox);
     return *this->metadata_;
 }
 #endif
@@ -318,6 +351,7 @@ ColorRole& SendspinClient::add_color() {
         SS_LOGW(TAG, "add_color() called after start_server()");
     }
     this->color_ = std::make_unique<ColorRole>(this);
+    this->color_->impl_->attach_inbox(this->event_state_->inbox);
     return *this->color_;
 }
 #endif

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -76,7 +76,10 @@ SendspinClient::SendspinClient(SendspinClientConfig config)
 }
 
 SendspinClient::~SendspinClient() {
-    // Stop background threads before tearing down connections.
+    // Stop background threads before tearing down connections. Every role is reset explicitly
+    // (not just the threaded ones): role InboxSlots release their topic-bit claims against
+    // event_state_'s Inbox on destruction, so all roles must be gone before the alphabetized
+    // member order destroys event_state_.
 #ifdef SENDSPIN_ENABLE_PLAYER
     this->player_.reset();
 #endif
@@ -85,6 +88,15 @@ SendspinClient::~SendspinClient() {
 #endif
 #ifdef SENDSPIN_ENABLE_ARTWORK
     this->artwork_.reset();
+#endif
+#ifdef SENDSPIN_ENABLE_CONTROLLER
+    this->controller_.reset();
+#endif
+#ifdef SENDSPIN_ENABLE_METADATA
+    this->metadata_.reset();
+#endif
+#ifdef SENDSPIN_ENABLE_COLOR
+    this->color_.reset();
 #endif
     this->connection_manager_.reset();
 }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -214,12 +214,16 @@ void SendspinClient::loop() {
                         break;
                     }
                     // CONTROLLER_CLEARED / METADATA_CLEARED / COLOR_CLEARED: pushed by each
-                    // role's cleanup() in place of the old boolean coalescing flag. Unlike that
-                    // flag, the ring does not coalesce repeats: a back-to-back disconnect/reconnect
-                    // within one tick can enqueue more than one CLEARED for the same role before
-                    // this drain runs, firing its clear callback more than once. That is safe
-                    // only because clear callbacks are idempotent by contract (see
-                    // on_controller_state_clear() / on_metadata_clear() / on_color_clear()).
+                    // role's cleanup() in place of the old boolean coalescing flag. At most one
+                    // CLEARED per role is ever pending when this drain runs: cleanup() is called
+                    // only from cleanup_connection_state(), which first calls inbox.reset_events()
+                    // (wiping the whole ring) before any role re-pushes its CLEARED, and that path
+                    // runs only under conn_ptr_mutex_ (ConnectionManager::drop_connection), so it
+                    // cannot interleave with itself. So even a back-to-back disconnect/reconnect
+                    // coalesces to a single CLEARED -- the reset_events() ordering is what
+                    // guarantees it, not clear-callback idempotency. (Callbacks are idempotent by
+                    // contract anyway; see on_controller_state_clear() / on_metadata_clear() /
+                    // on_color_clear().)
                     case InboxEventType::CONTROLLER_CLEARED: {
 #ifdef SENDSPIN_ENABLE_CONTROLLER
                         if (this->controller_) {
@@ -257,6 +261,12 @@ void SendspinClient::loop() {
     }
 
     // --- Role events (each role handles its own synchronization) ---
+    // These drains must stay unconditional (gated only on the role existing), NOT wrapped in an
+    // `inbox_bits & INBOX_TOPIC_*` test like the group slot below. metadata/color drain_events()
+    // take() clears the topic bit even when it defers a future-dated delta into held_delta; that
+    // deferred delta is re-evaluated against its deadline on later ticks only because this call
+    // runs every tick. Bit-gating it would strand the delta until an unrelated new delta happened
+    // to re-set the bit, silently starving deadline-based delivery.
 #ifdef SENDSPIN_ENABLE_PLAYER
     if (this->player_) {
         this->player_->impl_->drain_events();

--- a/src/color_role.cpp
+++ b/src/color_role.cpp
@@ -100,15 +100,14 @@ void ColorRole::Impl::handle_server_state(ServerColorStateDelta delta) const {
 void ColorRole::Impl::drain_events() {
     ServerColorStateDelta delta{};
     if (this->event_state->slot.take(delta)) {
-        if (this->has_held_delta) {
-            merge_color_state_delta(this->held_delta, std::move(delta));
+        if (this->held_delta.has_value()) {
+            merge_color_state_delta(*this->held_delta, std::move(delta));
         } else {
             this->held_delta = std::move(delta);
-            this->has_held_delta = true;
         }
     }
 
-    if (!this->has_held_delta) {
+    if (!this->held_delta.has_value()) {
         return;
     }
 
@@ -116,17 +115,16 @@ void ColorRole::Impl::drain_events() {
     // cannot honor the server-clock deadline, so fire immediately rather than starving the
     // listener. No lock is held here (the slot value was already taken above), unlike the old
     // take_if predicate which ran under the shadow slot's mutex.
-    int64_t client_ts = this->client->get_client_time(this->held_delta.timestamp);
+    int64_t client_ts = this->client->get_client_time(this->held_delta->timestamp);
     if (client_ts != 0 && client_ts > platform_time_us()) {
         return;
     }
 
-    apply_color_state_deltas(&this->color, this->held_delta);
+    apply_color_state_deltas(&this->color, *this->held_delta);
     if (this->listener) {
         this->listener->on_color(this->color);
     }
-    this->held_delta = {};
-    this->has_held_delta = false;
+    this->held_delta.reset();
 }
 
 void ColorRole::Impl::handle_cleared_event() {
@@ -140,17 +138,9 @@ void ColorRole::Impl::handle_cleared_event() {
 void ColorRole::Impl::cleanup() {
     this->event_state->slot.reset();
     this->color = {};
-    this->held_delta = {};
-    this->has_held_delta = false;
+    this->held_delta.reset();
 
-    if (this->inbox != nullptr) {
-        InboxEvent event{};
-        event.type = InboxEventType::COLOR_CLEARED;
-        event.code = 0;
-        if (!this->inbox->push_event(event)) {
-            SS_LOGW(TAG, "Inbox event ring full; dropping color cleared event");
-        }
-    }
+    push_event_or_log(this->inbox, InboxEventType::COLOR_CLEARED, 0, TAG, "color cleared event");
 }
 
 }  // namespace sendspin

--- a/src/color_role.cpp
+++ b/src/color_role.cpp
@@ -34,7 +34,8 @@ namespace {
 /// (handle_server_state); and main-thread, folding a freshly taken slot value into the held delta
 /// (ColorRole::Impl::drain_events). ServerColorStateDelta is trivially copyable (RgbColor is
 /// std::array<uint8_t, 3>), so fields are assigned directly without std::move.
-void merge_color_state_delta(ServerColorStateDelta& current, ServerColorStateDelta&& incoming) {
+void merge_color_state_delta(ServerColorStateDelta& current,
+                             const ServerColorStateDelta& incoming) {
     current.timestamp = incoming.timestamp;
     if (incoming.background_dark.has_value()) {
         current.background_dark = incoming.background_dark;
@@ -100,9 +101,9 @@ void ColorRole::Impl::drain_events() {
     ServerColorStateDelta delta{};
     if (this->event_state->slot.take(delta)) {
         if (this->held_delta.has_value()) {
-            merge_color_state_delta(*this->held_delta, std::move(delta));
+            merge_color_state_delta(*this->held_delta, delta);
         } else {
-            this->held_delta = std::move(delta);
+            this->held_delta = delta;
         }
     }
 
@@ -131,7 +132,7 @@ void ColorRole::Impl::drain_events() {
     this->held_delta.reset();
 }
 
-void ColorRole::Impl::handle_cleared_event() {
+void ColorRole::Impl::handle_cleared_event() const {
     // Deferred from cleanup() to avoid invoking the listener while ConnectionManager holds
     // conn_ptr_mutex_; a listener that calls back into the client would otherwise deadlock.
     if (this->listener) {

--- a/src/color_role.cpp
+++ b/src/color_role.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "color_role_impl.h"
-#include "platform/logging.h"
 #include "platform/time.h"
 #include "protocol_messages.h"
 #include "sendspin/client.h"
@@ -111,6 +110,11 @@ void ColorRole::Impl::drain_events() {
         return;
     }
 
+    // A future-dated delta is held across ticks below without any topic bit set (take() above
+    // cleared it). It is re-evaluated against its deadline only because the client calls this
+    // drain_events() unconditionally every tick -- see the warning at the drain-call site in
+    // SendspinClient::loop().
+    //
     // get_client_time returns 0 when there is no current connection. Without a connection we
     // cannot honor the server-clock deadline, so fire immediately rather than starving the
     // listener. No lock is held here (the slot value was already taken above), unlike the old

--- a/src/color_role.cpp
+++ b/src/color_role.cpp
@@ -13,13 +13,51 @@
 // limitations under the License.
 
 #include "color_role_impl.h"
+#include "platform/logging.h"
 #include "platform/time.h"
 #include "protocol_messages.h"
 #include "sendspin/client.h"
 
 #include <utility>
 
+static const char* const TAG = "sendspin.color";
+
 namespace sendspin {
+
+namespace {
+
+/// @brief Merges an incoming wire delta into an accumulated delta using field-overlay semantics
+///
+/// For each field, an outer-engaged incoming entry overwrites the accumulated entry verbatim;
+/// absent (outer-nullopt) incoming fields leave the accumulated entry untouched, so pending
+/// clears (inner-nullopt) from earlier deltas survive until applied. Shared by both merge sites
+/// so they cannot drift: cross-thread, merging a network-thread delta into the inbox slot
+/// (handle_server_state); and main-thread, folding a freshly taken slot value into the held delta
+/// (ColorRole::Impl::drain_events). ServerColorStateDelta is trivially copyable (RgbColor is
+/// std::array<uint8_t, 3>), so fields are assigned directly without std::move.
+void merge_color_state_delta(ServerColorStateDelta& current, ServerColorStateDelta&& incoming) {
+    current.timestamp = incoming.timestamp;
+    if (incoming.background_dark.has_value()) {
+        current.background_dark = incoming.background_dark;
+    }
+    if (incoming.background_light.has_value()) {
+        current.background_light = incoming.background_light;
+    }
+    if (incoming.primary.has_value()) {
+        current.primary = incoming.primary;
+    }
+    if (incoming.accent.has_value()) {
+        current.accent = incoming.accent;
+    }
+    if (incoming.on_dark.has_value()) {
+        current.on_dark = incoming.on_dark;
+    }
+    if (incoming.on_light.has_value()) {
+        current.on_light = incoming.on_light;
+    }
+}
+
+}  // namespace
 
 // ============================================================================
 // Impl constructor / destructor
@@ -44,77 +82,75 @@ void ColorRole::set_listener(ColorRoleListener* listener) {
 // Impl method implementations
 // ============================================================================
 
+void ColorRole::Impl::attach_inbox(Inbox& inbox) {
+    this->inbox = &inbox;
+    this->event_state->slot.bind(inbox, INBOX_TOPIC_COLOR);
+}
+
 void ColorRole::Impl::build_hello_fields(ClientHelloMessage& msg) {
     msg.supported_roles.push_back(SendspinRole::COLOR);
 }
 
 void ColorRole::Impl::handle_server_state(ServerColorStateDelta delta) const {
-    // Merge incoming wire delta into the accumulated delta in the shadow slot. For each field, an
-    // outer-engaged incoming entry overwrites the accumulated entry verbatim; absent
-    // (outer-nullopt) incoming fields leave the accumulated entry untouched, so pending clears
-    // (inner-nullopt) from earlier deltas survive until drain_events applies them.
-    // ServerColorStateDelta is trivially copyable (RgbColor is std::array<uint8_t, 3>), so the
-    // merge assigns fields directly without std::move.
-    this->event_state->shadow.merge(
-        [](ServerColorStateDelta& current, ServerColorStateDelta&& incoming) {
-            current.timestamp = incoming.timestamp;
-            if (incoming.background_dark.has_value()) {
-                current.background_dark = incoming.background_dark;
-            }
-            if (incoming.background_light.has_value()) {
-                current.background_light = incoming.background_light;
-            }
-            if (incoming.primary.has_value()) {
-                current.primary = incoming.primary;
-            }
-            if (incoming.accent.has_value()) {
-                current.accent = incoming.accent;
-            }
-            if (incoming.on_dark.has_value()) {
-                current.on_dark = incoming.on_dark;
-            }
-            if (incoming.on_light.has_value()) {
-                current.on_light = incoming.on_light;
-            }
-        },
-        delta);
+    // Merge incoming wire delta into the accumulated delta in the inbox slot; see
+    // merge_color_state_delta for the field-overlay semantics.
+    this->event_state->slot.merge(merge_color_state_delta, delta);
 }
 
 void ColorRole::Impl::drain_events() {
-    // Deferred from cleanup() to avoid invoking the listener while ConnectionManager holds
-    // conn_ptr_mutex_; a listener that calls back into the client would otherwise deadlock.
-    if (this->event_state->pending_clear) {
-        this->event_state->pending_clear = false;
-        if (this->listener) {
-            this->listener->on_color_clear();
+    ServerColorStateDelta delta{};
+    if (this->event_state->slot.take(delta)) {
+        if (this->has_held_delta) {
+            merge_color_state_delta(this->held_delta, std::move(delta));
+        } else {
+            this->held_delta = std::move(delta);
+            this->has_held_delta = true;
         }
     }
 
-    ServerColorStateDelta delta{};
-    const bool taken =
-        this->event_state->shadow.take_if(delta, [this](const ServerColorStateDelta& pending) {
-            // get_client_time returns 0 when there is no current connection. Without a connection
-            // we cannot honor the server-clock deadline, so fire immediately rather than starving
-            // the listener.
-            int64_t client_ts = this->client->get_client_time(pending.timestamp);
-            if (client_ts == 0) {
-                return true;
-            }
-            return client_ts <= platform_time_us();
-        });
-    if (!taken) {
+    if (!this->has_held_delta) {
         return;
     }
-    apply_color_state_deltas(&this->color, delta);
+
+    // get_client_time returns 0 when there is no current connection. Without a connection we
+    // cannot honor the server-clock deadline, so fire immediately rather than starving the
+    // listener. No lock is held here (the slot value was already taken above), unlike the old
+    // take_if predicate which ran under the shadow slot's mutex.
+    int64_t client_ts = this->client->get_client_time(this->held_delta.timestamp);
+    if (client_ts != 0 && client_ts > platform_time_us()) {
+        return;
+    }
+
+    apply_color_state_deltas(&this->color, this->held_delta);
     if (this->listener) {
         this->listener->on_color(this->color);
+    }
+    this->held_delta = {};
+    this->has_held_delta = false;
+}
+
+void ColorRole::Impl::handle_cleared_event() {
+    // Deferred from cleanup() to avoid invoking the listener while ConnectionManager holds
+    // conn_ptr_mutex_; a listener that calls back into the client would otherwise deadlock.
+    if (this->listener) {
+        this->listener->on_color_clear();
     }
 }
 
 void ColorRole::Impl::cleanup() {
-    this->event_state->shadow.reset();
+    this->event_state->slot.reset();
     this->color = {};
-    this->event_state->pending_clear = true;
+    this->held_delta = {};
+    this->has_held_delta = false;
+
+    if (this->inbox != nullptr) {
+        InboxEvent event{};
+        event.type = InboxEventType::COLOR_CLEARED;
+        event.code = 0;
+        if (!this->inbox->push_event(event)) {
+            SS_LOGW(TAG, "Inbox event ring full; dropping color cleared event");
+        }
+    }
 }
 
 }  // namespace sendspin

--- a/src/color_role_impl.h
+++ b/src/color_role_impl.h
@@ -22,6 +22,7 @@
 #include "sendspin/color_role.h"
 
 #include <memory>
+#include <optional>
 
 namespace sendspin {
 
@@ -62,17 +63,13 @@ struct ColorRole::Impl {
     ServerColorStateObject color{};
     // Delta accumulated from the inbox slot, awaiting its server-clock deadline. Main-thread
     // only: written and read exclusively from drain_events()/cleanup() on the loop thread.
-    ServerColorStateDelta held_delta{};
+    std::optional<ServerColorStateDelta> held_delta;
 
     // Pointer fields
     SendspinClient* client;
     std::unique_ptr<EventState> event_state;
     Inbox* inbox{nullptr};
     ColorRoleListener* listener{nullptr};
-
-    // 8-bit fields
-    // Main-thread only; see held_delta.
-    bool has_held_delta{false};
 };
 
 }  // namespace sendspin

--- a/src/color_role_impl.h
+++ b/src/color_role_impl.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "platform/shadow_slot.h"
+#include "inbox.h"
 #include "protocol_messages.h"
 #include "sendspin/color_role.h"
 
@@ -40,17 +40,18 @@ struct ColorRole::Impl {
     struct EventState {
         // Stores the wire-level delta type so accumulated clears (inner-nullopt) survive
         // cross-thread merging until drain_events applies them to the merged state.
-        ShadowSlot<ServerColorStateDelta> shadow;
-        bool pending_clear{false};
+        InboxSlot<ServerColorStateDelta> slot;
     };
 
     // ========================================
     // Internal integration methods (called by SendspinClient)
     // ========================================
 
+    void attach_inbox(Inbox& inbox);
     void build_hello_fields(ClientHelloMessage& msg);
     void handle_server_state(ServerColorStateDelta delta) const;
     void drain_events();
+    void handle_cleared_event();
     void cleanup();
 
     // ========================================
@@ -59,11 +60,19 @@ struct ColorRole::Impl {
 
     // Struct fields
     ServerColorStateObject color{};
+    // Delta accumulated from the inbox slot, awaiting its server-clock deadline. Main-thread
+    // only: written and read exclusively from drain_events()/cleanup() on the loop thread.
+    ServerColorStateDelta held_delta{};
 
     // Pointer fields
     SendspinClient* client;
     std::unique_ptr<EventState> event_state;
+    Inbox* inbox{nullptr};
     ColorRoleListener* listener{nullptr};
+
+    // 8-bit fields
+    // Main-thread only; see held_delta.
+    bool has_held_delta{false};
 };
 
 }  // namespace sendspin

--- a/src/color_role_impl.h
+++ b/src/color_role_impl.h
@@ -52,7 +52,7 @@ struct ColorRole::Impl {
     void build_hello_fields(ClientHelloMessage& msg);
     void handle_server_state(ServerColorStateDelta delta) const;
     void drain_events();
-    void handle_cleared_event();
+    void handle_cleared_event() const;
     void cleanup();
 
     // ========================================

--- a/src/controller_role.cpp
+++ b/src/controller_role.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "controller_role_impl.h"
-#include "platform/logging.h"
 #include "protocol_messages.h"
 #include "sendspin/client.h"
 

--- a/src/controller_role.cpp
+++ b/src/controller_role.cpp
@@ -13,8 +13,11 @@
 // limitations under the License.
 
 #include "controller_role_impl.h"
+#include "platform/logging.h"
 #include "protocol_messages.h"
 #include "sendspin/client.h"
+
+static const char* const TAG = "sendspin.controller";
 
 namespace sendspin {
 
@@ -50,6 +53,11 @@ void ControllerRole::send_command(SendspinControllerCommand cmd, std::optional<u
 // Impl method implementations
 // ============================================================================
 
+void ControllerRole::Impl::attach_inbox(Inbox& inbox) {
+    this->inbox = &inbox;
+    this->event_state->slot.bind(inbox, INBOX_TOPIC_CONTROLLER);
+}
+
 void ControllerRole::Impl::send_command(SendspinControllerCommand cmd,
                                         std::optional<uint8_t> volume,
                                         std::optional<bool> mute) const {
@@ -62,21 +70,12 @@ void ControllerRole::Impl::build_hello_fields(ClientHelloMessage& msg) {
 }
 
 void ControllerRole::Impl::handle_server_state(ServerStateControllerObject state) const {
-    this->event_state->shadow.write(std::move(state));
+    this->event_state->slot.write(std::move(state));
 }
 
 void ControllerRole::Impl::drain_events() {
-    // Deferred from cleanup() to avoid invoking the listener while ConnectionManager holds
-    // conn_ptr_mutex_; a listener that calls back into the client would otherwise deadlock.
-    if (this->event_state->pending_clear) {
-        this->event_state->pending_clear = false;
-        if (this->listener) {
-            this->listener->on_controller_state_clear();
-        }
-    }
-
     ServerStateControllerObject state;
-    if (this->event_state->shadow.take(state)) {
+    if (this->event_state->slot.take(state)) {
         this->controller_state = std::move(state);
         if (this->listener) {
             this->listener->on_controller_state(this->controller_state);
@@ -84,10 +83,26 @@ void ControllerRole::Impl::drain_events() {
     }
 }
 
+void ControllerRole::Impl::handle_cleared_event() {
+    // Deferred from cleanup() to avoid invoking the listener while ConnectionManager holds
+    // conn_ptr_mutex_; a listener that calls back into the client would otherwise deadlock.
+    if (this->listener) {
+        this->listener->on_controller_state_clear();
+    }
+}
+
 void ControllerRole::Impl::cleanup() {
-    this->event_state->shadow.reset();
+    this->event_state->slot.reset();
     this->controller_state = {};
-    this->event_state->pending_clear = true;
+
+    if (this->inbox != nullptr) {
+        InboxEvent event{};
+        event.type = InboxEventType::CONTROLLER_CLEARED;
+        event.code = 0;
+        if (!this->inbox->push_event(event)) {
+            SS_LOGW(TAG, "Inbox event ring full; dropping controller cleared event");
+        }
+    }
 }
 
 }  // namespace sendspin

--- a/src/controller_role.cpp
+++ b/src/controller_role.cpp
@@ -95,14 +95,8 @@ void ControllerRole::Impl::cleanup() {
     this->event_state->slot.reset();
     this->controller_state = {};
 
-    if (this->inbox != nullptr) {
-        InboxEvent event{};
-        event.type = InboxEventType::CONTROLLER_CLEARED;
-        event.code = 0;
-        if (!this->inbox->push_event(event)) {
-            SS_LOGW(TAG, "Inbox event ring full; dropping controller cleared event");
-        }
-    }
+    push_event_or_log(this->inbox, InboxEventType::CONTROLLER_CLEARED, 0, TAG,
+                      "controller cleared event");
 }
 
 }  // namespace sendspin

--- a/src/controller_role.cpp
+++ b/src/controller_role.cpp
@@ -82,7 +82,7 @@ void ControllerRole::Impl::drain_events() {
     }
 }
 
-void ControllerRole::Impl::handle_cleared_event() {
+void ControllerRole::Impl::handle_cleared_event() const {
     // Deferred from cleanup() to avoid invoking the listener while ConnectionManager holds
     // conn_ptr_mutex_; a listener that calls back into the client would otherwise deadlock.
     if (this->listener) {

--- a/src/controller_role_impl.h
+++ b/src/controller_role_impl.h
@@ -48,7 +48,7 @@ struct ControllerRole::Impl {
     void build_hello_fields(ClientHelloMessage& msg);
     void handle_server_state(ServerStateControllerObject state) const;
     void drain_events();
-    void handle_cleared_event();
+    void handle_cleared_event() const;
     void cleanup();
 
     // ========================================

--- a/src/controller_role_impl.h
+++ b/src/controller_role_impl.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "platform/shadow_slot.h"
+#include "inbox.h"
 #include "sendspin/controller_role.h"
 
 #include <memory>
@@ -37,17 +37,18 @@ struct ControllerRole::Impl {
     // ========================================
 
     struct EventState {
-        ShadowSlot<ServerStateControllerObject> shadow;
-        bool pending_clear{false};
+        InboxSlot<ServerStateControllerObject> slot;
     };
 
     // ========================================
     // Internal integration methods (called by SendspinClient)
     // ========================================
 
+    void attach_inbox(Inbox& inbox);
     void build_hello_fields(ClientHelloMessage& msg);
     void handle_server_state(ServerStateControllerObject state) const;
     void drain_events();
+    void handle_cleared_event();
     void cleanup();
 
     // ========================================
@@ -67,6 +68,7 @@ struct ControllerRole::Impl {
     // Pointer fields
     SendspinClient* client;
     std::unique_ptr<EventState> event_state;
+    Inbox* inbox{nullptr};
     ControllerRoleListener* listener{nullptr};
 };
 

--- a/src/metadata_role.cpp
+++ b/src/metadata_role.cpp
@@ -168,32 +168,30 @@ void MetadataRole::Impl::drain_events() {
     // or here, folding a taken slot value into held_delta.
     ServerMetadataStateDelta delta{};
     if (this->event_state->slot.take(delta)) {
-        if (this->has_held_delta) {
-            merge_metadata_state_delta(this->held_delta, std::move(delta));
+        if (this->held_delta.has_value()) {
+            merge_metadata_state_delta(*this->held_delta, std::move(delta));
         } else {
             this->held_delta = std::move(delta);
-            this->has_held_delta = true;
         }
     }
 
-    if (!this->has_held_delta) {
+    if (!this->held_delta.has_value()) {
         return;
     }
 
     // get_client_time returns 0 when there is no current connection. Without a connection we
     // cannot honor the server-clock deadline, so fire immediately rather than starving the
     // listener.
-    int64_t client_ts = this->client->get_client_time(this->held_delta.timestamp);
+    int64_t client_ts = this->client->get_client_time(this->held_delta->timestamp);
     if (client_ts != 0 && client_ts > platform_time_us()) {
         return;
     }
 
-    apply_metadata_state_deltas(&this->metadata, this->held_delta);
+    apply_metadata_state_deltas(&this->metadata, *this->held_delta);
     if (this->listener) {
         this->listener->on_metadata(this->metadata);
     }
-    this->held_delta = {};
-    this->has_held_delta = false;
+    this->held_delta.reset();
 }
 
 void MetadataRole::Impl::handle_cleared_event() {
@@ -207,17 +205,10 @@ void MetadataRole::Impl::handle_cleared_event() {
 void MetadataRole::Impl::cleanup() {
     this->event_state->slot.reset();
     this->metadata = {};
-    this->held_delta = {};
-    this->has_held_delta = false;
+    this->held_delta.reset();
 
-    if (this->inbox != nullptr) {
-        InboxEvent event{};
-        event.type = InboxEventType::METADATA_CLEARED;
-        event.code = 0;
-        if (!this->inbox->push_event(event)) {
-            SS_LOGW(TAG, "Inbox event ring full; dropping metadata cleared event");
-        }
-    }
+    push_event_or_log(this->inbox, InboxEventType::METADATA_CLEARED, 0, TAG,
+                      "metadata cleared event");
 }
 
 }  // namespace sendspin

--- a/src/metadata_role.cpp
+++ b/src/metadata_role.cpp
@@ -14,7 +14,6 @@
 
 #include "audio_stream_info.h"
 #include "metadata_role_impl.h"
-#include "platform/logging.h"
 #include "platform/time.h"
 #include "protocol_messages.h"
 #include "sendspin/client.h"
@@ -179,6 +178,11 @@ void MetadataRole::Impl::drain_events() {
         return;
     }
 
+    // A future-dated delta is held across ticks below without any topic bit set (take() above
+    // cleared it). It is re-evaluated against its deadline only because the client calls this
+    // drain_events() unconditionally every tick -- see the warning at the drain-call site in
+    // SendspinClient::loop().
+    //
     // get_client_time returns 0 when there is no current connection. Without a connection we
     // cannot honor the server-clock deadline, so fire immediately rather than starving the
     // listener.

--- a/src/metadata_role.cpp
+++ b/src/metadata_role.cpp
@@ -198,7 +198,7 @@ void MetadataRole::Impl::drain_events() {
     this->held_delta.reset();
 }
 
-void MetadataRole::Impl::handle_cleared_event() {
+void MetadataRole::Impl::handle_cleared_event() const {
     // Deferred from cleanup() to avoid invoking the listener while ConnectionManager holds
     // conn_ptr_mutex_; a listener that calls back into the client would otherwise deadlock.
     if (this->listener) {

--- a/src/metadata_role.cpp
+++ b/src/metadata_role.cpp
@@ -14,13 +14,58 @@
 
 #include "audio_stream_info.h"
 #include "metadata_role_impl.h"
+#include "platform/logging.h"
 #include "platform/time.h"
 #include "protocol_messages.h"
 #include "sendspin/client.h"
 
 #include <algorithm>
+#include <utility>
+
+static const char* const TAG = "sendspin.metadata";
 
 namespace sendspin {
+
+namespace {
+
+/// @brief Merges an incoming wire delta into an accumulated delta using field-overlay semantics
+///
+/// For each field, an outer-engaged incoming entry overwrites the accumulated entry verbatim;
+/// absent (outer-nullopt) incoming fields leave the accumulated entry untouched, so pending
+/// clears (inner-nullopt) from earlier deltas survive until applied. Shared by both merge sites
+/// so they cannot drift: cross-thread, merging a network-thread delta into the inbox slot
+/// (handle_server_state); and main-thread, folding a freshly taken slot value into the held delta
+/// (MetadataRole::Impl::drain_events).
+void merge_metadata_state_delta(ServerMetadataStateDelta& current,
+                                ServerMetadataStateDelta&& incoming) {
+    current.timestamp = incoming.timestamp;
+    if (incoming.title.has_value()) {
+        current.title = std::move(incoming.title);
+    }
+    if (incoming.artist.has_value()) {
+        current.artist = std::move(incoming.artist);
+    }
+    if (incoming.album_artist.has_value()) {
+        current.album_artist = std::move(incoming.album_artist);
+    }
+    if (incoming.album.has_value()) {
+        current.album = std::move(incoming.album);
+    }
+    if (incoming.artwork_url.has_value()) {
+        current.artwork_url = std::move(incoming.artwork_url);
+    }
+    if (incoming.year.has_value()) {
+        current.year = incoming.year;
+    }
+    if (incoming.track.has_value()) {
+        current.track = incoming.track;
+    }
+    if (incoming.progress.has_value()) {
+        current.progress = incoming.progress;
+    }
+}
+
+}  // namespace
 
 // ============================================================================
 // Impl constructor / destructor
@@ -94,84 +139,85 @@ uint32_t MetadataRole::Impl::get_track_progress_ms() const {
     return static_cast<uint32_t>(calculated);
 }
 
+void MetadataRole::Impl::attach_inbox(Inbox& inbox) {
+    this->inbox = &inbox;
+    this->event_state->slot.bind(inbox, INBOX_TOPIC_METADATA);
+}
+
 void MetadataRole::Impl::build_hello_fields(ClientHelloMessage& msg) {
     msg.supported_roles.push_back(SendspinRole::METADATA);
 }
 
 void MetadataRole::Impl::handle_server_state(ServerMetadataStateDelta delta) const {
-    // Merge incoming wire delta into the accumulated delta in the shadow slot. For each field, an
-    // outer-engaged incoming entry overwrites the accumulated entry verbatim; absent
-    // (outer-nullopt) incoming fields leave the accumulated entry untouched, so pending clears
-    // (inner-nullopt) from earlier deltas survive until drain_events applies them.
-    this->event_state->shadow.merge(
-        [](ServerMetadataStateDelta& current, ServerMetadataStateDelta&& incoming) {
-            current.timestamp = incoming.timestamp;
-            if (incoming.title.has_value()) {
-                current.title = std::move(incoming.title);
-            }
-            if (incoming.artist.has_value()) {
-                current.artist = std::move(incoming.artist);
-            }
-            if (incoming.album_artist.has_value()) {
-                current.album_artist = std::move(incoming.album_artist);
-            }
-            if (incoming.album.has_value()) {
-                current.album = std::move(incoming.album);
-            }
-            if (incoming.artwork_url.has_value()) {
-                current.artwork_url = std::move(incoming.artwork_url);
-            }
-            if (incoming.year.has_value()) {
-                current.year = incoming.year;
-            }
-            if (incoming.track.has_value()) {
-                current.track = incoming.track;
-            }
-            if (incoming.progress.has_value()) {
-                current.progress = incoming.progress;
-            }
-        },
-        std::move(delta));
+    // Merge incoming wire delta into the accumulated delta in the inbox slot; see
+    // merge_metadata_state_delta for the field-overlay semantics.
+    this->event_state->slot.merge(merge_metadata_state_delta, std::move(delta));
 }
 
 void MetadataRole::Impl::drain_events() {
-    // Deferred from cleanup() to avoid invoking the listener while ConnectionManager holds
-    // conn_ptr_mutex_; a listener that calls back into the client would otherwise deadlock.
-    if (this->event_state->pending_clear) {
-        this->event_state->pending_clear = false;
-        if (this->listener) {
-            this->listener->on_metadata_clear();
+    // InboxSlot has no take_if (a deadline predicate must not run under the shared Inbox mutex --
+    // see inbox.h), so the server-clock deadline gate that used to live inside the shadow slot's
+    // take_if predicate is split in two: take() unconditionally moves any pending slot value into
+    // held_delta (folding it in if a delta is already held), then the deadline is evaluated below
+    // with no lock held at all.
+    //
+    // Caveat: merged deltas carry only the newest timestamp, so a past-valid field merged under a
+    // later future-valid update gets held back until the later deadline. Accepted since
+    // overlapping fields are last-writer-wins anyway. This applies identically regardless of
+    // which merge site folded the fields together -- cross-thread in the slot (handle_server_state)
+    // or here, folding a taken slot value into held_delta.
+    ServerMetadataStateDelta delta{};
+    if (this->event_state->slot.take(delta)) {
+        if (this->has_held_delta) {
+            merge_metadata_state_delta(this->held_delta, std::move(delta));
+        } else {
+            this->held_delta = std::move(delta);
+            this->has_held_delta = true;
         }
     }
 
-    ServerMetadataStateDelta delta{};
-    // Caveat: merged deltas carry only the newest timestamp, so a past-valid field merged
-    // under a later future-valid update gets held back until the later deadline. Accepted
-    // since overlapping fields are last-writer-wins anyway.
-    const bool taken =
-        this->event_state->shadow.take_if(delta, [this](const ServerMetadataStateDelta& pending) {
-            // get_client_time returns 0 when there is no current connection. Without a connection
-            // we cannot honor the server-clock deadline, so fire immediately rather than starving
-            // the listener.
-            int64_t client_ts = this->client->get_client_time(pending.timestamp);
-            if (client_ts == 0) {
-                return true;
-            }
-            return client_ts <= platform_time_us();
-        });
-    if (!taken) {
+    if (!this->has_held_delta) {
         return;
     }
-    apply_metadata_state_deltas(&this->metadata, delta);
+
+    // get_client_time returns 0 when there is no current connection. Without a connection we
+    // cannot honor the server-clock deadline, so fire immediately rather than starving the
+    // listener.
+    int64_t client_ts = this->client->get_client_time(this->held_delta.timestamp);
+    if (client_ts != 0 && client_ts > platform_time_us()) {
+        return;
+    }
+
+    apply_metadata_state_deltas(&this->metadata, this->held_delta);
     if (this->listener) {
         this->listener->on_metadata(this->metadata);
+    }
+    this->held_delta = {};
+    this->has_held_delta = false;
+}
+
+void MetadataRole::Impl::handle_cleared_event() {
+    // Deferred from cleanup() to avoid invoking the listener while ConnectionManager holds
+    // conn_ptr_mutex_; a listener that calls back into the client would otherwise deadlock.
+    if (this->listener) {
+        this->listener->on_metadata_clear();
     }
 }
 
 void MetadataRole::Impl::cleanup() {
-    this->event_state->shadow.reset();
+    this->event_state->slot.reset();
     this->metadata = {};
-    this->event_state->pending_clear = true;
+    this->held_delta = {};
+    this->has_held_delta = false;
+
+    if (this->inbox != nullptr) {
+        InboxEvent event{};
+        event.type = InboxEventType::METADATA_CLEARED;
+        event.code = 0;
+        if (!this->inbox->push_event(event)) {
+            SS_LOGW(TAG, "Inbox event ring full; dropping metadata cleared event");
+        }
+    }
 }
 
 }  // namespace sendspin

--- a/src/metadata_role_impl.h
+++ b/src/metadata_role_impl.h
@@ -50,7 +50,7 @@ struct MetadataRole::Impl {
     void build_hello_fields(ClientHelloMessage& msg);
     void handle_server_state(ServerMetadataStateDelta delta) const;
     void drain_events();
-    void handle_cleared_event();
+    void handle_cleared_event() const;
     void cleanup();
 
     // ========================================

--- a/src/metadata_role_impl.h
+++ b/src/metadata_role_impl.h
@@ -22,6 +22,7 @@
 #include "sendspin/metadata_role.h"
 
 #include <memory>
+#include <optional>
 
 namespace sendspin {
 
@@ -67,17 +68,13 @@ struct MetadataRole::Impl {
     ServerMetadataStateObject metadata{};
     // Delta accumulated from the inbox slot, awaiting its server-clock deadline. Main-thread
     // only: written and read exclusively from drain_events()/cleanup() on the loop thread.
-    ServerMetadataStateDelta held_delta{};
+    std::optional<ServerMetadataStateDelta> held_delta;
 
     // Pointer fields
     SendspinClient* client;
     std::unique_ptr<EventState> event_state;
     Inbox* inbox{nullptr};
     MetadataRoleListener* listener{nullptr};
-
-    // 8-bit fields
-    // Main-thread only; see held_delta.
-    bool has_held_delta{false};
 };
 
 }  // namespace sendspin

--- a/src/metadata_role_impl.h
+++ b/src/metadata_role_impl.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "platform/shadow_slot.h"
+#include "inbox.h"
 #include "protocol_messages.h"
 #include "sendspin/metadata_role.h"
 
@@ -38,17 +38,18 @@ struct MetadataRole::Impl {
     // ========================================
 
     struct EventState {
-        ShadowSlot<ServerMetadataStateDelta> shadow;
-        bool pending_clear{false};
+        InboxSlot<ServerMetadataStateDelta> slot;
     };
 
     // ========================================
     // Internal integration methods (called by SendspinClient)
     // ========================================
 
+    void attach_inbox(Inbox& inbox);
     void build_hello_fields(ClientHelloMessage& msg);
     void handle_server_state(ServerMetadataStateDelta delta) const;
     void drain_events();
+    void handle_cleared_event();
     void cleanup();
 
     // ========================================
@@ -64,11 +65,19 @@ struct MetadataRole::Impl {
 
     // Struct fields
     ServerMetadataStateObject metadata{};
+    // Delta accumulated from the inbox slot, awaiting its server-clock deadline. Main-thread
+    // only: written and read exclusively from drain_events()/cleanup() on the loop thread.
+    ServerMetadataStateDelta held_delta{};
 
     // Pointer fields
     SendspinClient* client;
     std::unique_ptr<EventState> event_state;
+    Inbox* inbox{nullptr};
     MetadataRoleListener* listener{nullptr};
+
+    // 8-bit fields
+    // Main-thread only; see held_delta.
+    bool has_held_delta{false};
 };
 
 }  // namespace sendspin


### PR DESCRIPTION
Part 3/6 of the inbox ITC refactor stack (based on #85; merge in order).

Moves the three slot-shaped roles off their per-role `ShadowSlot`s onto shared `InboxSlot`s: controller state replaces, metadata/color deltas merge, and disconnect clears become payload-free ring events so the cleared callback ordering is preserved. The metadata/color server-clock deadline hold moves out of the old `take_if` predicate (which ran under the slot mutex) into a main-thread-only held delta, now a `std::optional` so the value and its presence flag cannot desynchronize.

Also folds in the review fixes for this slice: cleared-event producers go through `push_event_or_log()`, and `~SendspinClient` resets every role explicitly so role slots release their topic-bit claims before the alphabetized member order destroys the Inbox.