### PR TITLE
Migrate the player role onto the Inbox

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -92,8 +92,6 @@ Fixed-depth FIFO queue with timed send/receive. Used to defer events from networ
 
 | Queue | Depth | Data | Producer | Consumer |
 |-------|-------|------|----------|----------|
-| `PlayerRole::Impl::stream_queue` | 8 | `PlayerStreamCallbackType` | Network thread | Main loop (`drain_events`) |
-| `PlayerRole::Impl::state_queue` | 4 | `SendspinClientState` | Sync task thread | Main loop (`drain_events`) |
 | `ArtworkRole::Impl::notify_queue` | 8 | `ArtworkNotification` | Network thread | Artwork decode thread |
 | `ArtworkRole::Impl::queue` | 8 | `ArtworkEventType` | Network thread | Main loop (`drain_events`) |
 | `VisualizerRole::Impl::queue` | 8 | `VisualizerEventType` | Network thread | Main loop (`drain_events`) |
@@ -104,13 +102,11 @@ Single-slot state container with "latest wins" or custom merge semantics. The ne
 
 | Shadow Slot | Data | Merge Strategy |
 |-------------|------|----------------|
-| `PlayerRole::Impl::shadow_stream_params` | `ServerPlayerStreamObject` | Latest wins |
-| `PlayerRole::Impl::shadow_command` | `ServerCommandMessage` | Field-by-field merge (volume, mute, delay independent) |
 | `ArtworkRole::Impl::display_scheduler->pending[slot]` (×4) | `int64_t` (server display timestamp) | Latest wins |
 | `VisualizerRole::Impl::shadow_config` | `ServerVisualizerStreamObject` | Latest wins |
 | `SyncTask::playback_progress_slot_` | `PlaybackProgress` | Sum `frames_played`, keep latest `finish_timestamp` |
 
-The merge strategy for `shadow_command` is important: if a volume change and a mute change arrive between two drain ticks, both are preserved because the merge function only overwrites fields that have values in the delta.
+The field-by-field merge pattern - preserving, say, a volume change and a mute change that arrive between two drain ticks because the merge only overwrites fields present in the delta - now lives on the Inbox merge slots (the player's `command_slot`, and the metadata/color/group delta slots below) rather than on a `ShadowSlot`.
 
 ### Inbox (`src/inbox.h`)
 
@@ -125,13 +121,16 @@ State currently on the Inbox:
 
 | Endpoint | Topic bit | Data | Producer |
 |----------|-----------|------|----------|
-| Event ring | `INBOX_TOPIC_EVENTS` | Lifecycle events (`TimeResponsePayload`, plus `CONTROLLER_CLEARED` / `METADATA_CLEARED` / `COLOR_CLEARED`) via `InboxEvent` | Network thread (`TimeResponsePayload`) / main-loop thread (`*_CLEARED` via role `cleanup()`) |
+| Event ring | `INBOX_TOPIC_EVENTS` | Lifecycle events (`TimeResponsePayload` and `PLAYER_STREAM` STREAM_START/STREAM_END, plus `CONTROLLER_CLEARED` / `METADATA_CLEARED` / `COLOR_CLEARED`) via `InboxEvent` | Network thread (`TimeResponsePayload`, `PLAYER_STREAM`) / main-loop thread (`*_CLEARED` via role `cleanup()`) |
 | `Client::group_slot` | `INBOX_TOPIC_GROUP` | `GroupUpdateObject` (field-by-field delta merge) | Network thread |
 | `ControllerRole::Impl::slot` | `INBOX_TOPIC_CONTROLLER` | `ServerStateControllerObject` (latest wins) | Network thread |
 | `MetadataRole::Impl::slot` | `INBOX_TOPIC_METADATA` | `ServerMetadataStateDelta` (field-by-field delta merge) | Network thread |
 | `ColorRole::Impl::slot` | `INBOX_TOPIC_COLOR` | `ServerColorStateDelta` (field-by-field delta merge) | Network thread |
+| `PlayerRole::Impl::EventState::stream_params_slot` | `INBOX_TOPIC_PLAYER_STREAM_PARAMS` | `ServerPlayerStreamObject` (latest wins) | Network thread |
+| `PlayerRole::Impl::EventState::command_slot` | `INBOX_TOPIC_PLAYER_COMMAND` | `ServerCommandMessage` (field-by-field merge) | Network thread |
+| `PlayerRole::Impl::EventState::state_slot` | `INBOX_TOPIC_PLAYER_STATE` | `SendspinClientState` (latest wins) | Sync task thread |
 
-The controller, metadata, and color roles have been migrated onto the Inbox: each `handle_server_state()` writes or merges into its `InboxSlot`, and the disconnect clear is delivered as a `*_CLEARED` lifecycle event on the shared ring rather than a per-role flag. The remaining role-level state (player, artwork, visualizer) still uses the per-role `ThreadSafeQueue`/`ShadowSlot` endpoints above; migrating those onto the Inbox is a later phase.
+The controller, metadata, color, and player roles have been migrated onto the Inbox. The controller/metadata/color roles write or merge server state into their `InboxSlot` from `handle_server_state()`, and their disconnect clear arrives as a `*_CLEARED` lifecycle event on the shared ring rather than a per-role flag. The player role owns three `InboxSlot`s (stream params, command, and client state, on its `EventState`) plus `PLAYER_STREAM` lifecycle events on the shared ring; its disconnect clear is the synthetic STREAM_END that `cleanup()` pushes onto the ring. The remaining role-level state (artwork, visualizer) still uses the per-role `ThreadSafeQueue`/`ShadowSlot` endpoints above; migrating those onto the Inbox is a later phase.
 
 ### SpscRingBuffer (`src/platform/spsc_ring_buffer.h`)
 
@@ -180,10 +179,10 @@ Network thread (IXWebSocket / esp_http_server)
 | `SERVER_HELLO` | Stores server info and connection reason on the connection, then sets `server_hello_received_` (an atomic store that publishes the fields to the main loop; the manager's promotion scan observes `is_handshake_complete()` on its next tick) |
 | `SERVER_TIME` | Pushes a `TIME_RESPONSE` `InboxEvent` onto the shared inbox ring |
 | `SERVER_STATE` | Writes/merges into the controller, metadata, and color `InboxSlot`s via each role's `handle_server_state()` |
-| `SERVER_COMMAND` | Merges into `PlayerRole::Impl::shadow_command` |
+| `SERVER_COMMAND` | Merges into the player's `command_slot` (`InboxSlot<ServerCommandMessage>`) |
 | `GROUP_UPDATE` | Merges into `Client::group_slot` (`InboxSlot<GroupUpdateObject>`) |
-| `STREAM_START` | Writes to `PlayerRole::Impl::shadow_stream_params`, enqueues `STREAM_START` into `stream_queue`. Marks the artwork stream active, flushes the decode thread's notification queue, and resets any pending per-slot display timestamps. Writes to `VisualizerRole::Impl::shadow_config`, enqueues a start event. |
-| `STREAM_END` | Enqueues `STREAM_END` into player/artwork/visualizer queues, signals sync task `COMMAND_STREAM_END` |
+| `STREAM_START` | Writes to the player's `stream_params_slot`, pushes a `PLAYER_STREAM` (STREAM_START) event onto the inbox ring. Marks the artwork stream active, flushes the decode thread's notification queue, and resets any pending per-slot display timestamps. Writes to `VisualizerRole::Impl::shadow_config`, enqueues a start event. |
+| `STREAM_END` | Pushes a `PLAYER_STREAM` (STREAM_END) event onto the inbox ring and signals sync task `COMMAND_STREAM_END`; enqueues `STREAM_END` into the artwork/visualizer queues |
 | `STREAM_CLEAR` | Enqueues `STREAM_CLEAR` into artwork/visualizer queues; for the player, signals sync task `COMMAND_STREAM_CLEAR` and enqueues a `CHUNK_TYPE_STREAM_CLEAR_MARKER` chunk into the encoded ring buffer (no player listener callback — a seek is not a stream lifecycle event) |
 
 #### JSON parse arena (`src/platform/json_arena.h`)
@@ -244,18 +243,18 @@ This ordering matters: connection lifecycle events are processed before role eve
 
 Each role implements `drain_events()` to process its deferred events on the main loop thread. This is the mechanism that converts thread-safe queue/shadow writes into sequential, single-threaded callback delivery.
 
-### PlayerRole::Impl::drain_events() (`src/player_role.cpp:341`)
+### PlayerRole::Impl::drain_events() (`src/player_role.cpp:363`)
 
 Three stages, processed in order:
 
-**1. Client state updates**: Drains `state_queue` (last value wins). Calls `client_->update_state()`.
+**1. Client state updates**: Takes from `state_slot` (latest-wins `InboxSlot`, written by the sync task). Calls `client_->update_state()`.
 
-**2. Server commands**: Takes from `shadow_command`. Checks each field independently (volume, mute, static_delay) and fires the corresponding listener callback.
+**2. Server commands**: Takes from `command_slot`. Checks each field independently (volume, mute, static_delay) and fires the corresponding listener callback.
 
 **3. Stream lifecycle**: The most complex part:
 
 ```api
-stream_queue → awaiting_sync_idle_events_ list
+PLAYER_STREAM ring events → on_stream_ring_event() → awaiting_sync_idle_events list
                        │
                        ▼
          For each event in order:
@@ -264,8 +263,8 @@ stream_queue → awaiting_sync_idle_events_ list
            │    If sync task is idle → fire on_stream_end(), continue
            │
            └─ STREAM_START:
-                Take shadow_stream_params
-                Fire on_stream_start()
+                Take stream_params_slot
+                Mark stream active, fire on_stream_start()
                 Signal sync task COMMAND_START
 ```
 
@@ -326,7 +325,7 @@ The sync task (`SyncTask::thread_entry`, `src/sync_task.cpp`) runs a two-level s
 └──────────────────────────────────────────────────────────┘
 ```
 
-The **WAIT FOR CLIENT ACK** step is critical. Without it, the sync task could race from IDLE back to ACTIVE so fast that the main loop never observes TASK_IDLE, and the `awaiting_sync_idle_events_` mechanism in `PlayerRole::drain_events()` would deadlock waiting for an idle transition that already passed.
+The **WAIT FOR CLIENT ACK** step is critical. Without it, the sync task could race from IDLE back to ACTIVE so fast that the main loop never observes TASK_IDLE, and the `awaiting_sync_idle_events` mechanism in `PlayerRole::drain_events()` would deadlock waiting for an idle transition that already passed.
 
 ### Inner State Machine (active stream)
 
@@ -427,8 +426,8 @@ When a connection is lost (`on_connection_lost`):
 
 ```api
 1. conn->disable_message_dispatch()      ← atomic, immediate on network thread
-2. client_->cleanup_connection_state()  ← stop time sync, drain all role queues/shadows,
-                                           signal stream end
+2. client_->cleanup_connection_state()  ← stop time sync, reset the inbox event ring and every
+                                           role's slots, signal stream end
 3. Queue the connection on deferred_releases_ (released outside the manager lock)
 4. The current slot stays empty; the next promotion scan fills it from the nursery
 ```
@@ -469,11 +468,11 @@ All network thread actions are deferred to the main loop via queues, shadow slot
 
 ### Stream Lifecycle Ordering
 
-The combination of `awaiting_sync_idle_events_` (main loop) and `COMMAND_START` (sync task wait) creates a two-way handshake:
+The combination of `awaiting_sync_idle_events` (main loop) and `COMMAND_START` (sync task wait) creates a two-way handshake:
 
-1. Network thread enqueues STREAM_END → STREAM_START into `stream_queue`.
+1. Network thread pushes STREAM_END → STREAM_START as `PLAYER_STREAM` events onto the inbox event ring.
 2. Sync task receives `COMMAND_STREAM_END`, finishes active stream, enters IDLE, sets `TASK_IDLE`.
-3. Main loop sees STREAM_END in queue, checks `is_running()` → false (idle), fires `on_stream_end()`.
+3. Main loop drains the ring into `awaiting_sync_idle_events`, sees STREAM_END, checks `is_running()` → false (idle), fires `on_stream_end()`.
 4. Main loop sees STREAM_START, fires `on_stream_start()`, signals `COMMAND_START`.
 5. Sync task receives `COMMAND_START`, exits wait, enters ACTIVE.
 
@@ -491,3 +490,12 @@ Audio output callbacks run on a platform audio thread. They report consumed fram
 - All pending events are discarded.
 - The sync task is signaled to end its current stream.
 - The main loop will process the synthetic STREAM_END on its next tick.
+
+### Re-entrant Teardown During Callback Dispatch
+
+A listener callback fired from the main loop can synchronously re-enter connection teardown - for example an `on_stream_start()` or `on_*_clear()` handler that calls `connect_to()`, whose `drop_connection()` runs `cleanup_connection_state()` on the same stack. That cleanup wipes the inbox event ring (`reset_events()`) and each role re-pushes its synthetic clear/STREAM_END, so a drain already in progress must not act on the stale events it copied out before the wipe. Two plain `uint32_t` generation counters, both touched only on the main loop, guard this:
+
+- `SendspinClient::event_state_->drain_generation`, bumped by `cleanup_connection_state()`. The event-ring drain in `loop()` snapshots it before the batch and aborts the instant it changes, discarding the events it had already copied out (they were wiped deliberately) and leaving the cleanup's freshly re-pushed events in the live ring for the next tick. The abort is checked both at the top of the inner per-event loop and once more after the loop body, so a teardown that re-enters on the final event of a full batch cannot fall through into a second `take_events()` that would destructively pull, and then drop, those re-pushed events.
+- `PlayerRole::Impl::cleanup_generation`, bumped by the player's `cleanup()`. `drain_events()` snapshots it around each `on_stream_start()` call; if it changes, the stream was torn down from inside the callback, so the player abandons the rest of the batch rather than re-arm the sync task for a dead stream. `stream_active` is set before the callback runs, so the STREAM_END that `cleanup()` enqueued still passes its gate and delivers a paired `on_stream_end()`.
+
+Neither counter needs atomics: they only let an in-flight drain notice that teardown ran underneath it and stop touching state that cleanup already reset.

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -56,6 +56,13 @@ namespace sendspin {
 struct SendspinClient::EventState {
     Inbox inbox;
     InboxSlot<GroupUpdateObject> group_slot{inbox, INBOX_TOPIC_GROUP};
+    /// Bumped by cleanup_connection_state() so an in-progress ring drain abandons the rest of
+    /// its already-copied batch. Main-thread only: the ring drain copies events out before
+    /// dispatching, so a listener callback that re-enters connection teardown (e.g. connect_to()
+    /// replacing a present-but-disconnected connection from inside a clear callback) wipes the
+    /// live ring but cannot un-copy the local batch; without this counter the drain would keep
+    /// dispatching those stale events (worst case a PLAYER_STREAM start for the dead stream).
+    uint32_t drain_generation{0};
 };
 
 // ============================================================================
@@ -195,9 +202,21 @@ void SendspinClient::loop() {
         constexpr size_t EVENT_DRAIN_BATCH_SIZE = Inbox::EVENT_CAPACITY / 4;
         InboxEvent events[EVENT_DRAIN_BATCH_SIZE];
         size_t event_count = 0;
+        // Snapshot the drain generation: a dispatched event below can run a listener callback
+        // that re-enters connection teardown (cleanup_connection_state() bumps the counter and
+        // wipes the ring). Events already copied into the local batch are stale at that point
+        // and must be dropped, exactly as the ring reset intended; events pushed after the
+        // reset (e.g. the role cleanups' own STREAM_END) sit in the live ring and are picked up
+        // next tick.
+        const uint32_t drain_generation = this->event_state_->drain_generation;
+        bool drain_aborted = false;
         do {
             event_count = this->event_state_->inbox.take_events(events, EVENT_DRAIN_BATCH_SIZE);
             for (size_t i = 0; i < event_count; ++i) {
+                if (this->event_state_->drain_generation != drain_generation) {
+                    drain_aborted = true;
+                    break;
+                }
                 const InboxEvent& event = events[i];
                 switch (event.type) {
                     case InboxEventType::TIME_RESPONSE: {
@@ -211,6 +230,30 @@ void SendspinClient::loop() {
                                                                 event.time.max_error,
                                                                 event.time.timestamp);
                         }
+                        break;
+                    }
+                    // Stream lifecycle / client state events from the player role. Dispatched to
+                    // main-thread-only Impl methods that mirror the arrival exactly as the old
+                    // per-role queues delivered it: PLAYER_STREAM appends to
+                    // awaiting_sync_idle_events (the sync-idle gate itself is untouched);
+                    // PLAYER_STATE overwrites a latest-wins pending slot consumed once by
+                    // drain_events() below.
+                    case InboxEventType::PLAYER_STREAM: {
+#ifdef SENDSPIN_ENABLE_PLAYER
+                        if (this->player_) {
+                            this->player_->impl_->on_stream_ring_event(
+                                static_cast<PlayerStreamCallbackType>(event.code));
+                        }
+#endif
+                        break;
+                    }
+                    case InboxEventType::PLAYER_STATE: {
+#ifdef SENDSPIN_ENABLE_PLAYER
+                        if (this->player_) {
+                            this->player_->impl_->on_state_ring_event(
+                                static_cast<SendspinClientState>(event.code));
+                        }
+#endif
                         break;
                     }
                     // CONTROLLER_CLEARED / METADATA_CLEARED / COLOR_CLEARED: pushed by each
@@ -257,7 +300,7 @@ void SendspinClient::loop() {
                     }
                 }
             }
-        } while (event_count == EVENT_DRAIN_BATCH_SIZE);
+        } while (!drain_aborted && event_count == EVENT_DRAIN_BATCH_SIZE);
     }
 
     // --- Role events (each role handles its own synchronization) ---
@@ -341,6 +384,7 @@ PlayerRole& SendspinClient::add_player(PlayerRoleConfig config) {
     }
     this->player_ =
         std::make_unique<PlayerRole>(std::move(config), this, this->persistence_provider_);
+    this->player_->impl_->attach_inbox(this->event_state_->inbox);
     return *this->player_;
 }
 #endif
@@ -483,7 +527,9 @@ void SendspinClient::cleanup_connection_state() {
     // down a connection without also stopping its burst.
     this->time_burst_->reset();
 
-    // Reset client event state
+    // Reset client event state. The generation bump makes an in-progress ring drain abandon any
+    // events it already copied out of the ring before this reset (see the drain in loop()).
+    this->event_state_->drain_generation++;
     this->event_state_->inbox.reset_events();
     this->event_state_->group_slot.reset();
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -232,26 +232,17 @@ void SendspinClient::loop() {
                         }
                         break;
                     }
-                    // Stream lifecycle / client state events from the player role. Dispatched to
-                    // main-thread-only Impl methods that mirror the arrival exactly as the old
-                    // per-role queues delivered it: PLAYER_STREAM appends to
-                    // awaiting_sync_idle_events (the sync-idle gate itself is untouched);
-                    // PLAYER_STATE overwrites a latest-wins pending slot consumed once by
-                    // drain_events() below.
+                    // Stream lifecycle events from the player role. Dispatched to a
+                    // main-thread-only Impl method that mirrors the arrival exactly as the old
+                    // per-role queue delivered it: PLAYER_STREAM appends to
+                    // awaiting_sync_idle_events (the sync-idle gate itself is untouched).
+                    // Client-state updates from the sync task travel via the player's
+                    // latest-wins state slot, not this ring; see PlayerRole::Impl::EventState.
                     case InboxEventType::PLAYER_STREAM: {
 #ifdef SENDSPIN_ENABLE_PLAYER
                         if (this->player_) {
                             this->player_->impl_->on_stream_ring_event(
                                 static_cast<PlayerStreamCallbackType>(event.code));
-                        }
-#endif
-                        break;
-                    }
-                    case InboxEventType::PLAYER_STATE: {
-#ifdef SENDSPIN_ENABLE_PLAYER
-                        if (this->player_) {
-                            this->player_->impl_->on_state_ring_event(
-                                static_cast<SendspinClientState>(event.code));
                         }
 #endif
                         break;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -520,6 +520,14 @@ void SendspinClient::cleanup_connection_state() {
 
     // Reset client event state. The generation bump makes an in-progress ring drain abandon any
     // events it already copied out of the ring before this reset (see the drain in loop()).
+    //
+    // A second teardown in the same tick (a handoff chain can displace two current connections
+    // in one manager pass) wipes the first teardown's just-pushed CLEARED/STREAM_END events
+    // here before they are ever drained. That is safe only because every role's cleanup() below
+    // pushes its full event set unconditionally, so this call re-creates exactly what it wiped
+    // and the drain still fires each (payload-free, idempotent) callback once -- the same
+    // coalescing the old per-role pending_clear booleans provided. Keep role cleanups
+    // unconditional or this reset starts losing clear signals.
     this->event_state_->drain_generation++;
     this->event_state_->inbox.reset_events();
     this->event_state_->group_slot.reset();

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -291,6 +291,14 @@ void SendspinClient::loop() {
                     }
                 }
             }
+            // A teardown that re-entered on the final event of a full batch bumps the drain
+            // generation but leaves drain_aborted false: the check at the top of the inner loop
+            // never runs again because there is no next iteration. Re-check here so the loop stops
+            // instead of calling take_events() again and destructively pulling the cleanup's
+            // freshly re-pushed CLEARED/STREAM_END events off the live ring (dropping them).
+            if (this->event_state_->drain_generation != drain_generation) {
+                drain_aborted = true;
+            }
         } while (!drain_aborted && event_count == EVENT_DRAIN_BATCH_SIZE);
     }
 

--- a/src/inbox.h
+++ b/src/inbox.h
@@ -254,14 +254,20 @@ private:
 ///
 /// Shared by the role stream-event and cleared-event producers so the build/push/log-on-drop
 /// pattern stays uniform across roles. `what` names the dropped event in the log line; `code`
-/// carries the role-local enum value (0 when unused).
+/// carries the role-local enum value (0 when unused). `error_level` logs the drop at ERROR rather
+/// than WARN: use it for events whose loss wedges the stream (player START/END), not for the
+/// idempotent CLEARED events whose loss leaves merely recoverable stale state.
 inline void push_event_or_log(Inbox* inbox, InboxEventType type, uint8_t code, const char* tag,
-                              const char* what) {
+                              const char* what, bool error_level = false) {
     InboxEvent event{};
     event.type = type;
     event.code = code;
     if (inbox == nullptr || !inbox->push_event(event)) {
-        SS_LOGW(tag, "Inbox event ring full; dropping %s", what);
+        if (error_level) {
+            SS_LOGE(tag, "Inbox event ring full; dropping %s", what);
+        } else {
+            SS_LOGW(tag, "Inbox event ring full; dropping %s", what);
+        }
     }
 }
 

--- a/src/inbox.h
+++ b/src/inbox.h
@@ -47,6 +47,7 @@ static constexpr uint32_t INBOX_TOPIC_PLAYER_COMMAND = 1U << 5;        // Player
 static constexpr uint32_t INBOX_TOPIC_PLAYER_STREAM_PARAMS = 1U << 6;  // Player stream params slot
 static constexpr uint32_t INBOX_TOPIC_VISUALIZER_CONFIG = 1U << 7;     // Visualizer config slot
 static constexpr uint32_t INBOX_TOPIC_ARTWORK_DISPLAY = 1U << 8;       // Artwork display slot
+static constexpr uint32_t INBOX_TOPIC_PLAYER_STATE = 1U << 9;          // Player client-state slot
 
 // ============================================================================
 // Event ring types
@@ -59,7 +60,6 @@ static constexpr uint32_t INBOX_TOPIC_ARTWORK_DISPLAY = 1U << 8;       // Artwor
 enum class InboxEventType : uint8_t {
     TIME_RESPONSE,       // Time-sync measurement; payload in InboxEvent::time
     PLAYER_STREAM,       // Player stream lifecycle; code = PlayerStreamCallbackType
-    PLAYER_STATE,        // Client state from sync task; code = SendspinClientState
     CONTROLLER_CLEARED,  // Controller state cleared on disconnect; no payload
     METADATA_CLEARED,    // Metadata cleared on disconnect; no payload
     COLOR_CLEARED,       // Color state cleared on disconnect; no payload

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -417,6 +417,7 @@ void PlayerRole::Impl::drain_events() {
         // callbacks below may re-enter connection teardown, whose cleanup() clears this vector
         // mid-loop. Cached range-for iterators would dangle; re-checking size() ends the loop
         // and the clamp before the erase below keeps the range valid.
+        // NOLINTNEXTLINE(modernize-loop-convert): body mutates the vector, see above
         for (size_t idx = 0; idx < this->awaiting_sync_idle_events.size(); ++idx) {
             const PlayerStreamCallbackType event = this->awaiting_sync_idle_events[idx];
             if (event == PlayerStreamCallbackType::STREAM_END && !sync_idle) {

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -415,6 +415,7 @@ void PlayerRole::Impl::drain_events() {
     if (!this->awaiting_sync_idle_events.empty()) {
         bool sync_idle = !this->sync_task->is_running();
         size_t processed = 0;
+        bool teardown_reentered = false;
 
         // Indexed with a fresh size() check per iteration (not a range-for): the listener
         // callbacks below may re-enter connection teardown, whose cleanup() clears this vector
@@ -455,7 +456,17 @@ void PlayerRole::Impl::drain_events() {
                         this->current_stream_params = std::move(stream_params);
                     }
                     if (this->listener) {
+                        const uint32_t generation = this->cleanup_generation;
                         this->listener->on_stream_start();
+                        // on_stream_start() may re-enter connection teardown, whose cleanup()
+                        // already ended the stream, cleared this vector, and enqueued a fresh
+                        // STREAM_END. Re-arming the sync task below would resurrect the dead
+                        // stream, so abandon the batch instead (the clamp below then erases
+                        // nothing from the already-cleared vector).
+                        if (this->cleanup_generation != generation) {
+                            teardown_reentered = true;
+                            break;
+                        }
                     }
                     this->stream_active = true;
                     this->sync_task->signal_stream_start();
@@ -465,6 +476,9 @@ void PlayerRole::Impl::drain_events() {
                     sync_idle = false;
                     break;
                 }
+            }
+            if (teardown_reentered) {
+                break;
             }
             ++processed;
         }
@@ -483,6 +497,10 @@ void PlayerRole::Impl::drain_events() {
 }
 
 void PlayerRole::Impl::cleanup() {
+    // Flag the teardown for a drain_events() frame that may be on the call stack right now (a
+    // listener callback re-entering teardown); see the STREAM_START branch there.
+    this->cleanup_generation++;
+
     // End the current stream: the sync task drains and returns to idle. (Not signal_stream_clear():
     // that path is a seek within a live stream and expects a marker to follow.)
     this->sync_task->signal_stream_end();

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -72,10 +72,7 @@ PlayerRole::Impl::Impl(PlayerRoleConfig config, SendspinClient* client,
       client(client),
       event_state(std::make_unique<EventState>()),
       persistence(persistence),
-      sync_task(std::make_unique<SyncTask>()) {
-    this->event_state->stream_queue.create(8);
-    this->event_state->state_queue.create(4);
-}
+      sync_task(std::make_unique<SyncTask>()) {}
 
 PlayerRole::Impl::~Impl() {
     // Stop the sync task thread first, before destroying other members.
@@ -167,6 +164,12 @@ void PlayerRole::Impl::update_static_delay(uint16_t delay_ms) {
 // ============================================================================
 // Impl: Internal integration methods
 // ============================================================================
+
+void PlayerRole::Impl::attach_inbox(Inbox& inbox) {
+    this->inbox = &inbox;
+    this->event_state->stream_params_slot.bind(inbox, INBOX_TOPIC_PLAYER_STREAM_PARAMS);
+    this->event_state->command_slot.bind(inbox, INBOX_TOPIC_PLAYER_COMMAND);
+}
 
 bool PlayerRole::Impl::start() {
     this->load_static_delay();
@@ -290,10 +293,12 @@ void PlayerRole::Impl::handle_stream_start(const ServerPlayerStreamObject& playe
         return;
     }
 
-    // Shadow stream params for main thread, then signal. The high-performance acquire for
-    // playback happens when the main loop drains the STREAM_START event, keeping
-    // high_performance_requested_for_playback main-thread-only.
-    this->event_state->shadow_stream_params.write(player_obj);
+    // Write stream params to the inbox slot for the main thread, then signal. The high-performance
+    // acquire for playback happens when the main loop drains the STREAM_START event, keeping
+    // high_performance_requested_for_playback main-thread-only. Both operations lock the same
+    // shared Inbox mutex, in this order, so a consumer that later takes the START event is
+    // guaranteed to observe these params (see stream_params_slot.take() in drain_events()).
+    this->event_state->stream_params_slot.write(player_obj);
     this->enqueue_stream_event(PlayerStreamCallbackType::STREAM_START);
 }
 
@@ -324,7 +329,7 @@ void PlayerRole::Impl::handle_server_command(const ServerCommandMessage& cmd) co
         SS_LOGV(TAG, "Server command has no player commands");
         return;
     }
-    this->event_state->shadow_command.merge(
+    this->event_state->command_slot.merge(
         [](ServerCommandMessage& current, ServerCommandMessage&& delta) {
             if (!delta.player.has_value()) {
                 return;
@@ -350,24 +355,31 @@ void PlayerRole::Impl::handle_server_command(const ServerCommandMessage& cmd) co
         cmd);
 }
 
+void PlayerRole::Impl::on_stream_ring_event(PlayerStreamCallbackType event) {
+    this->awaiting_sync_idle_events.push_back(event);
+}
+
+void PlayerRole::Impl::on_state_ring_event(SendspinClientState state) {
+    this->pending_state = state;
+    this->has_pending_state = true;
+}
+
 void PlayerRole::Impl::drain_events() {
-    // --- Client state events (from sync task) ---
-    SendspinClientState state{};
-    SendspinClientState last_state{};
-    bool has_state = false;
-    while (this->event_state->state_queue.receive(state, 0)) {
-        last_state = state;
-        has_state = true;
-    }
-    if (has_state) {
-        this->client->update_state(last_state);
+    // --- Client state events (from sync task, delivered via on_state_ring_event) ---
+    // Latest-wins: the ring is fully drained (and on_state_ring_event() called for each
+    // PLAYER_STATE entry) before drain_events() runs each tick, so has_pending_state/pending_state
+    // already hold the last state pushed this tick -- equivalent to the collapse loop this
+    // replaces.
+    if (this->has_pending_state) {
+        this->client->update_state(this->pending_state);
+        this->has_pending_state = false;
     }
 
     // --- Server command events (volume, mute, static delay) ---
     // Check each field independently since multiple command types may have been
-    // merged into one shadow slot between drain ticks.
+    // merged into one inbox slot between drain ticks.
     ServerCommandMessage cmd_msg{};
-    if (this->event_state->shadow_command.take(cmd_msg)) {
+    if (this->event_state->command_slot.take(cmd_msg)) {
         if (cmd_msg.player.has_value()) {
             const ServerPlayerCommandObject& player_cmd = cmd_msg.player.value();
 
@@ -395,18 +407,21 @@ void PlayerRole::Impl::drain_events() {
         }
     }
 
-    // --- Stream lifecycle callback events ---
-    PlayerStreamCallbackType stream_event{};
-    while (this->event_state->stream_queue.receive(stream_event, 0)) {
-        this->awaiting_sync_idle_events.push_back(stream_event);
-    }
-
     // --- Process awaiting sync idle events ---
+    // Stream lifecycle arrivals (STREAM_START/STREAM_END) are appended directly to
+    // awaiting_sync_idle_events by on_stream_ring_event(), called from the ring drain in
+    // SendspinClient::loop() before role drain_events() runs each tick -- so every event pushed
+    // this tick is already in the vector below in FIFO arrival order.
     if (!this->awaiting_sync_idle_events.empty()) {
         bool sync_idle = !this->sync_task->is_running();
         size_t processed = 0;
 
-        for (auto& event : this->awaiting_sync_idle_events) {
+        // Indexed with a fresh size() check per iteration (not a range-for): the listener
+        // callbacks below may re-enter connection teardown, whose cleanup() clears this vector
+        // mid-loop. Cached range-for iterators would dangle; re-checking size() ends the loop
+        // and the clamp before the erase below keeps the range valid.
+        for (size_t idx = 0; idx < this->awaiting_sync_idle_events.size(); ++idx) {
+            const PlayerStreamCallbackType event = this->awaiting_sync_idle_events[idx];
             if (event == PlayerStreamCallbackType::STREAM_END && !sync_idle) {
                 break;  // Wait for sync task to go idle before firing this and anything after it
             }
@@ -436,7 +451,7 @@ void PlayerRole::Impl::drain_events() {
                         this->high_performance_requested_for_playback = true;
                     }
                     ServerPlayerStreamObject stream_params;
-                    if (this->event_state->shadow_stream_params.take(stream_params)) {
+                    if (this->event_state->stream_params_slot.take(stream_params)) {
                         this->current_stream_params = std::move(stream_params);
                     }
                     if (this->listener) {
@@ -454,6 +469,11 @@ void PlayerRole::Impl::drain_events() {
             ++processed;
         }
 
+        // Clamp: a re-entrant cleanup() may have cleared the vector mid-loop, so processed can
+        // exceed the current size.
+        if (processed > this->awaiting_sync_idle_events.size()) {
+            processed = this->awaiting_sync_idle_events.size();
+        }
         if (processed > 0) {
             this->awaiting_sync_idle_events.erase(
                 this->awaiting_sync_idle_events.begin(),
@@ -467,15 +487,16 @@ void PlayerRole::Impl::cleanup() {
     // that path is a seek within a live stream and expects a marker to follow.)
     this->sync_task->signal_stream_end();
 
-    // Discard stale events from the dead connection
-    this->event_state->stream_queue.reset();
-    this->event_state->state_queue.reset();
-    this->event_state->shadow_stream_params.reset();
-    this->event_state->shadow_command.reset();
+    // Discard stale slot content from the dead connection. Stale ring-borne events (an
+    // in-flight STREAM_START/STREAM_END/state update queued before this cleanup) are already
+    // discarded by SendspinClient::cleanup_connection_state()'s inbox.reset_events() call, which
+    // runs before any role's cleanup() -- so there is no per-queue ring reset to do here.
+    this->event_state->stream_params_slot.reset();
+    this->event_state->command_slot.reset();
 
-    // Enqueue a clean STREAM_END - drain_events() will fire the callback (the queue was just
-    // reset, so this send cannot fail)
-    this->event_state->stream_queue.send(PlayerStreamCallbackType::STREAM_END, 0);
+    // Enqueue a clean STREAM_END - drain_events() will fire the callback (the ring was just
+    // reset above us, so this push should not fail; enqueue_stream_event() logs if it somehow does)
+    this->enqueue_stream_event(PlayerStreamCallbackType::STREAM_END);
 
     // Clear awaiting events too (main-thread only, no mutex needed)
     this->awaiting_sync_idle_events.clear();
@@ -502,18 +523,24 @@ bool PlayerRole::Impl::send_audio_chunk(const uint8_t* data, size_t data_size, i
 }
 
 void PlayerRole::Impl::enqueue_state_update(SendspinClientState state) const {
-    if (!this->event_state->state_queue.send(state, 0)) {
+    InboxEvent event{};
+    event.type = InboxEventType::PLAYER_STATE;
+    event.code = static_cast<uint8_t>(state);
+    if (this->inbox == nullptr || !this->inbox->push_event(event)) {
         // The drain takes only the newest state, so a dropped older one is recoverable -- but
-        // a full queue means the main loop has stalled for several ticks
-        SS_LOGW(TAG, "Client state queue full; dropping state update");
+        // a full ring means the main loop has stalled for several ticks
+        SS_LOGW(TAG, "Inbox event ring full; dropping state update");
     }
 }
 
 void PlayerRole::Impl::enqueue_stream_event(PlayerStreamCallbackType event) const {
-    if (!this->event_state->stream_queue.send(event, 0)) {
+    InboxEvent ring_event{};
+    ring_event.type = InboxEventType::PLAYER_STREAM;
+    ring_event.code = static_cast<uint8_t>(event);
+    if (this->inbox == nullptr || !this->inbox->push_event(ring_event)) {
         // A lost STREAM_START would leave the sync task waiting for its start signal forever;
         // a lost STREAM_END would leave the consumer believing the stream is still active
-        SS_LOGE(TAG, "Stream event queue full; dropping %s event",
+        SS_LOGE(TAG, "Inbox event ring full; dropping %s event",
                 event == PlayerStreamCallbackType::STREAM_START ? "STREAM_START" : "STREAM_END");
     }
 }

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -169,6 +169,7 @@ void PlayerRole::Impl::attach_inbox(Inbox& inbox) {
     this->inbox = &inbox;
     this->event_state->stream_params_slot.bind(inbox, INBOX_TOPIC_PLAYER_STREAM_PARAMS);
     this->event_state->command_slot.bind(inbox, INBOX_TOPIC_PLAYER_COMMAND);
+    this->event_state->state_slot.bind(inbox, INBOX_TOPIC_PLAYER_STATE);
 }
 
 bool PlayerRole::Impl::start() {
@@ -359,20 +360,11 @@ void PlayerRole::Impl::on_stream_ring_event(PlayerStreamCallbackType event) {
     this->awaiting_sync_idle_events.push_back(event);
 }
 
-void PlayerRole::Impl::on_state_ring_event(SendspinClientState state) {
-    this->pending_state = state;
-    this->has_pending_state = true;
-}
-
 void PlayerRole::Impl::drain_events() {
-    // --- Client state events (from sync task, delivered via on_state_ring_event) ---
-    // Latest-wins: the ring is fully drained (and on_state_ring_event() called for each
-    // PLAYER_STATE entry) before drain_events() runs each tick, so has_pending_state/pending_state
-    // already hold the last state pushed this tick -- equivalent to the collapse loop this
-    // replaces.
-    if (this->has_pending_state) {
-        this->client->update_state(this->pending_state);
-        this->has_pending_state = false;
+    // --- Client state events (from the sync task, via the latest-wins state slot) ---
+    SendspinClientState state{};
+    if (this->event_state->state_slot.take(state)) {
+        this->client->update_state(state);
     }
 
     // --- Server command events (volume, mute, static delay) ---
@@ -506,11 +498,12 @@ void PlayerRole::Impl::cleanup() {
     this->sync_task->signal_stream_end();
 
     // Discard stale slot content from the dead connection. Stale ring-borne events (an
-    // in-flight STREAM_START/STREAM_END/state update queued before this cleanup) are already
-    // discarded by SendspinClient::cleanup_connection_state()'s inbox.reset_events() call, which
-    // runs before any role's cleanup() -- so there is no per-queue ring reset to do here.
+    // in-flight STREAM_START/STREAM_END queued before this cleanup) are already discarded by
+    // SendspinClient::cleanup_connection_state()'s inbox.reset_events() call, which runs before
+    // any role's cleanup() -- so there is no per-queue ring reset to do here.
     this->event_state->stream_params_slot.reset();
     this->event_state->command_slot.reset();
+    this->event_state->state_slot.reset();
 
     // Enqueue a clean STREAM_END - drain_events() will fire the callback (the ring was just
     // reset above us, so this push should not fail; enqueue_stream_event() logs if it somehow does)
@@ -541,14 +534,11 @@ bool PlayerRole::Impl::send_audio_chunk(const uint8_t* data, size_t data_size, i
 }
 
 void PlayerRole::Impl::enqueue_state_update(SendspinClientState state) const {
-    InboxEvent event{};
-    event.type = InboxEventType::PLAYER_STATE;
-    event.code = static_cast<uint8_t>(state);
-    if (this->inbox == nullptr || !this->inbox->push_event(event)) {
-        // The drain takes only the newest state, so a dropped older one is recoverable -- but
-        // a full ring means the main loop has stalled for several ticks
-        SS_LOGW(TAG, "Inbox event ring full; dropping state update");
-    }
+    // Latest-wins slot, never the shared event ring: consecutive transitions between drains
+    // collapse to the newest (matching the drain's semantics), and a sync task that keeps
+    // transitioning while the main loop stalls cannot fill the ring and starve the
+    // non-idempotent lifecycle events that live there.
+    this->event_state->state_slot.write(state);
 }
 
 void PlayerRole::Impl::enqueue_stream_event(PlayerStreamCallbackType event) const {

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -296,9 +296,13 @@ void PlayerRole::Impl::handle_stream_start(const ServerPlayerStreamObject& playe
 
     // Write stream params to the inbox slot for the main thread, then signal. The high-performance
     // acquire for playback happens when the main loop drains the STREAM_START event, keeping
-    // high_performance_requested_for_playback main-thread-only. Both operations lock the same
-    // shared Inbox mutex, in this order, so a consumer that later takes the START event is
-    // guaranteed to observe these params (see stream_params_slot.take() in drain_events()).
+    // high_performance_requested_for_playback main-thread-only. The params write and the event push
+    // are two separate Inbox lock acquisitions, not one critical section: the mutex orders the
+    // write before the push for visibility, but a concurrent main-thread cleanup() can slip its
+    // stream_params_slot.reset() between them. If that happens the drain takes START and finds the
+    // slot empty, so take() returns false and current_stream_params keeps its prior value (see
+    // stream_params_slot.take() in drain_events()). That window is benign: the same teardown
+    // enqueues a STREAM_END right behind this START.
     this->event_state->stream_params_slot.write(player_obj);
     this->enqueue_stream_event(PlayerStreamCallbackType::STREAM_START);
 }
@@ -447,6 +451,11 @@ void PlayerRole::Impl::drain_events() {
                     if (this->event_state->stream_params_slot.take(stream_params)) {
                         this->current_stream_params = std::move(stream_params);
                     }
+                    // Mark the stream active before invoking the listener. on_stream_start() may
+                    // re-enter teardown, and the STREAM_END that cleanup() enqueues fires
+                    // on_stream_end() only when stream_active is set (see the gate above). Setting
+                    // it first keeps start/end paired even when the batch is abandoned below.
+                    this->stream_active = true;
                     if (this->listener) {
                         const uint32_t generation = this->cleanup_generation;
                         this->listener->on_stream_start();
@@ -454,13 +463,13 @@ void PlayerRole::Impl::drain_events() {
                         // already ended the stream, cleared this vector, and enqueued a fresh
                         // STREAM_END. Re-arming the sync task below would resurrect the dead
                         // stream, so abandon the batch instead (the clamp below then erases
-                        // nothing from the already-cleared vector).
+                        // nothing from the already-cleared vector). stream_active stays true so the
+                        // enqueued STREAM_END still delivers a paired on_stream_end().
                         if (this->cleanup_generation != generation) {
                             teardown_reentered = true;
                             break;
                         }
                     }
-                    this->stream_active = true;
                     this->sync_task->signal_stream_start();
                     // The sync task sets TASK_RUNNING asynchronously after this signal, so the
                     // pre-loop snapshot is stale now: a STREAM_END later in this same batch must
@@ -543,10 +552,13 @@ void PlayerRole::Impl::enqueue_state_update(SendspinClientState state) const {
 
 void PlayerRole::Impl::enqueue_stream_event(PlayerStreamCallbackType event) const {
     // A dropped STREAM_START would leave the sync task waiting for its start signal forever;
-    // a dropped STREAM_END would leave the consumer believing the stream is still active
+    // a dropped STREAM_END would leave the consumer believing the stream is still active. Both
+    // wedge the stream, so log the drop at ERROR (the helper defaults to WARN, which suits the
+    // idempotent CLEARED events but understates a wedged player stream).
     push_event_or_log(
         this->inbox, InboxEventType::PLAYER_STREAM, static_cast<uint8_t>(event), TAG,
-        event == PlayerStreamCallbackType::STREAM_START ? "STREAM_START" : "STREAM_END");
+        event == PlayerStreamCallbackType::STREAM_START ? "STREAM_START" : "STREAM_END",
+        /*error_level=*/true);
 }
 
 void PlayerRole::Impl::load_static_delay() {

--- a/src/player_role.cpp
+++ b/src/player_role.cpp
@@ -542,15 +542,11 @@ void PlayerRole::Impl::enqueue_state_update(SendspinClientState state) const {
 }
 
 void PlayerRole::Impl::enqueue_stream_event(PlayerStreamCallbackType event) const {
-    InboxEvent ring_event{};
-    ring_event.type = InboxEventType::PLAYER_STREAM;
-    ring_event.code = static_cast<uint8_t>(event);
-    if (this->inbox == nullptr || !this->inbox->push_event(ring_event)) {
-        // A lost STREAM_START would leave the sync task waiting for its start signal forever;
-        // a lost STREAM_END would leave the consumer believing the stream is still active
-        SS_LOGE(TAG, "Inbox event ring full; dropping %s event",
-                event == PlayerStreamCallbackType::STREAM_START ? "STREAM_START" : "STREAM_END");
-    }
+    // A dropped STREAM_START would leave the sync task waiting for its start signal forever;
+    // a dropped STREAM_END would leave the consumer believing the stream is still active
+    push_event_or_log(
+        this->inbox, InboxEventType::PLAYER_STREAM, static_cast<uint8_t>(event), TAG,
+        event == PlayerStreamCallbackType::STREAM_START ? "STREAM_START" : "STREAM_END");
 }
 
 void PlayerRole::Impl::load_static_delay() {

--- a/src/player_role_impl.h
+++ b/src/player_role_impl.h
@@ -50,6 +50,12 @@ struct PlayerRole::Impl {
     struct EventState {
         InboxSlot<ServerPlayerStreamObject> stream_params_slot;
         InboxSlot<ServerCommandMessage> command_slot;
+        // Client state from the sync task. Latest-wins by design (the old ring events were
+        // collapsed to the newest at drain time anyway), and deliberately NOT on the event
+        // ring: the sync task is the one producer that can keep emitting while the main loop
+        // stalls, and un-coalesced state transitions must not be able to fill the shared ring
+        // and starve non-idempotent lifecycle events out of it.
+        InboxSlot<SendspinClientState> state_slot;
     };
 
     // ========================================
@@ -66,7 +72,6 @@ struct PlayerRole::Impl {
     void handle_stream_clear() const;
     void handle_server_command(const ServerCommandMessage& cmd) const;
     void on_stream_ring_event(PlayerStreamCallbackType event);
-    void on_state_ring_event(SendspinClientState state);
     void drain_events();
     void cleanup();
 
@@ -124,12 +129,6 @@ struct PlayerRole::Impl {
     bool stream_active{false};
     std::atomic<bool> static_delay_adjustable{false};
     uint8_t volume{0};
-    // Main-thread only: latest state delivered by on_state_ring_event() from the ring drain,
-    // awaiting drain_events()'s single update_state() call; pending_state is valid only when
-    // has_pending_state is true. Reproduces the prior collapse-to-last (latest-wins) semantics
-    // exactly, since the ring is fully drained before drain_events() runs each tick.
-    SendspinClientState pending_state{SendspinClientState::SYNCHRONIZED};
-    bool has_pending_state{false};
 };
 
 }  // namespace sendspin

--- a/src/player_role_impl.h
+++ b/src/player_role_impl.h
@@ -107,6 +107,12 @@ struct PlayerRole::Impl {
     SendspinPersistenceProvider* persistence;
     std::unique_ptr<SyncTask> sync_task;
 
+    // 32-bit fields
+    // Bumped by cleanup() so a drain_events() listener callback that re-enters connection
+    // teardown is detected when control returns: the STREAM_START tail must not re-arm the
+    // sync task for a stream cleanup() just ended. Main-thread only.
+    uint32_t cleanup_generation{0};
+
     // 16-bit fields
     std::atomic<uint16_t> static_delay_ms{0};
 

--- a/src/player_role_impl.h
+++ b/src/player_role_impl.h
@@ -17,8 +17,7 @@
 
 #pragma once
 
-#include "platform/shadow_slot.h"
-#include "platform/thread_safe_queue.h"
+#include "inbox.h"
 #include "sendspin/player_role.h"
 #include "sync_task.h"
 
@@ -49,16 +48,15 @@ struct PlayerRole::Impl {
     // ========================================
 
     struct EventState {
-        ThreadSafeQueue<PlayerStreamCallbackType> stream_queue;
-        ThreadSafeQueue<SendspinClientState> state_queue;
-        ShadowSlot<ServerPlayerStreamObject> shadow_stream_params;
-        ShadowSlot<ServerCommandMessage> shadow_command;
+        InboxSlot<ServerPlayerStreamObject> stream_params_slot;
+        InboxSlot<ServerCommandMessage> command_slot;
     };
 
     // ========================================
     // Internal integration methods (called by SendspinClient)
     // ========================================
 
+    void attach_inbox(Inbox& inbox);
     bool start();
     void build_hello_fields(ClientHelloMessage& msg);
     void build_state_fields(ClientStateMessage& msg) const;
@@ -67,6 +65,8 @@ struct PlayerRole::Impl {
     void handle_stream_end() const;
     void handle_stream_clear() const;
     void handle_server_command(const ServerCommandMessage& cmd) const;
+    void on_stream_ring_event(PlayerStreamCallbackType event);
+    void on_state_ring_event(SendspinClientState state);
     void drain_events();
     void cleanup();
 
@@ -102,6 +102,7 @@ struct PlayerRole::Impl {
     // Pointer fields
     SendspinClient* client;
     std::unique_ptr<EventState> event_state;
+    Inbox* inbox{nullptr};
     PlayerRoleListener* listener{nullptr};
     SendspinPersistenceProvider* persistence;
     std::unique_ptr<SyncTask> sync_task;
@@ -117,6 +118,12 @@ struct PlayerRole::Impl {
     bool stream_active{false};
     std::atomic<bool> static_delay_adjustable{false};
     uint8_t volume{0};
+    // Main-thread only: latest state delivered by on_state_ring_event() from the ring drain,
+    // awaiting drain_events()'s single update_state() call; pending_state is valid only when
+    // has_pending_state is true. Reproduces the prior collapse-to-last (latest-wins) semantics
+    // exactly, since the ring is fully drained before drain_events() runs each tick.
+    SendspinClientState pending_state{SendspinClientState::SYNCHRONIZED};
+    bool has_pending_state{false};
 };
 
 }  // namespace sendspin


### PR DESCRIPTION
Part 4/6 of the inbox ITC refactor stack (based on #86; merge in order).

Moves the player role off its `ThreadSafeQueue`s: server commands and stream params ride `InboxSlot`s, and stream lifecycle events ride the shared event ring (STREAM_END still waits for sync-task idle before its callback fires). Adds the ring-drain `drain_generation` so a listener callback that re-enters connection teardown mid-drain abandons the stale batch.

Includes the two player bug fixes found after the migration landed on the big branch:

- Guard the STREAM_START tail against re-entrant teardown: `on_stream_start()` can re-enter `cleanup()` (e.g. a callback calling `connect_to()`), and the tail then re-armed the sync task for the dead stream. A cleanup generation counter detects the re-entry and abandons the batch.
- Move client-state updates off the event ring onto a latest-wins `InboxSlot`: the sync task is the one producer that can keep emitting while the main loop stalls, so it could fill the 32-entry ring and starve the non-idempotent lifecycle events out of it; the slot also gets reset in `cleanup()` like the player's other slots, so a stale state from a dead connection can no longer leak into the next drain.