### PR TITLE
Migrate visualizer and artwork roles onto the Inbox

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -60,7 +60,7 @@ On host builds, `platform_configure_thread()` is a no-op; threads use OS default
 
 1. `ArtworkRole::Impl::start()` spawns the decode thread.
 2. The thread blocks on notification queue receives with a 100 ms timeout.
-3. On notification: calls `on_image_decode()`, then writes the server display timestamp into a per-slot `ShadowSlot<int64_t>` (`DisplayScheduler::pending[slot]`). The main loop's `ArtworkRole::Impl::drain_events()` fires `on_image_display()` once the timestamp is reached. Latest-wins per slot: if a newer frame's timestamp overwrites the pending one before the main loop takes it, only the newer display fires.
+3. On notification: calls `on_image_decode()`, then merges an `ArtworkDisplayUpdate` (the slot's server display timestamp plus the `stream_epoch` it was decoded under) into the `ArtworkRole::Impl::EventState::display_slot` `InboxSlot` via `merge_artwork_display_update`. The main loop's `ArtworkRole::Impl::drain_events()` folds the taken update into its main-thread-only `held_display_*` state and fires `on_image_display()` once the timestamp is reached. Latest-wins per slot: if a newer frame's timestamp overwrites the pending one before the main loop takes it, only the newer display fires; the per-slot epoch lets the deadline sweep drop a display whose stream was replaced after the hand-off.
 4. `ArtworkRole::Impl` destructor sets `COMMAND_STOP` and joins.
 
 **Destruction order** matters because external audio callbacks may still reference the sync task. `PlayerRole::Impl`'s destructor resets the sync task first (`sync_task_.reset()`) before tearing down anything else, so the thread is fully joined before any shared state is destroyed.
@@ -93,8 +93,6 @@ Fixed-depth FIFO queue with timed send/receive. Used to defer events from networ
 | Queue | Depth | Data | Producer | Consumer |
 |-------|-------|------|----------|----------|
 | `ArtworkRole::Impl::notify_queue` | 8 | `ArtworkNotification` | Network thread | Artwork decode thread |
-| `ArtworkRole::Impl::queue` | 8 | `ArtworkEventType` | Network thread | Main loop (`drain_events`) |
-| `VisualizerRole::Impl::queue` | 8 | `VisualizerEventType` | Network thread | Main loop (`drain_events`) |
 
 ### ShadowSlot (`src/platform/shadow_slot.h`)
 
@@ -102,8 +100,6 @@ Single-slot state container with "latest wins" or custom merge semantics. The ne
 
 | Shadow Slot | Data | Merge Strategy |
 |-------------|------|----------------|
-| `ArtworkRole::Impl::display_scheduler->pending[slot]` (×4) | `int64_t` (server display timestamp) | Latest wins |
-| `VisualizerRole::Impl::shadow_config` | `ServerVisualizerStreamObject` | Latest wins |
 | `SyncTask::playback_progress_slot_` | `PlaybackProgress` | Sum `frames_played`, keep latest `finish_timestamp` |
 
 The field-by-field merge pattern - preserving, say, a volume change and a mute change that arrive between two drain ticks because the merge only overwrites fields present in the delta - now lives on the Inbox merge slots (the player's `command_slot`, and the metadata/color/group delta slots below) rather than on a `ShadowSlot`.
@@ -121,7 +117,7 @@ State currently on the Inbox:
 
 | Endpoint | Topic bit | Data | Producer |
 |----------|-----------|------|----------|
-| Event ring | `INBOX_TOPIC_EVENTS` | Lifecycle events (`TimeResponsePayload` and `PLAYER_STREAM` STREAM_START/STREAM_END, plus `CONTROLLER_CLEARED` / `METADATA_CLEARED` / `COLOR_CLEARED`) via `InboxEvent` | Network thread (`TimeResponsePayload`, `PLAYER_STREAM`) / main-loop thread (`*_CLEARED` via role `cleanup()`) |
+| Event ring | `INBOX_TOPIC_EVENTS` | Lifecycle events (`TimeResponsePayload`, `PLAYER_STREAM` STREAM_START/STREAM_END, `ARTWORK_STREAM` STREAM_END/STREAM_CLEAR, `VISUALIZER_STREAM` STREAM_START/STREAM_END/STREAM_CLEAR, plus `CONTROLLER_CLEARED` / `METADATA_CLEARED` / `COLOR_CLEARED`) via `InboxEvent` | Network thread (`TimeResponsePayload`, `PLAYER_STREAM`, `ARTWORK_STREAM`, `VISUALIZER_STREAM`) / main-loop thread (`*_CLEARED` and the synthetic `cleanup()` stream events) |
 | `Client::group_slot` | `INBOX_TOPIC_GROUP` | `GroupUpdateObject` (field-by-field delta merge) | Network thread |
 | `ControllerRole::Impl::slot` | `INBOX_TOPIC_CONTROLLER` | `ServerStateControllerObject` (latest wins) | Network thread |
 | `MetadataRole::Impl::slot` | `INBOX_TOPIC_METADATA` | `ServerMetadataStateDelta` (field-by-field delta merge) | Network thread |
@@ -129,8 +125,10 @@ State currently on the Inbox:
 | `PlayerRole::Impl::EventState::stream_params_slot` | `INBOX_TOPIC_PLAYER_STREAM_PARAMS` | `ServerPlayerStreamObject` (latest wins) | Network thread |
 | `PlayerRole::Impl::EventState::command_slot` | `INBOX_TOPIC_PLAYER_COMMAND` | `ServerCommandMessage` (field-by-field merge) | Network thread |
 | `PlayerRole::Impl::EventState::state_slot` | `INBOX_TOPIC_PLAYER_STATE` | `SendspinClientState` (latest wins) | Sync task thread |
+| `VisualizerRole::Impl::EventState::config_slot` | `INBOX_TOPIC_VISUALIZER_CONFIG` | `ServerVisualizerStreamObject` (latest wins) | Network thread |
+| `ArtworkRole::Impl::EventState::display_slot` | `INBOX_TOPIC_ARTWORK_DISPLAY` | `ArtworkDisplayUpdate` (per-slot display timestamp + epoch, merged) | Artwork decode thread |
 
-The controller, metadata, color, and player roles have been migrated onto the Inbox. The controller/metadata/color roles write or merge server state into their `InboxSlot` from `handle_server_state()`, and their disconnect clear arrives as a `*_CLEARED` lifecycle event on the shared ring rather than a per-role flag. The player role owns three `InboxSlot`s (stream params, command, and client state, on its `EventState`) plus `PLAYER_STREAM` lifecycle events on the shared ring; its disconnect clear is the synthetic STREAM_END that `cleanup()` pushes onto the ring. The remaining role-level state (artwork, visualizer) still uses the per-role `ThreadSafeQueue`/`ShadowSlot` endpoints above; migrating those onto the Inbox is a later phase.
+All roles have been migrated onto the Inbox. The controller/metadata/color roles write or merge server state into their `InboxSlot` from `handle_server_state()`, and their disconnect clear arrives as a `*_CLEARED` lifecycle event on the shared ring rather than a per-role flag. The player role owns three `InboxSlot`s (stream params, command, and client state, on its `EventState`) plus `PLAYER_STREAM` lifecycle events on the shared ring; its disconnect clear is the synthetic STREAM_END that `cleanup()` pushes onto the ring. The visualizer role writes its stream config to `config_slot` and delivers STREAM_START/END/CLEAR as `VISUALIZER_STREAM` ring events (no per-tick `drain_events()`; the config is taken when the START event is dispatched). The artwork role merges per-slot display timestamps (tagged with the decode `stream_epoch`) into `display_slot`, delivers STREAM_END/CLEAR as `ARTWORK_STREAM` ring events, and keeps a per-tick `drain_events()` for its server-clock display-deadline sweep. Both roles' disconnect clears are synthetic stream events that `cleanup()` pushes onto the ring.
 
 ### SpscRingBuffer (`src/platform/spsc_ring_buffer.h`)
 
@@ -181,9 +179,9 @@ Network thread (IXWebSocket / esp_http_server)
 | `SERVER_STATE` | Writes/merges into the controller, metadata, and color `InboxSlot`s via each role's `handle_server_state()` |
 | `SERVER_COMMAND` | Merges into the player's `command_slot` (`InboxSlot<ServerCommandMessage>`) |
 | `GROUP_UPDATE` | Merges into `Client::group_slot` (`InboxSlot<GroupUpdateObject>`) |
-| `STREAM_START` | Writes to the player's `stream_params_slot`, pushes a `PLAYER_STREAM` (STREAM_START) event onto the inbox ring. Marks the artwork stream active, flushes the decode thread's notification queue, and resets any pending per-slot display timestamps. Writes to `VisualizerRole::Impl::shadow_config`, enqueues a start event. |
-| `STREAM_END` | Pushes a `PLAYER_STREAM` (STREAM_END) event onto the inbox ring and signals sync task `COMMAND_STREAM_END`; enqueues `STREAM_END` into the artwork/visualizer queues |
-| `STREAM_CLEAR` | Enqueues `STREAM_CLEAR` into artwork/visualizer queues; for the player, signals sync task `COMMAND_STREAM_CLEAR` and enqueues a `CHUNK_TYPE_STREAM_CLEAR_MARKER` chunk into the encoded ring buffer (no player listener callback — a seek is not a stream lifecycle event) |
+| `STREAM_START` | Writes to the player's `stream_params_slot`, pushes a `PLAYER_STREAM` (STREAM_START) event onto the inbox ring. Marks the artwork stream active, flushes the decode thread's notification queue, bumps the artwork `stream_epoch`, and resets the artwork `display_slot`. Writes the config to the visualizer's `config_slot` and pushes a `VISUALIZER_STREAM` (STREAM_START) event onto the inbox ring. |
+| `STREAM_END` | Pushes a `PLAYER_STREAM` (STREAM_END) event onto the inbox ring and signals sync task `COMMAND_STREAM_END`; pushes `ARTWORK_STREAM` (STREAM_END) and `VISUALIZER_STREAM` (STREAM_END) events onto the inbox ring |
+| `STREAM_CLEAR` | Pushes `ARTWORK_STREAM` (STREAM_CLEAR) and `VISUALIZER_STREAM` (STREAM_CLEAR) events onto the inbox ring; for the player, signals sync task `COMMAND_STREAM_CLEAR` and enqueues a `CHUNK_TYPE_STREAM_CLEAR_MARKER` chunk into the encoded ring buffer (no player listener callback - a seek is not a stream lifecycle event) |
 
 #### JSON parse arena (`src/platform/json_arena.h`)
 
@@ -223,15 +221,17 @@ The bump arena suits ArduinoJson's allocation pattern: during a parse the varian
 
 3. Drain inbox event ring (when INBOX_TOPIC_EVENTS is set)
    ├─ Feed TIME_RESPONSE events into time_burst_->on_time_response()
-   └─ Fire CONTROLLER/METADATA/COLOR_CLEARED via each role's handle_cleared_event()
+   ├─ Fire CONTROLLER/METADATA/COLOR_CLEARED via each role's handle_cleared_event()
+   ├─ Dispatch PLAYER_STREAM via player_->impl_->on_stream_ring_event()
+   ├─ Dispatch ARTWORK_STREAM via artwork_->impl_->handle_stream_ring_event()
+   └─ Dispatch VISUALIZER_STREAM via visualizer_->impl_->handle_stream_ring_event()
 
 4. Role event draining (each role's impl_->drain_events())
    ├─ player_->impl_->drain_events()
    ├─ controller_->impl_->drain_events()
    ├─ metadata_->impl_->drain_events()
    ├─ color_->impl_->drain_events()
-   ├─ artwork_->impl_->drain_events()
-   └─ visualizer_->impl_->drain_events()
+   └─ artwork_->impl_->drain_events()   (display-deadline sweep; visualizer has no drain_events())
 
 5. Drain group_slot (when INBOX_TOPIC_GROUP is set)
    └─ Apply group deltas, fire on_group_update, persist last played server
@@ -241,7 +241,7 @@ This ordering matters: connection lifecycle events are processed before role eve
 
 ## Role Event Draining
 
-Each role implements `drain_events()` to process its deferred events on the main loop thread. This is the mechanism that converts thread-safe queue/shadow writes into sequential, single-threaded callback delivery.
+Most roles implement `drain_events()` to process their deferred state on the main loop thread; stream lifecycle events instead ride the shared inbox ring and are dispatched from the ring drain (step 3 above) via each role's `handle_stream_ring_event()` / `on_stream_ring_event()` / `handle_cleared_event()`. Together these convert cross-thread inbox writes into sequential, single-threaded callback delivery. (The visualizer role has no `drain_events()` - all its delivery is ring-driven.)
 
 ### PlayerRole::Impl::drain_events() (`src/player_role.cpp:363`)
 
@@ -275,8 +275,8 @@ The `awaiting_sync_idle_events` list (on `PlayerRole::Impl`) is the key ordering
 - **ControllerRole**: Takes the latest `ServerStateControllerObject` from its `InboxSlot`, fires `on_controller_state()`. The disconnect clear is not handled here; it arrives as a `CONTROLLER_CLEARED` event on the shared ring, whose `handle_cleared_event()` fires `on_controller_state_clear()` (deferred from `cleanup()` to avoid invoking the listener while `ConnectionManager` holds `conn_ptr_mutex_`).
 - **MetadataRole**: `InboxSlot` has no `take_if`, so the deadline gate that used to run under the shadow slot's mutex is split in two: `take()` unconditionally moves any pending delta into a main-thread-only `held_delta` (folding it into an already-held delta), then the server-clock deadline is evaluated with no lock held, applying deltas and firing `on_metadata()` once the `timestamp` is reached (or immediately if there is no active connection). A future-dated `held_delta` persists across ticks with no topic bit set, which is why this `drain_events()` must be called unconditionally every tick (see the warning in `SendspinClient::loop()`). The clear arrives separately as a `METADATA_CLEARED` ring event (`handle_cleared_event()` fires `on_metadata_clear()`), deferred from `cleanup()` for the same `conn_ptr_mutex_` reason.
 - **ColorRole**: Same structure as MetadataRole: `take()` into `held_delta`, a lock-free server-clock deadline gate firing `on_color()`, and a `COLOR_CLEARED` ring event driving `on_color_clear()`.
-- **ArtworkRole**: Drains event queue for stream end/clear lifecycle events first (resetting all per-slot pending display timestamps and firing `on_image_clear()` for each configured slot). Then iterates the per-slot `DisplayScheduler::pending` shadow slots and fires `on_image_display(slot)` for any slot whose pending timestamp is due on the synced client clock (or immediately if there is no active connection). `on_image_decode` still happens on the dedicated artwork decode thread.
-- **VisualizerRole**: Drains event queue, processes stream start/end/clear with shadow config.
+- **ArtworkRole**: Stream end/clear lifecycle is handled earlier in the tick by `handle_stream_ring_event()` (dispatched from the ring drain, before this call), which clears `held_display_mask`/`display_slot` and fires `on_image_clear()` for each configured slot - preserving the "lifecycle before display" ordering the old single-function drain guaranteed. `drain_events()` itself folds any taken `display_slot` update into the main-thread-only `held_display_*` state (latest-wins per slot), then sweeps the held slots and fires `on_image_display(slot)` for any whose timestamp is due on the synced client clock (or immediately if there is no active connection). Per-slot epochs drop a held display whose stream was replaced after the decode hand-off. The sweep runs unconditionally every tick (not bit-gated) so held displays are re-evaluated against their deadlines; `on_image_decode` still happens on the dedicated artwork decode thread.
+- **VisualizerRole**: Has no `drain_events()`. STREAM_START/END/CLEAR are dispatched entirely from `handle_stream_ring_event()` (from the ring drain): STREAM_START `take()`s the config from `config_slot` and fires `on_visualizer_stream_start()`; STREAM_END/CLEAR fire `on_visualizer_stream_end()`/`on_visualizer_stream_clear()`.
 
 ## Sync Task State Machine
 
@@ -460,7 +460,7 @@ The host build does not need this scheme: `SendspinWsServer` (host) routes IXWeb
 
 ### Network Thread → Main Loop
 
-All network thread actions are deferred to the main loop via queues, shadow slots, or mutex-protected vectors. The main loop processes them in a fixed order each tick (connections → time → roles → group). This guarantees that:
+All network thread actions are deferred to the main loop, primarily through the shared `Inbox` (its event ring and `InboxSlot`s), with a few remaining per-thread queues, shadow slots, and mutex-protected vectors. The main loop processes them in a fixed order each tick (connections → time → roles → group). This guarantees that:
 
 - Connection state is settled before roles process events.
 - Time sync is updated before audio sync decisions.

--- a/src/artwork_role.cpp
+++ b/src/artwork_role.cpp
@@ -282,13 +282,8 @@ void ArtworkRole::Impl::handle_stream_clear() {
 }
 
 void ArtworkRole::Impl::enqueue_stream_event(ArtworkEventType event) const {
-    InboxEvent ring_event{};
-    ring_event.type = InboxEventType::ARTWORK_STREAM;
-    ring_event.code = static_cast<uint8_t>(event);
-    if (this->inbox == nullptr || !this->inbox->push_event(ring_event)) {
-        SS_LOGW(TAG, "Inbox event ring full; dropping %s",
-                event == ArtworkEventType::STREAM_END ? "STREAM_END" : "STREAM_CLEAR");
-    }
+    push_event_or_log(this->inbox, InboxEventType::ARTWORK_STREAM, static_cast<uint8_t>(event), TAG,
+                      event == ArtworkEventType::STREAM_END ? "STREAM_END" : "STREAM_CLEAR");
 }
 
 // ============================================================================
@@ -334,7 +329,10 @@ void ArtworkRole::Impl::drain_events() {
         }
     }
 
-    if (!this->listener || this->held_display_mask == 0) {
+    // No listener guard here: the epoch/deadline sweep below must still consume held bits so a
+    // listener-less role does not report needs_drain() forever; only the callback itself is
+    // gated on the listener.
+    if (this->held_display_mask == 0) {
         return;
     }
 
@@ -361,7 +359,9 @@ void ArtworkRole::Impl::drain_events() {
             continue;
         }
         this->held_display_mask &= static_cast<uint8_t>(~(1U << slot));
-        this->listener->on_image_display(slot);
+        if (this->listener) {
+            this->listener->on_image_display(slot);
+        }
     }
 }
 

--- a/src/artwork_role.cpp
+++ b/src/artwork_role.cpp
@@ -53,6 +53,27 @@ static int64_t be64_to_host(const uint8_t* bytes) {
 
 namespace sendspin {
 
+namespace {
+
+/// @brief Merges a single-slot display delta into the accumulated cross-thread update
+///
+/// Called under the Inbox mutex via InboxSlot::merge() (see Impl::drain_thread_func), so it must
+/// stay a pure data operation with no callbacks into application code. `delta` carries exactly
+/// one slot's bit (set by the decode thread after a single image finishes decoding); OR-ing
+/// valid_mask and overwriting only the masked timestamps entries preserves latest-wins per slot
+/// while leaving any other slot's already-accumulated (not yet drained) timestamp untouched.
+void merge_artwork_display_update(ArtworkDisplayUpdate& current, ArtworkDisplayUpdate&& delta) {
+    current.valid_mask |= delta.valid_mask;
+    for (uint8_t slot = 0; slot < ARTWORK_MAX_SLOTS; ++slot) {
+        if (delta.valid_mask & (1U << slot)) {
+            current.timestamps[slot] = delta.timestamps[slot];
+            current.epochs[slot] = delta.epochs[slot];
+        }
+    }
+}
+
+}  // namespace
+
 // ============================================================================
 // ArtworkRole::Impl lifecycle
 // ============================================================================
@@ -61,8 +82,7 @@ ArtworkRole::Impl::Impl(ArtworkRoleConfig config, SendspinClient* client)
     : config(std::move(config)),
       client(client),
       drain_task(std::make_unique<DrainTask>()),
-      event_state(std::make_unique<EventState>()),
-      display_scheduler(std::make_unique<DisplayScheduler>()) {
+      event_state(std::make_unique<EventState>()) {
     // The array index is authoritative for channel/slot mapping: the hello advertises channels
     // in this->artwork_channels order, and handle_binary looks up this->config.preferred_formats
     // by index to match.
@@ -74,12 +94,16 @@ ArtworkRole::Impl::Impl(ArtworkRoleConfig config, SendspinClient* client)
     for (const auto& pref : this->config.preferred_formats) {
         this->artwork_channels.push_back({pref.source, pref.format, pref.width, pref.height});
     }
-    this->event_state->queue.create(8);
     this->drain_task->notify_queue.create(8);
 }
 
 ArtworkRole::Impl::~Impl() {
     this->stop();
+}
+
+void ArtworkRole::Impl::attach_inbox(Inbox& inbox) {
+    this->inbox = &inbox;
+    this->event_state->display_slot.bind(inbox, INBOX_TOPIC_ARTWORK_DISPLAY);
 }
 
 bool ArtworkRole::Impl::start() {
@@ -236,80 +260,108 @@ void ArtworkRole::Impl::handle_stream_start(const ServerArtworkStreamObject& str
     // already queued before this handler ran).
     this->stream_epoch.fetch_add(1, std::memory_order_relaxed);
 
-    // Discard any pending displays from a prior stream
-    if (this->display_scheduler) {
-        for (auto& slot : this->display_scheduler->pending) {
-            slot.reset();
-        }
-    }
+    // Discard any pending display from a prior stream that has not yet been folded into the
+    // main thread's held_display_mask (see drain_events()). A display already folded into the
+    // holds is not reachable from here, but it carries the epoch it was decoded under
+    // (held_display_epoch), so the epoch bump above makes the main-loop deadline check drop it.
+    this->event_state->display_slot.reset();
 }
 
 void ArtworkRole::Impl::handle_stream_end() {
     this->stream_active = false;
     this->stream_epoch.fetch_add(1, std::memory_order_relaxed);
 
-    if (!this->event_state->queue.send(ArtworkEventType::STREAM_END, 0)) {
-        SS_LOGW(TAG, "Artwork event queue full; dropping STREAM_END");
-    }
+    this->enqueue_stream_event(ArtworkEventType::STREAM_END);
 }
 
 void ArtworkRole::Impl::handle_stream_clear() {
     this->stream_active = false;
     this->stream_epoch.fetch_add(1, std::memory_order_relaxed);
 
-    if (!this->event_state->queue.send(ArtworkEventType::STREAM_CLEAR, 0)) {
-        SS_LOGW(TAG, "Artwork event queue full; dropping STREAM_CLEAR");
+    this->enqueue_stream_event(ArtworkEventType::STREAM_CLEAR);
+}
+
+void ArtworkRole::Impl::enqueue_stream_event(ArtworkEventType event) const {
+    InboxEvent ring_event{};
+    ring_event.type = InboxEventType::ARTWORK_STREAM;
+    ring_event.code = static_cast<uint8_t>(event);
+    if (this->inbox == nullptr || !this->inbox->push_event(ring_event)) {
+        SS_LOGW(TAG, "Inbox event ring full; dropping %s",
+                event == ArtworkEventType::STREAM_END ? "STREAM_END" : "STREAM_CLEAR");
     }
 }
 
 // ============================================================================
-// Event draining (main thread) - lifecycle events and scheduled displays
+// Event dispatch (main thread) - lifecycle via the ring, scheduled displays via polling
 // ============================================================================
 
+void ArtworkRole::Impl::handle_stream_ring_event(ArtworkEventType event) {
+    // Called from the ring drain in SendspinClient::loop() before this role's drain_events()
+    // runs each tick (see drain_events()), so clearing the holds and display_slot here cancels
+    // any display that would otherwise fire later this same tick -- the same "lifecycle first"
+    // ordering the old queue-drain loop at the top of drain_events() used to guarantee by running
+    // before the display-deadline loop below it.
+    switch (event) {
+        case ArtworkEventType::STREAM_END:
+        case ArtworkEventType::STREAM_CLEAR:
+            this->held_display_mask = 0;
+            this->event_state->display_slot.reset();
+            if (this->listener) {
+                // Array index is the authoritative slot number; see the Impl constructor.
+                for (size_t i = 0; i < this->config.preferred_formats.size(); ++i) {
+                    this->listener->on_image_clear(static_cast<uint8_t>(i));
+                }
+            }
+            break;
+    }
+}
+
 void ArtworkRole::Impl::drain_events() {
-    // Process stream lifecycle events first so we don't fire a display that was
-    // cancelled by an end/clear in the same tick.
-    ArtworkEventType event_type{};
-    while (this->event_state->queue.receive(event_type, 0)) {
-        switch (event_type) {
-            case ArtworkEventType::STREAM_END:
-            case ArtworkEventType::STREAM_CLEAR:
-                if (this->display_scheduler) {
-                    for (auto& pending : this->display_scheduler->pending) {
-                        pending.reset();
-                    }
-                }
-                if (this->listener) {
-                    // Array index is the authoritative slot number; see the Impl constructor.
-                    for (size_t i = 0; i < this->config.preferred_formats.size(); ++i) {
-                        this->listener->on_image_clear(static_cast<uint8_t>(i));
-                    }
-                }
-                break;
+    // Fold any newly published display update into the main-thread holds. Latest-wins per
+    // artwork slot, same as the old per-slot ShadowSlot overwrite: a bit set in valid_mask means
+    // timestamps[i] is a fresher pending display than whatever (if anything) slot i already
+    // held. Any STREAM_END/STREAM_CLEAR for this tick has already run via
+    // handle_stream_ring_event() before this call (see the comment there), so a lifecycle event
+    // arriving this tick has already cleared held_display_mask before we get here.
+    ArtworkDisplayUpdate update{};
+    if (this->event_state->display_slot.take(update)) {
+        for (uint8_t slot = 0; slot < ARTWORK_MAX_SLOTS; ++slot) {
+            if (update.valid_mask & (1U << slot)) {
+                this->held_display_ts[slot] = update.timestamps[slot];
+                this->held_display_epoch[slot] = update.epochs[slot];
+                this->held_display_mask |= static_cast<uint8_t>(1U << slot);
+            }
         }
     }
 
-    if (!this->display_scheduler || !this->listener) {
+    if (!this->listener || this->held_display_mask == 0) {
         return;
     }
 
+    // Single now snapshot per tick, like today. No lock is held here (the slot value was
+    // already taken above), unlike the old take_if predicate which ran under the shadow slot's
+    // mutex.
     const int64_t now = platform_time_us();
+    const uint32_t current_epoch = this->stream_epoch.load(std::memory_order_relaxed);
     for (uint8_t slot = 0; slot < ARTWORK_MAX_SLOTS; ++slot) {
-        int64_t server_ts = 0;
-        const bool taken = this->display_scheduler->pending[slot].take_if(
-            server_ts, [this, now](const int64_t& pending_ts) {
-                // get_client_time returns 0 when there is no current connection. Without a
-                // connection we cannot honor the server-clock deadline, so fire immediately rather
-                // than starving the listener.
-                int64_t client_ts = this->client->get_client_time(pending_ts);
-                if (client_ts == 0) {
-                    return true;
-                }
-                return client_ts <= now;
-            });
-        if (taken) {
-            this->listener->on_image_display(slot);
+        if (!(this->held_display_mask & (1U << slot))) {
+            continue;
         }
+        // Drop a display decoded under a since-replaced stream (restart with no intervening
+        // end/clear bumps the epoch but cannot reach these main-thread holds to cancel it).
+        if (this->held_display_epoch[slot] != current_epoch) {
+            this->held_display_mask &= static_cast<uint8_t>(~(1U << slot));
+            continue;
+        }
+        // get_client_time returns 0 when there is no current connection. Without a connection we
+        // cannot honor the server-clock deadline, so fire immediately rather than starving the
+        // listener.
+        int64_t client_ts = this->client->get_client_time(this->held_display_ts[slot]);
+        if (client_ts != 0 && client_ts > now) {
+            continue;
+        }
+        this->held_display_mask &= static_cast<uint8_t>(~(1U << slot));
+        this->listener->on_image_display(slot);
     }
 }
 
@@ -321,14 +373,17 @@ void ArtworkRole::Impl::cleanup() {
     this->stream_active = false;
     this->stream_epoch.fetch_add(1, std::memory_order_relaxed);
 
-    if (this->display_scheduler) {
-        for (auto& pending : this->display_scheduler->pending) {
-            pending.reset();
-        }
-    }
+    // Stale ring-borne events (an in-flight STREAM_END/STREAM_CLEAR queued before this cleanup)
+    // are already discarded by SendspinClient::cleanup_connection_state()'s inbox.reset_events()
+    // call, which runs before any role's cleanup() -- so there is no per-event ring reset to do
+    // here.
+    this->held_display_mask = 0;
+    this->event_state->display_slot.reset();
 
-    this->event_state->queue.reset();
-    this->event_state->queue.send(ArtworkEventType::STREAM_END, 0);
+    // Enqueue a clean STREAM_END - handle_stream_ring_event() will fire the on_image_clear()
+    // callbacks (the ring was just reset above us, so this push should not fail;
+    // enqueue_stream_event() logs if it somehow does).
+    this->enqueue_stream_event(ArtworkEventType::STREAM_END);
 }
 
 // ============================================================================
@@ -401,9 +456,17 @@ void ArtworkRole::Impl::drain_thread_func(ArtworkRole::Impl* self) {
         }
 
         // Hand off the timestamp to the main loop. Skip if the stream ended while we were
-        // decoding so the main loop doesn't fire a display after on_image_clear.
-        if (self->stream_active.load(std::memory_order_acquire) && self->display_scheduler) {
-            self->display_scheduler->pending[slot].write(notif.timestamp);
+        // decoding so the main loop doesn't fire a display after on_image_clear. The delta
+        // carries just this slot's bit; merge_artwork_display_update ORs it into whatever the
+        // main loop hasn't drained out of display_slot yet.
+        if (self->stream_active.load(std::memory_order_acquire)) {
+            ArtworkDisplayUpdate delta{};
+            delta.timestamps[slot] = notif.timestamp;
+            // The epoch this decode was validated under: lets the main-loop deadline check drop
+            // the display if the stream is replaced after this hand-off (see held_display_epoch).
+            delta.epochs[slot] = notif.stream_epoch;
+            delta.valid_mask = static_cast<uint8_t>(1U << slot);
+            self->event_state->display_slot.merge(merge_artwork_display_update, delta);
         }
     }
 

--- a/src/artwork_role_impl.h
+++ b/src/artwork_role_impl.h
@@ -17,9 +17,9 @@
 
 #pragma once
 
+#include "inbox.h"
 #include "platform/event_flags.h"
 #include "platform/memory.h"
-#include "platform/shadow_slot.h"
 #include "platform/thread_safe_queue.h"
 #include "protocol_messages.h"
 #include "sendspin/artwork_role.h"
@@ -85,6 +85,19 @@ struct ArtworkNotification {
     uint32_t stream_epoch;
 };
 
+/// @brief Latest-wins display timestamps accumulated across artwork slots
+///
+/// Merged cross-thread by the decode thread (one slot per merge) and taken whole by the
+/// main-loop drain; a bit set in valid_mask means timestamps[i] holds a pending display.
+/// epochs[i] carries the stream_epoch the decode ran under, so the main-loop deadline check can
+/// drop a display whose stream has since been replaced (a stream restart bumps the epoch but
+/// cannot reach a display already folded into the main-thread holds).
+struct ArtworkDisplayUpdate {
+    int64_t timestamps[ARTWORK_MAX_SLOTS]{};
+    uint32_t epochs[ARTWORK_MAX_SLOTS]{};
+    uint8_t valid_mask{0};
+};
+
 /// @brief Private implementation of the artwork role
 struct ArtworkRole::Impl {
     Impl(ArtworkRoleConfig config, SendspinClient* client);
@@ -105,31 +118,24 @@ struct ArtworkRole::Impl {
         std::mutex slot_mutex;
     };
 
-    /// @brief Deferred event state for thread-safe artwork stream lifecycle delivery
+    /// @brief Deferred event state for artwork display timestamps, delivered to the main thread
+    /// via the shared Inbox
     struct EventState {
-        ThreadSafeQueue<ArtworkEventType> queue;
-    };
-
-    /// @brief Pending display timestamps, one slot per artwork slot
-    ///
-    /// The decode thread writes the server timestamp after on_image_decode() completes; the
-    /// main loop reads the timestamp and fires on_image_display() once it is reached. Latest-
-    /// wins per slot: if a newer frame finishes decoding before the pending display fires,
-    /// the older timestamp is overwritten and only the newer display is delivered.
-    struct DisplayScheduler {
-        ShadowSlot<int64_t> pending[ARTWORK_MAX_SLOTS];
+        InboxSlot<ArtworkDisplayUpdate> display_slot;
     };
 
     // ========================================
     // Internal integration methods (called by SendspinClient)
     // ========================================
 
+    void attach_inbox(Inbox& inbox);
     bool start();
     void build_hello_fields(ClientHelloMessage& msg) const;
     void handle_binary(uint8_t slot, const uint8_t* data, size_t len);
     void handle_stream_start(const ServerArtworkStreamObject& stream);
     void handle_stream_end();
     void handle_stream_clear();
+    void handle_stream_ring_event(ArtworkEventType event);
     void drain_events();
     void cleanup();
 
@@ -138,6 +144,7 @@ struct ArtworkRole::Impl {
     // ========================================
 
     void stop() const;
+    void enqueue_stream_event(ArtworkEventType event) const;
     static void drain_thread_func(ArtworkRole::Impl* self);
 
     // ========================================
@@ -152,11 +159,27 @@ struct ArtworkRole::Impl {
     SendspinClient* client;
     std::unique_ptr<DrainTask> drain_task;
     std::unique_ptr<EventState> event_state;
-    std::unique_ptr<DisplayScheduler> display_scheduler;
+    Inbox* inbox{nullptr};
     ArtworkRoleListener* listener{nullptr};
+
+    // 64-bit fields
+    // Latest-wins display timestamps folded in from display_slot, awaiting their server-clock
+    // deadlines. Main-thread only: written and read exclusively from drain_events()/
+    // handle_stream_ring_event()/cleanup() on the loop thread. held_display_ts[i] is valid only
+    // when bit i of held_display_mask is set.
+    int64_t held_display_ts[ARTWORK_MAX_SLOTS]{};
+
+    // 32-bit fields
+    // Stream epoch each held display was decoded under; a mismatch against stream_epoch at
+    // deadline-check time means the stream was since replaced (e.g. a restart with no
+    // intervening end/clear) and the display must be dropped, since the network thread cannot
+    // reach the main-thread holds to cancel it. Main-thread only; see held_display_ts.
+    uint32_t held_display_epoch[ARTWORK_MAX_SLOTS]{};
 
     // 8-bit fields
     std::atomic<bool> stream_active{false};
+    // Main-thread only; see held_display_ts.
+    uint8_t held_display_mask{0};
 
     /// @brief Bumped on stream start/end/clear/cleanup so in-flight notifications from a
     /// previous stream are recognized as stale and skipped by the decode thread, instead of

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -282,9 +282,31 @@ void SendspinClient::loop() {
 #endif
                         break;
                     }
+                    // ARTWORK_STREAM / VISUALIZER_STREAM: stream lifecycle sub-events (code =
+                    // the role-local ArtworkEventType/VisualizerEventType) from the artwork and
+                    // visualizer roles, dispatched the same way as PLAYER_STREAM above -- straight
+                    // to a main-thread-only Impl method keyed on the role-local enum.
+                    case InboxEventType::ARTWORK_STREAM: {
+#ifdef SENDSPIN_ENABLE_ARTWORK
+                        if (this->artwork_) {
+                            this->artwork_->impl_->handle_stream_ring_event(
+                                static_cast<ArtworkEventType>(event.code));
+                        }
+#endif
+                        break;
+                    }
+                    case InboxEventType::VISUALIZER_STREAM: {
+#ifdef SENDSPIN_ENABLE_VISUALIZER
+                        if (this->visualizer_) {
+                            this->visualizer_->impl_->handle_stream_ring_event(
+                                static_cast<VisualizerEventType>(event.code));
+                        }
+#endif
+                        break;
+                    }
                     default: {
-                        // No role event types are produced yet; unhandled types are logged and
-                        // dropped.
+                        // Every InboxEventType is dispatched above; this guards only against a
+                        // corrupted enum value.
                         SS_LOGD(TAG, "Unhandled inbox event type: %d",
                                 static_cast<int>(event.type));
                         break;
@@ -332,11 +354,6 @@ void SendspinClient::loop() {
 #ifdef SENDSPIN_ENABLE_ARTWORK
     if (this->artwork_) {
         this->artwork_->impl_->drain_events();
-    }
-#endif
-#ifdef SENDSPIN_ENABLE_VISUALIZER
-    if (this->visualizer_) {
-        this->visualizer_->impl_->drain_events();
     }
 #endif
 
@@ -427,6 +444,7 @@ ArtworkRole& SendspinClient::add_artwork(ArtworkRoleConfig config) {
         SS_LOGW(TAG, "add_artwork() called after start_server()");
     }
     this->artwork_ = std::make_unique<ArtworkRole>(std::move(config), this);
+    this->artwork_->impl_->attach_inbox(this->event_state_->inbox);
     return *this->artwork_;
 }
 #endif
@@ -437,6 +455,7 @@ VisualizerRole& SendspinClient::add_visualizer(VisualizerRoleConfig config) {
         SS_LOGW(TAG, "add_visualizer() called after start_server()");
     }
     this->visualizer_ = std::make_unique<VisualizerRole>(std::move(config), this);
+    this->visualizer_->impl_->attach_inbox(this->event_state_->inbox);
     return *this->visualizer_;
 }
 #endif

--- a/src/visualizer_role.cpp
+++ b/src/visualizer_role.cpp
@@ -130,8 +130,6 @@ VisualizerRole::Impl::Impl(VisualizerRoleConfig config, SendspinClient* client)
       visualizer_support(std::move(this->config.support)),
       client(client),
       event_state(std::make_unique<EventState>()) {
-    this->event_state->queue.create(8);
-
     if (this->visualizer_support.has_value()) {
         // Normalize the advertised type order so the server packs fields in the order the
         // drain thread parser expects. See normalize_type_order() above for the constraint.
@@ -169,6 +167,11 @@ void VisualizerRole::set_listener(VisualizerRoleListener* listener) {
 // ============================================================================
 // Impl method implementations
 // ============================================================================
+
+void VisualizerRole::Impl::attach_inbox(Inbox& inbox) {
+    this->inbox = &inbox;
+    this->event_state->config_slot.bind(inbox, INBOX_TOPIC_VISUALIZER_CONFIG);
+}
 
 bool VisualizerRole::Impl::start() {
     if (!this->drain_task || !this->drain_task->ring_buffer.is_created()) {
@@ -314,11 +317,11 @@ void VisualizerRole::Impl::handle_stream_start(const ServerVisualizerStreamObjec
         this->drain_task->event_flags.set(COMMAND_FLUSH);
     }
 
-    // Shadow the config for main-thread callback, then signal
-    this->event_state->shadow_config.write(stream);
-    if (!this->event_state->queue.send(VisualizerEventType::STREAM_START, 0)) {
-        SS_LOGW(TAG, "Visualizer event queue full; dropping STREAM_START");
-    }
+    // Write the config to the inbox slot for the main thread, then push the event. Both lock the
+    // same shared Inbox mutex, in this order, so a consumer that later takes the START event is
+    // guaranteed to observe this config (see config_slot.take() in handle_stream_ring_event()).
+    this->event_state->config_slot.write(stream);
+    this->enqueue_stream_event(VisualizerEventType::STREAM_START);
 }
 
 void VisualizerRole::Impl::handle_stream_end() {
@@ -328,9 +331,7 @@ void VisualizerRole::Impl::handle_stream_end() {
         this->drain_task->event_flags.set(COMMAND_FLUSH);
     }
 
-    if (!this->event_state->queue.send(VisualizerEventType::STREAM_END, 0)) {
-        SS_LOGW(TAG, "Visualizer event queue full; dropping STREAM_END");
-    }
+    this->enqueue_stream_event(VisualizerEventType::STREAM_END);
 }
 
 void VisualizerRole::Impl::handle_stream_clear() {
@@ -340,37 +341,48 @@ void VisualizerRole::Impl::handle_stream_clear() {
         this->drain_task->event_flags.set(COMMAND_FLUSH);
     }
 
-    if (!this->event_state->queue.send(VisualizerEventType::STREAM_CLEAR, 0)) {
-        SS_LOGW(TAG, "Visualizer event queue full; dropping STREAM_CLEAR");
+    this->enqueue_stream_event(VisualizerEventType::STREAM_CLEAR);
+}
+
+void VisualizerRole::Impl::enqueue_stream_event(VisualizerEventType event) const {
+    InboxEvent ring_event{};
+    ring_event.type = InboxEventType::VISUALIZER_STREAM;
+    ring_event.code = static_cast<uint8_t>(event);
+    if (this->inbox == nullptr || !this->inbox->push_event(ring_event)) {
+        const char* name = "STREAM_CLEAR";
+        if (event == VisualizerEventType::STREAM_START) {
+            name = "STREAM_START";
+        } else if (event == VisualizerEventType::STREAM_END) {
+            name = "STREAM_END";
+        }
+        SS_LOGW(TAG, "Inbox event ring full; dropping %s", name);
     }
 }
 
 // ============================================================================
-// Event draining (main thread) - lifecycle events only
+// Event dispatch (main thread) - lifecycle events only, called from the ring drain in
+// SendspinClient::loop()
 // ============================================================================
 
-void VisualizerRole::Impl::drain_events() const {
-    VisualizerEventType event_type{};
-    while (this->event_state->queue.receive(event_type, 0)) {
-        switch (event_type) {
-            case VisualizerEventType::STREAM_START: {
-                ServerVisualizerStreamObject config{};
-                if (this->event_state->shadow_config.take(config) && this->listener) {
-                    this->listener->on_visualizer_stream_start(config);
-                }
-                break;
+void VisualizerRole::Impl::handle_stream_ring_event(VisualizerEventType event) {
+    switch (event) {
+        case VisualizerEventType::STREAM_START: {
+            ServerVisualizerStreamObject config{};
+            if (this->event_state->config_slot.take(config) && this->listener) {
+                this->listener->on_visualizer_stream_start(config);
             }
-            case VisualizerEventType::STREAM_END:
-                if (this->listener) {
-                    this->listener->on_visualizer_stream_end();
-                }
-                break;
-            case VisualizerEventType::STREAM_CLEAR:
-                if (this->listener) {
-                    this->listener->on_visualizer_stream_clear();
-                }
-                break;
+            break;
         }
+        case VisualizerEventType::STREAM_END:
+            if (this->listener) {
+                this->listener->on_visualizer_stream_end();
+            }
+            break;
+        case VisualizerEventType::STREAM_CLEAR:
+            if (this->listener) {
+                this->listener->on_visualizer_stream_clear();
+            }
+            break;
     }
 }
 
@@ -385,9 +397,16 @@ void VisualizerRole::Impl::cleanup() {
         this->drain_task->event_flags.set(COMMAND_FLUSH);
     }
 
-    this->event_state->queue.reset();
-    this->event_state->shadow_config.reset();
-    this->event_state->queue.send(VisualizerEventType::STREAM_END, 0);
+    // Discard stale slot content from the dead connection. Stale ring-borne events (an in-flight
+    // STREAM_START/STREAM_END/STREAM_CLEAR queued before this cleanup) are already discarded by
+    // SendspinClient::cleanup_connection_state()'s inbox.reset_events() call, which runs before
+    // any role's cleanup() -- so there is no per-event ring reset to do here.
+    this->event_state->config_slot.reset();
+
+    // Enqueue a clean STREAM_END - handle_stream_ring_event() will fire the callback (the ring
+    // was just reset above us, so this push should not fail; enqueue_stream_event() logs if it
+    // somehow does).
+    this->enqueue_stream_event(VisualizerEventType::STREAM_END);
 }
 
 // ============================================================================

--- a/src/visualizer_role.cpp
+++ b/src/visualizer_role.cpp
@@ -360,7 +360,7 @@ void VisualizerRole::Impl::enqueue_stream_event(VisualizerEventType event) const
 // SendspinClient::loop()
 // ============================================================================
 
-void VisualizerRole::Impl::handle_stream_ring_event(VisualizerEventType event) {
+void VisualizerRole::Impl::handle_stream_ring_event(VisualizerEventType event) const {
     switch (event) {
         case VisualizerEventType::STREAM_START: {
             ServerVisualizerStreamObject config{};

--- a/src/visualizer_role.cpp
+++ b/src/visualizer_role.cpp
@@ -345,18 +345,14 @@ void VisualizerRole::Impl::handle_stream_clear() {
 }
 
 void VisualizerRole::Impl::enqueue_stream_event(VisualizerEventType event) const {
-    InboxEvent ring_event{};
-    ring_event.type = InboxEventType::VISUALIZER_STREAM;
-    ring_event.code = static_cast<uint8_t>(event);
-    if (this->inbox == nullptr || !this->inbox->push_event(ring_event)) {
-        const char* name = "STREAM_CLEAR";
-        if (event == VisualizerEventType::STREAM_START) {
-            name = "STREAM_START";
-        } else if (event == VisualizerEventType::STREAM_END) {
-            name = "STREAM_END";
-        }
-        SS_LOGW(TAG, "Inbox event ring full; dropping %s", name);
+    const char* name = "STREAM_CLEAR";
+    if (event == VisualizerEventType::STREAM_START) {
+        name = "STREAM_START";
+    } else if (event == VisualizerEventType::STREAM_END) {
+        name = "STREAM_END";
     }
+    push_event_or_log(this->inbox, InboxEventType::VISUALIZER_STREAM, static_cast<uint8_t>(event),
+                      TAG, name);
 }
 
 // ============================================================================

--- a/src/visualizer_role_impl.h
+++ b/src/visualizer_role_impl.h
@@ -17,11 +17,10 @@
 
 #pragma once
 
+#include "inbox.h"
 #include "platform/event_flags.h"
 #include "platform/memory.h"
-#include "platform/shadow_slot.h"
 #include "platform/spsc_ring_buffer.h"
-#include "platform/thread_safe_queue.h"
 #include "sendspin/visualizer_role.h"
 
 #include <atomic>
@@ -58,23 +57,24 @@ struct VisualizerRole::Impl {
         std::thread drain_thread;
     };
 
-    /// @brief Deferred event state for thread-safe visualizer stream lifecycle delivery
+    /// @brief Deferred event state for the visualizer stream config, delivered to the main thread
+    /// via the shared Inbox
     struct EventState {
-        ThreadSafeQueue<VisualizerEventType> queue;
-        ShadowSlot<ServerVisualizerStreamObject> shadow_config;
+        InboxSlot<ServerVisualizerStreamObject> config_slot;
     };
 
     // ========================================
     // Internal integration methods (called by SendspinClient)
     // ========================================
 
+    void attach_inbox(Inbox& inbox);
     bool start();
     void build_hello_fields(ClientHelloMessage& msg);
     void handle_binary(uint8_t binary_type, const uint8_t* data, size_t len);
     void handle_stream_start(const ServerVisualizerStreamObject& stream);
     void handle_stream_end();
     void handle_stream_clear();
-    void drain_events() const;
+    void handle_stream_ring_event(VisualizerEventType event);
     void cleanup();
 
     // ========================================
@@ -83,6 +83,7 @@ struct VisualizerRole::Impl {
 
     void stop() const;
     void flush_ring_buffer() const;
+    void enqueue_stream_event(VisualizerEventType event) const;
 
     static void drain_thread_func(VisualizerRole::Impl* self);
 
@@ -98,6 +99,7 @@ struct VisualizerRole::Impl {
     SendspinClient* client;
     std::unique_ptr<DrainTask> drain_task;
     std::unique_ptr<EventState> event_state;
+    Inbox* inbox{nullptr};
     VisualizerRoleListener* listener{nullptr};
 
     // Atomic fields (written by network thread, read by drain thread / cleanup)

--- a/src/visualizer_role_impl.h
+++ b/src/visualizer_role_impl.h
@@ -74,7 +74,7 @@ struct VisualizerRole::Impl {
     void handle_stream_start(const ServerVisualizerStreamObject& stream);
     void handle_stream_end();
     void handle_stream_clear();
-    void handle_stream_ring_event(VisualizerEventType event);
+    void handle_stream_ring_event(VisualizerEventType event) const;
     void cleanup();
 
     // ========================================


### PR DESCRIPTION
Part 5/6 of the inbox ITC refactor stack (based on #87; merge in order).

Moves the last two roles onto the Inbox: visualizer config rides an `InboxSlot` and its stream lifecycle rides the event ring; artwork decoded-image display slots ride an `InboxSlot` (bitmask of ready slots) with stream end/clear on the ring, and the per-slot server-clock display deadlines move into main-thread-only held state stamped with a stream epoch so a stale display from a previous stream is dropped instead of shown.

Includes the review fixes for this slice: the artwork epoch/deadline sweep now runs even with no listener attached (only the callback itself is gated), so a listener-less role cannot hold a display bit forever and defeat the drain gating added in the final PR; both stream-event producers go through `push_event_or_log()`.