### PR TITLE
Bit-gate loop() drains and gate ConnectionManager on lock-free work hints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ The library provides `SendspinClient` as the main public API. It handles the ful
 - `SyncTask` (`sync_task.h`): decodes encoded audio, synchronizes to server timestamps, writes PCM via audio write callback
 - `SendspinConnection` (`connection.h`): abstract WebSocket connection base
 - `SendspinServerConnection` / `SendspinClientConnection`: platform-specific WebSocket transports (ESP uses `esp_websocket_client`/`esp_http_server`, host uses IXWebSocket)
+- `Inbox` / `InboxSlot` (`inbox.h`): single-mutex mailbox for all main-loop-bound cross-thread state - atomic topic bitmask polled lock-free by `loop()`, plus a fixed event ring for ordered lifecycle/time events
 - `SendspinTimeFilter` (`time_filter.h`): 2D Kalman filter for NTP-style time sync
 - `SendspinTimeBurst` (`time_burst.h`): burst-based time message coordinator
 - `SendspinDecoder` (`decoder.h`): FLAC/Opus/PCM decoder wrapper
@@ -102,7 +103,7 @@ Headers in `src/platform/` use `#ifdef ESP_PLATFORM` to provide unified APIs acr
 - `spsc_ring_buffer.h`: single-producer/single-consumer ring buffer (ESP: FreeRTOS `xRingbuffer`, host: mutex/condition variable)
 - `thread_safe_queue.h`: thread-safe queue (ESP: FreeRTOS queue, host: mutex/condition variable)
 - `event_flags.h`: event flag group (ESP: FreeRTOS event group, host: mutex/condition variable)
-- `shadow_slot.h`: mutex-protected slot for publishing state from one thread and reading from another
+- `shadow_slot.h`: mutex-protected slot for publishing state between two non-main-loop threads (e.g. the sync task's playback-progress slot); main-loop-bound traffic goes through the inbox (`inbox.h`) instead
 
 Core source files in `src/` have no `#ifdef ESP_PLATFORM` guards; all platform differences are isolated to the platform layer and the `src/esp/`/`src/host/` directories.
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -96,7 +96,7 @@ Fixed-depth FIFO queue with timed send/receive. Used to defer events from networ
 
 ### ShadowSlot (`src/platform/shadow_slot.h`)
 
-Single-slot state container with "latest wins" or custom merge semantics. The network thread writes or merges; the main loop takes the accumulated value:
+Single-slot state container with "latest wins" or custom merge semantics for a producer/consumer thread pair where **neither thread is the main loop**. The writer thread writes or merges; the reader thread takes the accumulated value. Main-loop-bound cross-thread state goes through the Inbox / `InboxSlot` instead (see below), which consolidates many producers onto one shared mutex and a single lock-free `poll()` read per tick. Its one remaining user is the sync task's playback-progress slot (audio-callback thread → sync-task thread):
 
 | Shadow Slot | Data | Merge Strategy |
 |-------------|------|----------------|
@@ -204,15 +204,16 @@ The bump arena suits ArduinoJson's allocation pattern: during a parse the varian
 `SendspinClient::loop()` (`src/client.cpp`) runs the following steps **in order** on each tick:
 
 ```api
-1. connection_manager_->loop()
+1. connection_manager_->loop()   (sections gated on lock-free atomic hints - see below)
    ├─ Start WS server if network ready
-   ├─ Swap deferred connection events under mutex
+   ├─ Swap deferred connection events under mutex   (only when has_pending_events_)
    ├─ Process close/disconnect events (on_connection_lost)
    ├─ Promotion scan: establish nursery connections whose hello handshake completed
    │  (handoff decisions against the incumbent)
-   ├─ Call loop() on the current and nursery connections
-   ├─ Check per-connection hello retry timers
-   └─ Reap nursery connections past the establish deadline; tick the platform ws_server
+   ├─ Call loop() on the current and nursery connections   (only when has_current_ or nursery_size_)
+   ├─ Check per-connection hello retry timers   (only when nursery_size_)
+   ├─ Reap nursery connections past the establish deadline; tick the platform ws_server
+   └─ flush_deferred_releases()   (early-returns without locking when deferred_size_ is 0)
 
 2. time_burst_->loop(conn)  (skipped when no current connection)
    ├─ Send next time message if ready
@@ -226,18 +227,29 @@ The bump arena suits ArduinoJson's allocation pattern: during a parse the varian
    ├─ Dispatch ARTWORK_STREAM via artwork_->impl_->handle_stream_ring_event()
    └─ Dispatch VISUALIZER_STREAM via visualizer_->impl_->handle_stream_ring_event()
 
-4. Role event draining (each role's impl_->drain_events())
+4. Role event draining (each role's impl_->drain_events(), gated on impl_->needs_drain(slot_bits))
    ├─ player_->impl_->drain_events()
    ├─ controller_->impl_->drain_events()
    ├─ metadata_->impl_->drain_events()
    ├─ color_->impl_->drain_events()
    └─ artwork_->impl_->drain_events()   (display-deadline sweep; visualizer has no drain_events())
 
-5. Drain group_slot (when INBOX_TOPIC_GROUP is set)
+5. Drain group_slot (when INBOX_TOPIC_GROUP is set in slot_bits)
    └─ Apply group deltas, fire on_group_update, persist last played server
 ```
 
 This ordering matters: connection lifecycle events are processed before role events, and time sync before audio processing, so that roles always see a consistent connection and time state.
+
+Each `loop()` section that would otherwise take a mutex first consults a lock-free atomic hint, so an idle tick pays only for the atomic loads it needs to decide there is nothing to do. `ConnectionManager` keeps four such hints, each refreshed under the owning mutex right after the container/pointer it mirrors changes (always re-derived from `.size()` or the assigned value, never incremented in place, so the hint cannot drift from ground truth):
+
+- `has_pending_events_` (under `conn_mutex_`): set at every push into either deferred connection-event queue, cleared once `loop()` has swapped both out. Lets `loop()` skip the `conn_mutex_` acquisition when neither queue has anything pending.
+- `nursery_size_` (under `conn_ptr_mutex_`): mirrors `nursery_.size()`. Lets `loop()` skip the current/nursery copy-and-`loop()` block, the hello-retry scan, and the nursery reap scan when the nursery is empty, while keeping the lifecycle block running while any nursery connection exists (its promotion scan is level-triggered on connection flags, not on events).
+- `has_current_` (under `conn_ptr_mutex_`): true whenever `current_connection_` is non-null. Lets `loop()` skip the copy-and-`loop()` block when there is no current connection and the nursery is empty.
+- `deferred_size_` (under `conn_ptr_mutex_`): mirrors `deferred_releases_.size()`. Lets `flush_deferred_releases()` early-return without locking when nothing is queued.
+
+Steady state is therefore cheap: connected-and-idle costs one `conn_ptr_mutex_` acquisition (the current/nursery copy ahead of the `conn->loop()` calls) plus a handful of atomic loads; disconnected-and-idle costs zero mutex acquisitions. The mutex-protected containers and pointers remain the ground truth in every case; the hints only decide whether it is worth locking to look.
+
+The Inbox drain steps gate the same way, off two lock-free `poll()` snapshots of the topic bitmask. `inbox_bits` is taken first and gates only the event-ring drain (step 3). `slot_bits` is taken *after* that drain completes and gates the role drains (step 4) and the group drain (step 5); the second snapshot catches topic bits a producer set while the ring drain was running (including a ring event's own side effects re-entering the inbox). A bit either snapshot races and misses is not lost - it stays set and the next tick's `poll()` observes it (bounded staleness, per `Inbox::poll()`). Each role's `needs_drain(slot_bits)` decides whether its drain runs: mostly a simple `slot_bits & INBOX_TOPIC_*` test, but the player, metadata, and artwork roles OR in a main-thread-only carry-over term (the player's `awaiting_sync_idle_events`, the metadata role's future-dated `held_delta`, the artwork role's nonzero `held_display_mask`) so that work waiting out a deadline no inbox bit tracks still gets a drain every tick until it fires.
 
 ## Role Event Draining
 
@@ -273,9 +285,9 @@ The `awaiting_sync_idle_events` list (on `PlayerRole::Impl`) is the key ordering
 ### Other Roles
 
 - **ControllerRole**: Takes the latest `ServerStateControllerObject` from its `InboxSlot`, fires `on_controller_state()`. The disconnect clear is not handled here; it arrives as a `CONTROLLER_CLEARED` event on the shared ring, whose `handle_cleared_event()` fires `on_controller_state_clear()` (deferred from `cleanup()` to avoid invoking the listener while `ConnectionManager` holds `conn_ptr_mutex_`).
-- **MetadataRole**: `InboxSlot` has no `take_if`, so the deadline gate that used to run under the shadow slot's mutex is split in two: `take()` unconditionally moves any pending delta into a main-thread-only `held_delta` (folding it into an already-held delta), then the server-clock deadline is evaluated with no lock held, applying deltas and firing `on_metadata()` once the `timestamp` is reached (or immediately if there is no active connection). A future-dated `held_delta` persists across ticks with no topic bit set, which is why this `drain_events()` must be called unconditionally every tick (see the warning in `SendspinClient::loop()`). The clear arrives separately as a `METADATA_CLEARED` ring event (`handle_cleared_event()` fires `on_metadata_clear()`), deferred from `cleanup()` for the same `conn_ptr_mutex_` reason.
+- **MetadataRole**: `InboxSlot` has no `take_if`, so the deadline gate that used to run under the shadow slot's mutex is split in two: `take()` unconditionally moves any pending delta into a main-thread-only `held_delta` (folding it into an already-held delta), then the server-clock deadline is evaluated with no lock held, applying deltas and firing `on_metadata()` once the `timestamp` is reached (or immediately if there is no active connection). A future-dated `held_delta` persists across ticks with no topic bit set, which is why `needs_drain()` ORs in `held_delta.has_value()` alongside the `INBOX_TOPIC_METADATA` bit test: the deadline sets no inbox bit, so without that term a bit-gated tick would strand the delta until an unrelated new delta happened to re-set the bit, silently starving deadline-based delivery. The clear arrives separately as a `METADATA_CLEARED` ring event (`handle_cleared_event()` fires `on_metadata_clear()`), deferred from `cleanup()` for the same `conn_ptr_mutex_` reason.
 - **ColorRole**: Same structure as MetadataRole: `take()` into `held_delta`, a lock-free server-clock deadline gate firing `on_color()`, and a `COLOR_CLEARED` ring event driving `on_color_clear()`.
-- **ArtworkRole**: Stream end/clear lifecycle is handled earlier in the tick by `handle_stream_ring_event()` (dispatched from the ring drain, before this call), which clears `held_display_mask`/`display_slot` and fires `on_image_clear()` for each configured slot - preserving the "lifecycle before display" ordering the old single-function drain guaranteed. `drain_events()` itself folds any taken `display_slot` update into the main-thread-only `held_display_*` state (latest-wins per slot), then sweeps the held slots and fires `on_image_display(slot)` for any whose timestamp is due on the synced client clock (or immediately if there is no active connection). Per-slot epochs drop a held display whose stream was replaced after the decode hand-off. The sweep runs unconditionally every tick (not bit-gated) so held displays are re-evaluated against their deadlines; `on_image_decode` still happens on the dedicated artwork decode thread.
+- **ArtworkRole**: Stream end/clear lifecycle is handled earlier in the tick by `handle_stream_ring_event()` (dispatched from the ring drain, before this call), which clears `held_display_mask`/`display_slot` and fires `on_image_clear()` for each configured slot - preserving the "lifecycle before display" ordering the old single-function drain guaranteed. `drain_events()` itself folds any taken `display_slot` update into the main-thread-only `held_display_*` state (latest-wins per slot), then sweeps the held slots and fires `on_image_display(slot)` for any whose timestamp is due on the synced client clock (or immediately if there is no active connection). Per-slot epochs drop a held display whose stream was replaced after the decode hand-off. `needs_drain()` ORs a nonzero `held_display_mask` into the `INBOX_TOPIC_ARTWORK_DISPLAY` bit test (the same carry-over pattern the metadata role uses for `held_delta`) so held displays keep getting a drain every tick until their deadline fires, even though the deadline sets no inbox bit; `on_image_decode` still happens on the dedicated artwork decode thread.
 - **VisualizerRole**: Has no `drain_events()`. STREAM_START/END/CLEAR are dispatched entirely from `handle_stream_ring_event()` (from the ring drain): STREAM_START `take()`s the config from `config_slot` and fires `on_visualizer_stream_start()`; STREAM_END/CLEAR fire `on_visualizer_stream_end()`/`on_visualizer_stream_clear()`.
 
 ## Sync Task State Machine
@@ -460,7 +472,7 @@ The host build does not need this scheme: `SendspinWsServer` (host) routes IXWeb
 
 ### Network Thread → Main Loop
 
-All network thread actions are deferred to the main loop, primarily through the shared `Inbox` (its event ring and `InboxSlot`s), with a few remaining per-thread queues, shadow slots, and mutex-protected vectors. The main loop processes them in a fixed order each tick (connections → time → roles → group). This guarantees that:
+All network thread actions are deferred to the main loop, primarily through the shared `Inbox` (its event ring and `InboxSlot`s), with a few remaining per-thread queues and mutex-protected vectors. The main loop processes them in a fixed order each tick (connections → time → roles → group). This guarantees that:
 
 - Connection state is settled before roles process events.
 - Time sync is updated before audio sync decisions.

--- a/src/artwork_role_impl.h
+++ b/src/artwork_role_impl.h
@@ -136,6 +136,14 @@ struct ArtworkRole::Impl {
     void handle_stream_end();
     void handle_stream_clear();
     void handle_stream_ring_event(ArtworkEventType event);
+    // True if this tick has drainable artwork work. The display-slot bit covers newly decoded
+    // images; a nonzero held_display_mask means displays folded in on a prior tick are still
+    // waiting out their server-clock deadlines (see held_display_ts) -- the deadline itself sets
+    // no inbox bit, so a nonzero mask must be polled every tick until each slot fires or is
+    // dropped for a stream-epoch mismatch.
+    bool needs_drain(uint32_t pending_bits) const {
+        return (pending_bits & INBOX_TOPIC_ARTWORK_DISPLAY) != 0 || this->held_display_mask != 0;
+    }
     void drain_events();
     void cleanup();
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -22,7 +22,6 @@
 #include "platform/logging.h"
 #include "platform/memory.h"
 #include "platform/network_info.h"
-#include "platform/time.h"
 #ifdef SENDSPIN_ENABLE_ARTWORK
 #include "artwork_role_impl.h"
 #endif
@@ -44,9 +43,6 @@
 #endif
 #include "time_burst.h"
 #include <ArduinoJson.h>
-
-#include <algorithm>
-#include <cstring>
 
 static const char* const TAG = "sendspin.client";
 
@@ -188,8 +184,13 @@ void SendspinClient::loop() {
     }
 
     // Process deferred events: all state mutations and user callbacks happen here, on the main
-    // loop thread, to avoid cross-thread data races. Each role drains its own queues/shadows
-    // internally.
+    // loop thread, to avoid cross-thread data races. Two poll() snapshots gate the work below:
+    // inbox_bits (here) gates only the event-ring drain immediately following it; slot_bits
+    // (taken after that drain completes, below) gates the role drains and the group-update drain,
+    // since a role's InboxSlot can be written by a producer between this snapshot and that one.
+    // Both are lock-free atomic loads, so a tick with nothing pending performs zero inbox mutex
+    // acquisitions in this section. A bit either snapshot races and misses is picked up by the
+    // next tick's poll() -- bounded staleness, already documented on Inbox::poll().
     const uint32_t inbox_bits = this->event_state_->inbox.poll();
 
     // --- Time sync events ---
@@ -324,41 +325,41 @@ void SendspinClient::loop() {
         } while (!drain_aborted && event_count == EVENT_DRAIN_BATCH_SIZE);
     }
 
-    // --- Role events (each role handles its own synchronization) ---
-    // These drains must stay unconditional (gated only on the role existing), NOT wrapped in an
-    // `inbox_bits & INBOX_TOPIC_*` test like the group slot below. metadata/color drain_events()
-    // take() clears the topic bit even when it defers a future-dated delta into held_delta; that
-    // deferred delta is re-evaluated against its deadline on later ticks only because this call
-    // runs every tick. Bit-gating it would strand the delta until an unrelated new delta happened
-    // to re-set the bit, silently starving deadline-based delivery.
+    // Second snapshot: catches topic bits a producer set while the ring drain above was running
+    // (e.g. a role's own ring-event side effects re-entering the inbox, or any other producer
+    // thread racing the drain). Gates the role drains and the group drain below; see the
+    // inbox_bits comment above for the staleness argument, which applies identically here.
+    const uint32_t slot_bits = this->event_state_->inbox.poll();
+
+    // --- Role events: bit-gated so an idle tick performs zero inbox mutex acquisitions here ---
 #ifdef SENDSPIN_ENABLE_PLAYER
-    if (this->player_) {
+    if (this->player_ && this->player_->impl_->needs_drain(slot_bits)) {
         this->player_->impl_->drain_events();
     }
 #endif
 #ifdef SENDSPIN_ENABLE_CONTROLLER
-    if (this->controller_) {
+    if (this->controller_ && this->controller_->impl_->needs_drain(slot_bits)) {
         this->controller_->impl_->drain_events();
     }
 #endif
 #ifdef SENDSPIN_ENABLE_METADATA
-    if (this->metadata_) {
+    if (this->metadata_ && this->metadata_->impl_->needs_drain(slot_bits)) {
         this->metadata_->impl_->drain_events();
     }
 #endif
 #ifdef SENDSPIN_ENABLE_COLOR
-    if (this->color_) {
+    if (this->color_ && this->color_->impl_->needs_drain(slot_bits)) {
         this->color_->impl_->drain_events();
     }
 #endif
 #ifdef SENDSPIN_ENABLE_ARTWORK
-    if (this->artwork_) {
+    if (this->artwork_ && this->artwork_->impl_->needs_drain(slot_bits)) {
         this->artwork_->impl_->drain_events();
     }
 #endif
 
     // --- Group update events ---
-    if (inbox_bits & INBOX_TOPIC_GROUP) {
+    if (slot_bits & INBOX_TOPIC_GROUP) {
         GroupUpdateObject group_delta;
         if (this->event_state_->group_slot.take(group_delta)) {
             apply_group_update_deltas(&this->group_state_, group_delta);

--- a/src/color_role.cpp
+++ b/src/color_role.cpp
@@ -112,9 +112,10 @@ void ColorRole::Impl::drain_events() {
     }
 
     // A future-dated delta is held across ticks below without any topic bit set (take() above
-    // cleared it). It is re-evaluated against its deadline only because the client calls this
-    // drain_events() unconditionally every tick -- see the warning at the drain-call site in
-    // SendspinClient::loop().
+    // cleared it). It is re-evaluated against its deadline on later ticks only because
+    // needs_drain() ORs in held_delta.has_value() alongside the INBOX_TOPIC_COLOR bit test, so
+    // this drain_events() keeps running each tick until the deadline fires. Dropping that OR term
+    // would strand the delta until an unrelated new delta re-set the topic bit.
     //
     // get_client_time returns 0 when there is no current connection. Without a connection we
     // cannot honor the server-clock deadline, so fire immediately rather than starving the

--- a/src/color_role_impl.h
+++ b/src/color_role_impl.h
@@ -51,6 +51,12 @@ struct ColorRole::Impl {
     void attach_inbox(Inbox& inbox);
     void build_hello_fields(ClientHelloMessage& msg);
     void handle_server_state(ServerColorStateDelta delta) const;
+    // True if a slot delta needs folding in, or a delta already held from a prior tick (see
+    // held_delta) is still waiting out its server-clock deadline -- the deadline itself sets no
+    // inbox bit, so held_delta must be polled every tick until it fires.
+    bool needs_drain(uint32_t pending_bits) const {
+        return (pending_bits & INBOX_TOPIC_COLOR) != 0 || this->held_delta.has_value();
+    }
     void drain_events();
     void handle_cleared_event() const;
     void cleanup();

--- a/src/connection_manager.cpp
+++ b/src/connection_manager.cpp
@@ -78,8 +78,18 @@ static const char* to_cstr(SetupStage stage) {
 ConnectionManager::ConnectionManager(SendspinClient* client) : client_(client) {}
 
 ConnectionManager::~ConnectionManager() {
-    // Move everything out under the lock, destroy outside it: a connection destructor can join
-    // its transport thread (see DeferredRelease), which must not happen while the lock is held.
+    // Move everything out under the locks, destroy outside them: a connection destructor can join
+    // its transport thread (see DeferredRelease), which must not happen while a lock is held.
+    // The two mutexes guard disjoint state and are taken in separate scopes, never nested.
+    std::vector<std::shared_ptr<SendspinConnection>> pending_connected;
+    std::vector<std::shared_ptr<SendspinConnection>> pending_disconnects;
+    {
+        std::lock_guard<std::mutex> lock(this->conn_mutex_);
+        pending_connected = std::move(this->pending_connected_events_);
+        pending_disconnects = std::move(this->pending_disconnect_events_);
+        this->has_pending_events_.store(false, std::memory_order_release);
+    }
+
     std::shared_ptr<SendspinConnection> current;
     std::vector<NurseryEntry> nursery;
     std::vector<HelloRetryState> retries;
@@ -90,9 +100,10 @@ ConnectionManager::~ConnectionManager() {
         nursery = std::move(this->nursery_);
         retries = std::move(this->hello_retries_);
         releases = std::move(this->deferred_releases_);
-        // Keep the hint atomics in sync with the now-empty containers. Nothing reads them again
-        // after destruction, but this keeps the "atomic mirrors container" invariant unconditional
-        // rather than carving out an exception for teardown.
+        // Keep the hint atomics in sync with the now-empty containers (has_pending_events_ was
+        // handled above under its own mutex). Nothing reads them again after destruction, but
+        // this keeps the "atomic mirrors container" invariant unconditional rather than carving
+        // out an exception for teardown.
         this->has_current_.store(false, std::memory_order_release);
         this->nursery_size_.store(0, std::memory_order_release);
         this->deferred_size_.store(0, std::memory_order_release);

--- a/src/connection_manager.cpp
+++ b/src/connection_manager.cpp
@@ -90,6 +90,12 @@ ConnectionManager::~ConnectionManager() {
         nursery = std::move(this->nursery_);
         retries = std::move(this->hello_retries_);
         releases = std::move(this->deferred_releases_);
+        // Keep the hint atomics in sync with the now-empty containers. Nothing reads them again
+        // after destruction, but this keeps the "atomic mirrors container" invariant unconditional
+        // rather than carving out an exception for teardown.
+        this->has_current_.store(false, std::memory_order_release);
+        this->nursery_size_.store(0, std::memory_order_release);
+        this->deferred_size_.store(0, std::memory_order_release);
     }
     // Locals release here. Queued goodbyes are skipped on destruction; shutdown drops slots
     // without a send.
@@ -116,11 +122,13 @@ void ConnectionManager::connect_to(const std::string& url) {
         c->mark_ws_upgraded();
         std::lock_guard<std::mutex> lock(this->conn_mutex_);
         this->pending_connected_events_.push_back(c->shared_from_this());
+        this->has_pending_events_.store(true, std::memory_order_release);
     };
     client_conn->on_disconnected_cb = [this](SendspinConnection* conn) {
         // Defer to loop(); this callback runs on IXWebSocket's internal thread
         std::lock_guard<std::mutex> lock(this->conn_mutex_);
         this->pending_disconnect_events_.push_back(conn->shared_from_this());
+        this->has_pending_events_.store(true, std::memory_order_release);
     };
 
     client_conn->init_time_filter();
@@ -155,7 +163,7 @@ void ConnectionManager::connect_to(const std::string& url) {
         // A user-initiated connect is admitted even against a full nursery: there is at most one
         // outbound entry (replaced above), so the nursery is still bounded (NURSERY_CAPACITY + 1)
         // and an explicit user request never fails against inbound peers.
-        this->nursery_.push_back(NurseryEntry{client_conn, /*inbound=*/false});
+        this->push_nursery_entry(NurseryEntry{client_conn, /*inbound=*/false});
         client_conn->start();
     }
     this->flush_deferred_releases();
@@ -230,6 +238,7 @@ void ConnectionManager::init_server(SendspinClient* client) {
             // a new connection (drop_connection no-ops on connections it does not manage).
             std::lock_guard<std::mutex> lock(this->conn_mutex_);
             this->pending_disconnect_events_.push_back(std::move(conn));
+            this->has_pending_events_.store(true, std::memory_order_release);
         });
 
     // Connection lookup-by-sockfd. Used by the host build's ws_server to route IXWebSocket
@@ -269,13 +278,22 @@ void ConnectionManager::loop() {
     {
         std::vector<std::shared_ptr<SendspinConnection>> connected_events;
         std::vector<std::shared_ptr<SendspinConnection>> disconnect_events;
-        {
+        // Skip the conn_mutex_ acquisition entirely when the hint says both queues are empty.
+        // Sound because every push site sets has_pending_events_ = true under conn_mutex_ before
+        // releasing it (see the field's doc comment in connection_manager.h).
+        if (this->has_pending_events_.load(std::memory_order_acquire)) {
             std::lock_guard<std::mutex> lock(this->conn_mutex_);
             connected_events.swap(this->pending_connected_events_);
             disconnect_events.swap(this->pending_disconnect_events_);
+            this->has_pending_events_.store(false, std::memory_order_release);
         }
 
-        {
+        // Also runs whenever the nursery is non-empty even with no swapped-out events: the
+        // promotion scan below is level-triggered on handshake flags set by network threads with
+        // no corresponding event push, so it must keep running every tick a nursery connection
+        // exists, not just on the tick its flags happen to flip.
+        if (!connected_events.empty() || !disconnect_events.empty() ||
+            this->nursery_size_.load(std::memory_order_acquire) > 0) {
             std::lock_guard<std::mutex> lock(this->conn_ptr_mutex_);
 
             // Connection close/disconnect events (inbound ws_server closes on both platforms,
@@ -312,10 +330,12 @@ void ConnectionManager::loop() {
                 }
                 auto conn = std::move(it->conn);
                 it = this->nursery_.erase(it);
+                this->nursery_size_.store(this->nursery_.size(), std::memory_order_release);
                 this->remove_hello_retry(conn.get());
 
                 if (this->current_connection_ == nullptr) {
                     this->current_connection_ = std::move(conn);
+                    this->has_current_.store(true, std::memory_order_release);
                 } else if (this->should_switch_to_new_server(this->current_connection_.get(),
                                                              conn.get())) {
                     // Both sides of the comparison are established, so the PLAYBACK-reason and
@@ -325,13 +345,14 @@ void ConnectionManager::loop() {
                     this->drop_connection(this->current_connection_.get(),
                                           SendspinGoodbyeReason::ANOTHER_SERVER);
                     this->current_connection_ = std::move(conn);
+                    this->has_current_.store(true, std::memory_order_release);
                 } else {
                     SS_LOGI(TAG, "Handoff decision: keep current server");
                     // Leaving management: block stale network-thread dispatch during the goodbye
                     // window (outgoing sends, including the goodbye itself, are unaffected).
                     conn->disable_message_dispatch();
-                    this->deferred_releases_.push_back(
-                        {std::move(conn), SendspinGoodbyeReason::ANOTHER_SERVER});
+                    this->queue_deferred_release(std::move(conn),
+                                                 SendspinGoodbyeReason::ANOTHER_SERVER);
                     continue;
                 }
 
@@ -355,7 +376,10 @@ void ConnectionManager::loop() {
     std::shared_ptr<SendspinConnection> current_copy;
     std::array<std::shared_ptr<SendspinConnection>, NURSERY_CAPACITY + 1> nursery_copies;
     size_t nursery_count = 0;
-    {
+    // Skip the copy (and thus every conn->loop() call below) when there is nothing to call it
+    // on: no current connection and an empty nursery.
+    if (this->nursery_size_.load(std::memory_order_acquire) > 0 ||
+        this->has_current_.load(std::memory_order_acquire)) {
         std::lock_guard<std::mutex> lock(this->conn_ptr_mutex_);
         current_copy = this->current_connection_;
         for (const auto& entry : this->nursery_) {
@@ -369,63 +393,75 @@ void ConnectionManager::loop() {
         nursery_copies[i]->loop();
     }
 
-    // Check hello retry timers (one entry per managed connection, so a second connection arriving
-    // mid-handshake cannot clobber the first connection's pending hello).
-    {
+    // Hello retry timers and the nursery establish-deadline reap both operate purely on nursery
+    // membership: hello_retries_ entries exist only for nursery members (initiate_hello is only
+    // ever called for a connection that is already in, or about to be inserted into, the
+    // nursery -- see its call sites), and every path that erases from nursery_
+    // (release_nursery_entry() and the promotion scan's erase above) calls remove_hello_retry()
+    // immediately after. So an empty nursery implies hello_retries_ is empty too, and both scans
+    // are skipped together, under one lock, when nursery_size_ == 0. (The lazy erase inside the
+    // first scan below, for a retry whose connection already left the nursery, is purely
+    // defensive given that invariant -- it should never actually fire.)
+    if (this->nursery_size_.load(std::memory_order_acquire) > 0) {
         std::lock_guard<std::mutex> lock(this->conn_ptr_mutex_);
-        const int64_t now_us = platform_time_us();
-        for (auto it = this->hello_retries_.begin(); it != this->hello_retries_.end();) {
-            HelloRetryState& retry = *it;
 
-            // Drop retries whose connection has left the nursery. A retry entry is live only for
-            // nursery members: the current connection is established by construction and never
-            // awaits a hello.
-            if (this->find_in_nursery(retry.conn.get()) == this->nursery_.end()) {
-                it = this->hello_retries_.erase(it);
-                continue;
-            }
+        // Check hello retry timers (one entry per managed connection, so a second connection
+        // arriving mid-handshake cannot clobber the first connection's pending hello).
+        {
+            const int64_t now_us = platform_time_us();
+            for (auto it = this->hello_retries_.begin(); it != this->hello_retries_.end();) {
+                HelloRetryState& retry = *it;
 
-            if (retry.retry_time_us == 0 || now_us < retry.retry_time_us) {
-                ++it;
-                continue;
-            }
+                // Drop retries whose connection has left the nursery. A retry entry is live only
+                // for nursery members: the current connection is established by construction and
+                // never awaits a hello.
+                if (this->find_in_nursery(retry.conn.get()) == this->nursery_.end()) {
+                    it = this->hello_retries_.erase(it);
+                    continue;
+                }
 
-            if (this->send_hello_message(retry.attempts - 1, retry.conn.get())) {
-                // Sent, or the connection left the nursery; the retry is complete.
-                it = this->hello_retries_.erase(it);
-                continue;
-            }
+                if (retry.retry_time_us == 0 || now_us < retry.retry_time_us) {
+                    ++it;
+                    continue;
+                }
 
-            // Transient failure: retry with exponential backoff until attempts are exhausted.
-            if (retry.attempts > 1) {
-                retry.delay_ms *= 2;
-                retry.attempts--;
-                retry.retry_time_us = now_us + static_cast<int64_t>(retry.delay_ms) * US_PER_MS;
-                ++it;
-            } else {
-                it = this->hello_retries_.erase(it);
+                if (this->send_hello_message(retry.attempts - 1, retry.conn.get())) {
+                    // Sent, or the connection left the nursery; the retry is complete.
+                    it = this->hello_retries_.erase(it);
+                    continue;
+                }
+
+                // Transient failure: retry with exponential backoff until attempts are exhausted.
+                if (retry.attempts > 1) {
+                    retry.delay_ms *= 2;
+                    retry.attempts--;
+                    retry.retry_time_us = now_us + static_cast<int64_t>(retry.delay_ms) * US_PER_MS;
+                    ++it;
+                } else {
+                    it = this->hello_retries_.erase(it);
+                }
             }
         }
-    }
 
-    // Nursery tick: reap connections that miss the establish deadline. This is the only release
-    // path for peers that connect and then stall without completing the hello, and for outbound
-    // sockets whose transport never delivers a close (host IXWebSocket, issue #75). Hello arming
-    // is event-driven (admission for inbound, connected event for outbound), so the tick only
-    // ever reaps.
-    {
-        std::lock_guard<std::mutex> lock(this->conn_ptr_mutex_);
-        const int64_t now_us = platform_time_us();
-        for (auto it = this->nursery_.begin(); it != this->nursery_.end();) {
-            NurseryEntry& entry = *it;
-            if (now_us - entry.conn->get_provisional_time_us() >= NURSERY_ESTABLISH_TIMEOUT_US) {
-                SS_LOGW(TAG, "Nursery connection stalled at %s (>%d s), dropping",
-                        to_cstr(setup_stage(*entry.conn)),
-                        static_cast<int>(NURSERY_ESTABLISH_TIMEOUT_US / US_PER_SECOND));
-                it = this->release_nursery_entry(it, SendspinGoodbyeReason::ANOTHER_SERVER);
-                continue;
+        // Nursery tick: reap connections that miss the establish deadline. This is the only
+        // release path for peers that connect and then stall without completing the hello, and
+        // for outbound sockets whose transport never delivers a close (host IXWebSocket, issue
+        // #75). Hello arming is event-driven (admission for inbound, connected event for
+        // outbound), so the tick only ever reaps.
+        {
+            const int64_t now_us = platform_time_us();
+            for (auto it = this->nursery_.begin(); it != this->nursery_.end();) {
+                NurseryEntry& entry = *it;
+                if (now_us - entry.conn->get_provisional_time_us() >=
+                    NURSERY_ESTABLISH_TIMEOUT_US) {
+                    SS_LOGW(TAG, "Nursery connection stalled at %s (>%d s), dropping",
+                            to_cstr(setup_stage(*entry.conn)),
+                            static_cast<int>(NURSERY_ESTABLISH_TIMEOUT_US / US_PER_SECOND));
+                    it = this->release_nursery_entry(it, SendspinGoodbyeReason::ANOTHER_SERVER);
+                    continue;
+                }
+                ++it;
             }
-            ++it;
         }
     }
 
@@ -520,15 +556,14 @@ void ConnectionManager::on_new_connection(std::shared_ptr<SendspinServerConnecti
             // Never managed, but its callbacks are already wired: block dispatch so it cannot
             // inject messages during the goodbye window.
             conn->disable_message_dispatch();
-            this->deferred_releases_.push_back(
-                {std::move(conn), SendspinGoodbyeReason::ANOTHER_SERVER});
+            this->queue_deferred_release(std::move(conn), SendspinGoodbyeReason::ANOTHER_SERVER);
         } else {
             SS_LOGD(TAG, "Admitting new connection into the nursery");
             // Arm the hello right away: the connection arrives WS-upgraded, so there is no
             // earlier signal to wait for. (Outbound connections instead arm theirs when the
             // transport's connected event is processed in loop().)
             this->initiate_hello(conn.get());
-            this->nursery_.push_back(NurseryEntry{std::move(conn), /*inbound=*/true});
+            this->push_nursery_entry(NurseryEntry{std::move(conn), /*inbound=*/true});
         }
     }
     this->flush_deferred_releases();
@@ -636,25 +671,62 @@ std::vector<NurseryEntry>::iterator ConnectionManager::find_in_nursery(
     return this->nursery_.end();
 }
 
+void ConnectionManager::push_nursery_entry(NurseryEntry entry) {
+    // Note: caller must hold conn_ptr_mutex_
+    this->nursery_.push_back(std::move(entry));
+    this->nursery_size_.store(this->nursery_.size(), std::memory_order_release);
+}
+
 std::vector<NurseryEntry>::iterator ConnectionManager::release_nursery_entry(
     std::vector<NurseryEntry>::iterator it, std::optional<SendspinGoodbyeReason> reason) {
     // Note: caller must hold conn_ptr_mutex_ and flush_deferred_releases() after dropping it
     auto conn = std::move(it->conn);
     auto next = this->nursery_.erase(it);
+    this->nursery_size_.store(this->nursery_.size(), std::memory_order_release);
     // Leaving management: block stale network-thread dispatch into role/state queues during the
     // goodbye window. Outgoing sends, including the goodbye itself, are unaffected.
     conn->disable_message_dispatch();
     this->remove_hello_retry(conn.get());
-    this->deferred_releases_.push_back({std::move(conn), reason});
+    this->queue_deferred_release(std::move(conn), reason);
     return next;
+}
+
+void ConnectionManager::queue_deferred_release(std::shared_ptr<SendspinConnection> conn,
+                                               std::optional<SendspinGoodbyeReason> reason) {
+    // Note: caller must hold conn_ptr_mutex_ and call flush_deferred_releases() after dropping it
+    this->deferred_releases_.push_back({std::move(conn), reason});
+    this->deferred_size_.store(this->deferred_releases_.size(), std::memory_order_release);
 }
 
 void ConnectionManager::flush_deferred_releases() {
     // Note: caller must NOT hold conn_ptr_mutex_ (see DeferredRelease)
+    //
+    // Lock-free early return: deferred_size_ mirrors deferred_releases_.size() and is refreshed
+    // only under conn_ptr_mutex_, at every push (queue_deferred_release()) and at the drain swap
+    // below, so observing 0 here means the container was empty as of that acquire-load. This is
+    // sound because every push site is followed by a call to this function on the SAME thread
+    // before the pushing function returns to its caller: loop()'s lifecycle block (Block 2) is
+    // followed by the Block-3 call below it in loop() itself; connect_to() and disconnect() each
+    // call this function right after their locked section; on_new_connection() calls it right
+    // after its locked section too (on the network/httpd thread, not the main loop thread -- the
+    // "same thread" guarantee is about the call stack that did the push, not about which thread
+    // that happens to be). So a push is normally drained by its own triggering call before that
+    // call returns. If a concurrently racing flush call (a different thread, or loop()'s other
+    // backstop call within the same tick) wins the lock first and drains it, that is equally
+    // fine: a queued release is performed exactly once by whichever call actually swaps it out,
+    // and the pushing call's own subsequent gate check then correctly observes 0 and skips a
+    // lock it no longer needs. Either way nothing pushed is ever left stranded: loop() also
+    // calls this function unconditionally twice per tick (after the lifecycle block and after
+    // the nursery reap), so even a hypothetical gap in the reasoning above is bounded to the
+    // very next tick.
+    if (this->deferred_size_.load(std::memory_order_acquire) == 0) {
+        return;
+    }
     std::vector<DeferredRelease> releases;
     {
         std::lock_guard<std::mutex> lock(this->conn_ptr_mutex_);
         releases.swap(this->deferred_releases_);
+        this->deferred_size_.store(this->deferred_releases_.size(), std::memory_order_release);
     }
     for (auto& release : releases) {
         if (release.goodbye.has_value()) {
@@ -700,8 +772,9 @@ void ConnectionManager::drop_connection(SendspinConnection* conn,
         this->client_->cleanup_connection_state();
         // std::exchange (not std::move) so the slot is never left in a moved-from state the
         // static analyzer flags when a later event in the same loop() pass reads it.
-        this->deferred_releases_.push_back(
-            {std::exchange(this->current_connection_, nullptr), goodbye});
+        auto dropped = std::exchange(this->current_connection_, nullptr);
+        this->has_current_.store(false, std::memory_order_release);
+        this->queue_deferred_release(std::move(dropped), goodbye);
         return;
     }
 

--- a/src/connection_manager.cpp
+++ b/src/connection_manager.cpp
@@ -132,14 +132,12 @@ void ConnectionManager::connect_to(const std::string& url) {
         // Inbound connections arrive already upgraded and arm their hello at admission.
         c->mark_ws_upgraded();
         std::lock_guard<std::mutex> lock(this->conn_mutex_);
-        this->pending_connected_events_.push_back(c->shared_from_this());
-        this->has_pending_events_.store(true, std::memory_order_release);
+        this->queue_pending_connected(c->shared_from_this());
     };
     client_conn->on_disconnected_cb = [this](SendspinConnection* conn) {
         // Defer to loop(); this callback runs on IXWebSocket's internal thread
         std::lock_guard<std::mutex> lock(this->conn_mutex_);
-        this->pending_disconnect_events_.push_back(conn->shared_from_this());
-        this->has_pending_events_.store(true, std::memory_order_release);
+        this->queue_pending_disconnect(conn->shared_from_this());
     };
 
     client_conn->init_time_filter();
@@ -248,8 +246,7 @@ void ConnectionManager::init_server(SendspinClient* client) {
             // queue: both carry the connection itself, so a stale event can never be mis-routed to
             // a new connection (drop_connection no-ops on connections it does not manage).
             std::lock_guard<std::mutex> lock(this->conn_mutex_);
-            this->pending_disconnect_events_.push_back(std::move(conn));
-            this->has_pending_events_.store(true, std::memory_order_release);
+            this->queue_pending_disconnect(std::move(conn));
         });
 
     // Connection lookup-by-sockfd. Used by the host build's ws_server to route IXWebSocket
@@ -345,8 +342,7 @@ void ConnectionManager::loop() {
                 this->remove_hello_retry(conn.get());
 
                 if (this->current_connection_ == nullptr) {
-                    this->current_connection_ = std::move(conn);
-                    this->has_current_.store(true, std::memory_order_release);
+                    this->set_current_connection(std::move(conn));
                 } else if (this->should_switch_to_new_server(this->current_connection_.get(),
                                                              conn.get())) {
                     // Both sides of the comparison are established, so the PLAYBACK-reason and
@@ -355,8 +351,7 @@ void ConnectionManager::loop() {
                     SS_LOGI(TAG, "Handoff decision: switch to new server");
                     this->drop_connection(this->current_connection_.get(),
                                           SendspinGoodbyeReason::ANOTHER_SERVER);
-                    this->current_connection_ = std::move(conn);
-                    this->has_current_.store(true, std::memory_order_release);
+                    this->set_current_connection(std::move(conn));
                 } else {
                     SS_LOGI(TAG, "Handoff decision: keep current server");
                     // Leaving management: block stale network-thread dispatch during the goodbye
@@ -688,6 +683,24 @@ void ConnectionManager::push_nursery_entry(NurseryEntry entry) {
     this->nursery_size_.store(this->nursery_.size(), std::memory_order_release);
 }
 
+void ConnectionManager::set_current_connection(std::shared_ptr<SendspinConnection> conn) {
+    // Note: caller must hold conn_ptr_mutex_
+    this->has_current_.store(conn != nullptr, std::memory_order_release);
+    this->current_connection_ = std::move(conn);
+}
+
+void ConnectionManager::queue_pending_connected(std::shared_ptr<SendspinConnection> conn) {
+    // Note: caller must hold conn_mutex_
+    this->pending_connected_events_.push_back(std::move(conn));
+    this->has_pending_events_.store(true, std::memory_order_release);
+}
+
+void ConnectionManager::queue_pending_disconnect(std::shared_ptr<SendspinConnection> conn) {
+    // Note: caller must hold conn_mutex_
+    this->pending_disconnect_events_.push_back(std::move(conn));
+    this->has_pending_events_.store(true, std::memory_order_release);
+}
+
 std::vector<NurseryEntry>::iterator ConnectionManager::release_nursery_entry(
     std::vector<NurseryEntry>::iterator it, std::optional<SendspinGoodbyeReason> reason) {
     // Note: caller must hold conn_ptr_mutex_ and flush_deferred_releases() after dropping it
@@ -781,10 +794,11 @@ void ConnectionManager::drop_connection(SendspinConnection* conn,
         // deferred (see DeferredRelease).
         conn->disable_message_dispatch();
         this->client_->cleanup_connection_state();
-        // std::exchange (not std::move) so the slot is never left in a moved-from state the
-        // static analyzer flags when a later event in the same loop() pass reads it.
-        auto dropped = std::exchange(this->current_connection_, nullptr);
-        this->has_current_.store(false, std::memory_order_release);
+        // set_current_connection(nullptr) reassigns the slot to a clean null (not a moved-from
+        // state) after we move the old connection out, so a later event in the same loop() pass
+        // that reads current_connection_ never trips the static analyzer.
+        auto dropped = std::move(this->current_connection_);
+        this->set_current_connection(nullptr);
         this->queue_deferred_release(std::move(dropped), goodbye);
         return;
     }

--- a/src/connection_manager.h
+++ b/src/connection_manager.h
@@ -22,6 +22,7 @@
 #include "protocol_messages.h"
 #include "sendspin/client.h"
 
+#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -152,6 +153,14 @@ public:
 
     /// @brief Drives connection state: starts server when network ready, processes lifecycle
     /// events, retries hello, calls loop() on active connections.
+    ///
+    /// Tick cost: every section below the ws_server start-retry check is gated on one of the
+    /// atomic hints in "Atomic fields" below (has_pending_events_, nursery_size_, has_current_,
+    /// deferred_size_), so an idle tick only pays for the atomic loads it needs to decide there
+    /// is nothing to do. Steady state: connected and idle (no pending events, empty nursery)
+    /// costs exactly one conn_ptr_mutex_ acquisition (the current/nursery copy ahead of the
+    /// conn->loop() calls) plus a handful of atomic loads; disconnected and idle costs zero
+    /// mutex acquisitions.
     void loop();
 
     // ========================================
@@ -213,6 +222,12 @@ private:
     /// @return Iterator into nursery_, or nursery_.end() if the connection is not in the nursery.
     std::vector<NurseryEntry>::iterator find_in_nursery(const SendspinConnection* conn);
 
+    /// @brief Appends an entry to the nursery and refreshes nursery_size_ in the same critical
+    /// section, so the hint atomic can never drift from nursery_.size(). Caller must hold
+    /// conn_ptr_mutex_.
+    /// @param entry The nursery entry to add.
+    void push_nursery_entry(NurseryEntry entry);
+
     /// @brief Releases a nursery entry: erases it, prunes its hello retry, and queues the
     /// goodbye+release on deferred_releases_. Caller must hold conn_ptr_mutex_ and call
     /// flush_deferred_releases() after dropping it.
@@ -223,10 +238,22 @@ private:
     std::vector<NurseryEntry>::iterator release_nursery_entry(
         std::vector<NurseryEntry>::iterator it, std::optional<SendspinGoodbyeReason> reason);
 
+    /// @brief Appends a release to deferred_releases_ and refreshes deferred_size_ in the same
+    /// critical section, so the hint atomic can never drift from deferred_releases_.size().
+    /// Caller must hold conn_ptr_mutex_ and call flush_deferred_releases() after dropping it.
+    /// @param conn The connection to release; empty on return (moved from).
+    /// @param reason The goodbye reason to send before closing, or nullopt when the transport is
+    ///        already gone so no goodbye should be attempted.
+    void queue_deferred_release(std::shared_ptr<SendspinConnection> conn,
+                                std::optional<SendspinGoodbyeReason> reason);
+
     /// @brief Performs the queued goodbye sends and connection releases from deferred_releases_.
     /// Caller must NOT hold conn_ptr_mutex_ (see DeferredRelease). Safe to call from any thread;
     /// a queued release is performed exactly once. Called after every locked section that can
     /// queue a release; loop() also calls it as a backstop.
+    ///
+    /// Early-returns without locking when deferred_size_ reads 0 -- see the definition for the
+    /// soundness argument.
     void flush_deferred_releases();
 
     // ========================================
@@ -317,6 +344,33 @@ private:
 
     // 8-bit fields
     bool has_last_played_server_{false};
+
+    // Atomic fields (lock-free hints for loop() tick gating; ground truth remains the
+    // mutex-protected containers/pointer above -- see the "Tick cost" note on loop())
+
+    /// True while pending_connected_events_ or pending_disconnect_events_ holds an unswapped
+    /// entry. Set under conn_mutex_ at every push into either queue; cleared under conn_mutex_
+    /// once loop() has swapped both queues out. Lets loop() skip the conn_mutex_ acquisition
+    /// entirely when neither queue has anything pending.
+    std::atomic<bool> has_pending_events_{false};
+
+    /// nursery_.size(), refreshed under conn_ptr_mutex_ immediately after every nursery_
+    /// mutation (always re-derived from .size(), never incremented/decremented in place, so it
+    /// cannot drift). Lets loop() skip the copies/loop() block, the hello-retry scan, and the
+    /// nursery reap scan when the nursery is empty, and keeps the lifecycle block running while
+    /// any nursery connection exists even with no swapped-out events (its promotion scan is
+    /// level-triggered on connection flags, not edge-triggered on events).
+    std::atomic<size_t> nursery_size_{0};
+
+    /// True whenever current_connection_ is non-null. Refreshed under conn_ptr_mutex_ at every
+    /// assignment (promotion, handoff, drop_connection's exchange, destructor). Lets loop() skip
+    /// the copies/loop() block when there is no current connection and the nursery is empty.
+    std::atomic<bool> has_current_{false};
+
+    /// deferred_releases_.size(), refreshed under conn_ptr_mutex_ after every push (see
+    /// queue_deferred_release()) and after the drain swap in flush_deferred_releases(). Lets
+    /// flush_deferred_releases() early-return without locking when nothing is queued.
+    std::atomic<size_t> deferred_size_{0};
 };
 
 }  // namespace sendspin

--- a/src/connection_manager.h
+++ b/src/connection_manager.h
@@ -228,6 +228,24 @@ private:
     /// @param entry The nursery entry to add.
     void push_nursery_entry(NurseryEntry entry);
 
+    /// @brief Assigns current_connection_ and refreshes has_current_ in the same critical section,
+    /// so the hint atomic can never drift from "current_connection_ != nullptr". Pass nullptr to
+    /// clear the slot. Caller must hold conn_ptr_mutex_.
+    /// @param conn The connection to install as current, or nullptr to clear; moved from.
+    void set_current_connection(std::shared_ptr<SendspinConnection> conn);
+
+    /// @brief Appends a connection to pending_connected_events_ and sets has_pending_events_ in
+    /// the same critical section, so loop()'s lock-free gate can never miss a pushed event.
+    /// Caller must hold conn_mutex_.
+    /// @param conn The freshly connected connection to defer to loop().
+    void queue_pending_connected(std::shared_ptr<SendspinConnection> conn);
+
+    /// @brief Appends a connection to pending_disconnect_events_ and sets has_pending_events_ in
+    /// the same critical section, so loop()'s lock-free gate can never miss a pushed event.
+    /// Caller must hold conn_mutex_.
+    /// @param conn The disconnected connection to defer to loop().
+    void queue_pending_disconnect(std::shared_ptr<SendspinConnection> conn);
+
     /// @brief Releases a nursery entry: erases it, prunes its hello retry, and queues the
     /// goodbye+release on deferred_releases_. Caller must hold conn_ptr_mutex_ and call
     /// flush_deferred_releases() after dropping it.

--- a/src/controller_role_impl.h
+++ b/src/controller_role_impl.h
@@ -47,6 +47,10 @@ struct ControllerRole::Impl {
     void attach_inbox(Inbox& inbox);
     void build_hello_fields(ClientHelloMessage& msg);
     void handle_server_state(ServerStateControllerObject state) const;
+    // True if a controller-state delta is waiting in the inbox slot.
+    bool needs_drain(uint32_t pending_bits) const {
+        return (pending_bits & INBOX_TOPIC_CONTROLLER) != 0;
+    }
     void drain_events();
     void handle_cleared_event() const;
     void cleanup();

--- a/src/metadata_role.cpp
+++ b/src/metadata_role.cpp
@@ -179,9 +179,10 @@ void MetadataRole::Impl::drain_events() {
     }
 
     // A future-dated delta is held across ticks below without any topic bit set (take() above
-    // cleared it). It is re-evaluated against its deadline only because the client calls this
-    // drain_events() unconditionally every tick -- see the warning at the drain-call site in
-    // SendspinClient::loop().
+    // cleared it). It is re-evaluated against its deadline on later ticks only because
+    // needs_drain() ORs in held_delta.has_value() alongside the INBOX_TOPIC_METADATA bit test, so
+    // this drain_events() keeps running each tick until the deadline fires. Dropping that OR term
+    // would strand the delta until an unrelated new delta re-set the topic bit.
     //
     // get_client_time returns 0 when there is no current connection. Without a connection we
     // cannot honor the server-clock deadline, so fire immediately rather than starving the

--- a/src/metadata_role_impl.h
+++ b/src/metadata_role_impl.h
@@ -49,6 +49,12 @@ struct MetadataRole::Impl {
     void attach_inbox(Inbox& inbox);
     void build_hello_fields(ClientHelloMessage& msg);
     void handle_server_state(ServerMetadataStateDelta delta) const;
+    // True if a slot delta needs folding in, or a delta already held from a prior tick (see
+    // held_delta) is still waiting out its server-clock deadline -- the deadline itself sets no
+    // inbox bit, so held_delta must be polled every tick until it fires.
+    bool needs_drain(uint32_t pending_bits) const {
+        return (pending_bits & INBOX_TOPIC_METADATA) != 0 || this->held_delta.has_value();
+    }
     void drain_events();
     void handle_cleared_event() const;
     void cleanup();

--- a/src/platform/shadow_slot.h
+++ b/src/platform/shadow_slot.h
@@ -23,9 +23,15 @@
 
 namespace sendspin {
 
-/// @brief Thread-safe shadow slot for passing state between threads
-/// The writer (e.g., network thread) locks briefly to write or merge a value.
-/// The reader (e.g., main loop) locks briefly to move the value out if dirty.
+/// @brief Thread-safe shadow slot for passing state between a producer and a consumer thread,
+/// neither of which is the main loop
+///
+/// The writer thread locks briefly to write or merge a value; the reader thread locks briefly to
+/// move the value out if dirty. Remains the right primitive for producer/consumer pairs outside
+/// the main loop -- its one user today is the sync task's playback-progress slot (audio callback
+/// thread to sync task thread). State bound for the main loop instead goes through Inbox /
+/// InboxSlot (see inbox.h), which consolidates many such producers onto one shared mutex and a
+/// single lock-free poll() read per tick.
 template <typename T>
 class ShadowSlot {
 public:
@@ -60,24 +66,6 @@ public:
     bool take(T& out) {
         std::lock_guard<std::mutex> lock(this->mutex_);
         if (!this->dirty_) {
-            return false;
-        }
-        out = std::move(this->slot_);
-        this->slot_ = T{};
-        this->dirty_ = false;
-        return true;
-    }
-
-    /// @brief Move the accumulated value out if dirty and the predicate accepts it
-    /// @param[out] out Receives the stored value if taken.
-    /// @param pred Callable invoked as `bool(const T&)` under the lock; the value is taken
-    /// only if it returns true. The value is left in place unchanged if the predicate returns
-    /// false, so a later call can re-check.
-    /// @return true if a value was taken, false if the slot was clean or the predicate rejected.
-    template <typename Predicate>
-    bool take_if(T& out, Predicate&& pred) {
-        std::lock_guard<std::mutex> lock(this->mutex_);
-        if (!this->dirty_ || !pred(static_cast<const T&>(this->slot_))) {
             return false;
         }
         out = std::move(this->slot_);

--- a/src/player_role_impl.h
+++ b/src/player_role_impl.h
@@ -72,6 +72,18 @@ struct PlayerRole::Impl {
     void handle_stream_clear() const;
     void handle_server_command(const ServerCommandMessage& cmd) const;
     void on_stream_ring_event(PlayerStreamCallbackType event);
+    // True if this tick has drainable player work. The command-slot bit covers server
+    // volume/mute/static-delay commands; the state-slot bit covers client-state updates from
+    // the sync task; a non-empty awaiting_sync_idle_events is a main-thread-only flag set by
+    // on_stream_ring_event() above during this tick's ring dispatch, or carried over from a
+    // prior tick while a STREAM_END waits for the sync task to go idle. stream_params_slot's
+    // own topic bit (INBOX_TOPIC_PLAYER_STREAM_PARAMS) needs no separate term here: it is only
+    // ever consumed from the STREAM_START branch while that event sits in
+    // awaiting_sync_idle_events, which the awaiting_sync_idle_events term above already covers.
+    bool needs_drain(uint32_t pending_bits) const {
+        return (pending_bits & (INBOX_TOPIC_PLAYER_COMMAND | INBOX_TOPIC_PLAYER_STATE)) != 0 ||
+               !this->awaiting_sync_idle_events.empty();
+    }
     void drain_events();
     void cleanup();
 


### PR DESCRIPTION
Part 6/6 of the inbox ITC refactor stack (based on #88; merge in order). The payoff PR: an idle `loop()` tick now performs zero mutex acquisitions.

- `SendspinClient::loop()` takes two lock-free `poll()` snapshots (one gating the event-ring drain, a second gating the role and group drains so writes landing mid-drain are not missed) and calls each role's `drain_events()` only when its `needs_drain()` says there is work: the role's topic bit, or a live main-thread flag for deadline-held deltas/displays and stream events awaiting sync-task idle.
- `ConnectionManager::loop()` gates its sections (pending events, nursery, hello retries, deferred releases, server tick) on atomic hints that mirror the containers, instead of taking `conn_mutex_`/`nursery_mutex_` every tick. The destructor drains the pending connected/disconnect event queues under the lock, keeping the "atomic mirrors container" invariant unconditional.
- `ShadowSlot::take_if` is deleted (deadline gating now lives in main-thread holds); `ShadowSlot` itself remains only for the sync task's playback-progress slot, and its docs plus CLAUDE.md now say so.

After this PR the tree is byte-identical to the original `inbox-refactor` branch.