### PR TITLE
Reimplement the visualizer role for the visualizer@v1 spec

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -132,7 +132,7 @@ vis_support.types = {
     VisualizerDataType::SPECTRUM,
     VisualizerDataType::PEAK,
 };
-vis_support.buffer_capacity = 8192;
+vis_support.buffer_capacity = 32768;  // Total ring buffer bytes; ~1/3 holds wire data
 vis_support.rate_max = 30;  // Set to the display refresh rate
 vis_support.spectrum = VisualizerSpectrumConfig{
     .n_disp_bins = 32,

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -121,7 +121,7 @@ The slot/channel number for each entry is its position (index) in `preferred_for
 
 ### Visualizer Role (Audio Visualization)
 
-Receives real-time beat, loudness, peak frequency, and spectrum data synchronized to playback.
+Receives real-time beat, loudness, peak frequency, onset, and spectrum data synchronized to playback.
 
 ```cpp
 VisualizerSupportObject vis_support;
@@ -130,15 +130,15 @@ vis_support.types = {
     VisualizerDataType::LOUDNESS,
     VisualizerDataType::F_PEAK,
     VisualizerDataType::SPECTRUM,
+    VisualizerDataType::PEAK,
 };
 vis_support.buffer_capacity = 8192;
-vis_support.batch_max = 4;
+vis_support.rate_max = 30;  // Set to the display refresh rate
 vis_support.spectrum = VisualizerSpectrumConfig{
     .n_disp_bins = 32,
     .scale = VisualizerSpectrumScale::MEL,
     .f_min = 40,
     .f_max = 16000,
-    .rate_max = 30,
 };
 
 auto& visualizer = client.add_visualizer({.support = vis_support});
@@ -298,17 +298,28 @@ struct MyArtworkListener : ArtworkRoleListener {
 
 ```cpp
 struct MyVisualizerListener : VisualizerRoleListener {
-    // THREAD SAFETY: Called from a dedicated drain thread. Copy data quickly
-    // and defer heavy processing.
-    void on_visualizer_frame(const VisualizerFrame& frame) override {
-        if (frame.loudness) update_vu_meter(*frame.loudness);
-        if (frame.peak_freq) update_peak_display(*frame.peak_freq);
-        if (!frame.spectrum.empty()) update_spectrum_bars(frame.spectrum);
+    // THREAD SAFETY: Data callbacks fire on a dedicated drain thread at each
+    // frame's display timestamp. Copy data quickly and defer heavy processing.
+    void on_loudness(int64_t client_timestamp, uint16_t loudness) override {
+        update_vu_meter(loudness);
     }
 
-    // Called from the drain thread on beat events.
-    void on_beat(int64_t client_timestamp) override {
-        trigger_beat_animation();
+    void on_f_peak(int64_t client_timestamp, uint16_t frequency_hz, uint16_t amplitude) override {
+        update_peak_display(frequency_hz, amplitude);
+    }
+
+    void on_spectrum(int64_t client_timestamp, const std::vector<uint16_t>& bins) override {
+        update_spectrum_bars(bins);
+    }
+
+    // Musical beat events; downbeat marks a bar start when the server tracks downbeats.
+    void on_beat(int64_t client_timestamp, bool downbeat) override {
+        trigger_beat_animation(downbeat);
+    }
+
+    // Energy onset (transient) events, independent of musical timing.
+    void on_peak(int64_t client_timestamp, uint8_t strength) override {
+        trigger_flash(strength);
     }
 
     // Called from the main loop thread.
@@ -582,8 +593,7 @@ Most listener callbacks fire on the main loop thread (the thread calling `client
 | `PlayerRoleListener::on_audio_write()` | Sync task background thread |
 | `ArtworkRoleListener::on_image_decode()` | Dedicated artwork decode thread |
 | `ArtworkRoleListener::on_image_display()` | Main loop thread |
-| `VisualizerRoleListener::on_visualizer_frame()` | Dedicated visualizer drain thread |
-| `VisualizerRoleListener::on_beat()` | Dedicated visualizer drain thread |
+| `VisualizerRoleListener` data callbacks (`on_loudness()`, `on_beat()`, `on_f_peak()`, `on_spectrum()`, `on_peak()`) | Dedicated visualizer drain thread |
 | All other listener methods | Main loop thread |
 
 `PlayerRole::notify_audio_played()` is thread-safe and is designed to be called from an audio output callback thread.
@@ -774,9 +784,9 @@ Configuration passed to `client.add_visualizer()`.
 
 | Field | Type | Description |
 |---|---|---|
-| `types` | `std::vector<VisualizerDataType>` | Data stream types to receive (`BEAT`, `LOUDNESS`, `F_PEAK`, `SPECTRUM`) |
-| `buffer_capacity` | `size_t` | Internal buffer size for incoming visualizer frames |
-| `batch_max` | `uint8_t` | Maximum number of frames to process per drain cycle |
+| `types` | `std::vector<VisualizerDataType>` | Data stream types to receive (`BEAT`, `LOUDNESS`, `F_PEAK`, `SPECTRUM`, `PEAK`) |
+| `buffer_capacity` | `size_t` | Max total size in bytes of buffered visualizer messages, counting each message's full wire size |
+| `rate_max` | `uint16_t` | Maximum periodic frames per second; set to the display refresh rate |
 | `spectrum` | `std::optional<VisualizerSpectrumConfig>` | Spectrum analysis parameters; required when `SPECTRUM` is in `types` |
 
 `VisualizerSpectrumConfig` fields:
@@ -787,7 +797,6 @@ Configuration passed to `client.add_visualizer()`.
 | `scale` | `VisualizerSpectrumScale` | Frequency scale (`MEL`, `LOG`, or `LIN`) |
 | `f_min` | `uint16_t` | Minimum frequency in Hz |
 | `f_max` | `uint16_t` | Maximum frequency in Hz |
-| `rate_max` | `uint16_t` | Maximum spectrum update rate in Hz |
 
 ---
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -785,7 +785,7 @@ Configuration passed to `client.add_visualizer()`.
 | Field | Type | Description |
 |---|---|---|
 | `types` | `std::vector<VisualizerDataType>` | Data stream types to receive (`BEAT`, `LOUDNESS`, `F_PEAK`, `SPECTRUM`, `PEAK`) |
-| `buffer_capacity` | `size_t` | Max total size in bytes of buffered visualizer messages, counting each message's full wire size |
+| `buffer_capacity` | `size_t` | Total RAM budget in bytes for the internal ring buffer. Per-entry overhead means only ~1/3 holds wire data; the client advertises that effective capacity to the server |
 | `rate_max` | `uint16_t` | Maximum periodic frames per second; set to the display refresh rate |
 | `spectrum` | `std::optional<VisualizerSpectrumConfig>` | Spectrum analysis parameters; required when `SPECTRUM` is in `types` |
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -50,7 +50,7 @@ On host builds, `platform_configure_thread()` is a no-op; threads use OS default
 3. The thread runs a persistent outer loop for the lifetime of the client.
 4. `SyncTask::stop()` sets `COMMAND_STOP` and joins the thread. Called from `SyncTask`'s destructor, which is triggered by `sync_task_.reset()` in `PlayerRole::Impl`'s destructor.
 
-**Visualizer drain** (`src/visualizer_role.cpp:120`):
+**Visualizer drain** (`src/visualizer_role.cpp`):
 
 1. `VisualizerRole::Impl::start()` spawns the drain thread.
 2. The thread blocks on ring buffer receives with a 50 ms timeout.
@@ -137,14 +137,14 @@ Single-producer/single-consumer ring buffer for variable-size binary data. Two-p
 Used for:
 
 - **Encoded audio**: Via the `SendspinAudioRingBuffer` wrapper (which adds chunk headers and exposes `write_chunk` / `receive_chunk` / `return_chunk`). Network thread writes chunks; sync task reads and decodes them.
-- **Visualizer frames**: Used directly. Network thread writes frame/beat entries; drain thread reads them at the correct playback time.
+- **Visualizer frames**: Used directly. Network thread writes one entry per visualizer binary message; drain thread reads them at the correct playback time.
 
 ### Other Primitives
 
 - **`std::mutex`** on `ConnectionManager::conn_mutex_`: protects deferred connection event vectors.
 - **`std::mutex`** on `SendspinTimeFilter::state_mutex_`: protects Kalman filter state (offset, drift, covariance).
 - **`std::atomic<bool>`** on `SendspinConnection::message_dispatch_enabled_`: allows the main loop to instantly suppress message delivery from the network thread.
-- **`std::atomic<bool/uint8_t/size_t>`** on `VisualizerRole::Impl`: network thread writes stream config atomically; drain thread reads it.
+- **`std::atomic<bool/uint8_t>`** on `VisualizerRole::Impl`: network thread writes stream config atomically; drain thread reads it.
 - **`std::atomic<bool>`** on `ArtworkRole::Impl::stream_active`: guards `handle_binary()` from writing when no stream is active.
 - **`std::atomic<uint8_t>`** on `ArtworkRole::Impl::SlotBuffer::write_idx`: tracks which of two double-buffers the network thread writes to next.
 - **`std::atomic<bool>`** on `ArtworkRole::Impl::SlotBuffer::drain_active`: set by the decode thread while decoding, checked by the network thread to avoid overwriting an in-use buffer.
@@ -197,7 +197,7 @@ The bump arena suits ArduinoJson's allocation pattern: during a parse the varian
 |-------------|---------|
 | Player audio | `PlayerRole::Impl::handle_binary()`: writes to encoded audio ring buffer |
 | Artwork image | `ArtworkRole::Impl::handle_binary()`: copies image data to a per-slot double buffer and enqueues a notification for the artwork decode thread |
-| Visualizer frame/beat | `VisualizerRole::Impl::handle_binary()`: writes to visualizer ring buffer |
+| Visualizer data (binary types 16-20) | `VisualizerRole::Impl::handle_binary()`: writes to visualizer ring buffer |
 
 ### Main Loop Processing
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -84,7 +84,7 @@ TASK_ERROR           (1 << 11)  Allocation or decode failure
 TASK_IDLE            (1 << 12)  Waiting for work
 ```
 
-The sync task, visualizer drain thread, and artwork decode thread all use event flags for command signaling from the main loop and status reporting back. The artwork decode thread and visualizer drain thread use a simpler subset: `COMMAND_STOP` and `COMMAND_FLUSH`.
+The sync task, visualizer drain thread, and artwork decode thread all use event flags for command signaling from the main loop and status reporting back. The artwork decode thread uses a simpler subset: `COMMAND_STOP` and `COMMAND_FLUSH`. The visualizer drain thread adds `COMMAND_CLEAR`, which discards buffered entries up to a 1-byte marker the network thread enqueues on `stream/start` and `stream/clear` (mirroring the sync task's clear-marker chunk) so frames received after the boundary survive; its `COMMAND_FLUSH` (drain to empty) is only used when the producer is already stopped (`stream/end`, cleanup).
 
 ### ThreadSafeQueue (`src/platform/thread_safe_queue.h`)
 

--- a/examples/tui_client/main.cpp
+++ b/examples/tui_client/main.cpp
@@ -534,15 +534,15 @@ int main(int argc, char* argv[]) {
     if (enable_visualizer) {
         VisualizerSupportObject vis;
         vis.types = {VisualizerDataType::BEAT, VisualizerDataType::LOUDNESS,
-                     VisualizerDataType::F_PEAK, VisualizerDataType::SPECTRUM};
+                     VisualizerDataType::F_PEAK, VisualizerDataType::SPECTRUM,
+                     VisualizerDataType::PEAK};
         vis.buffer_capacity = 8192;
-        vis.batch_max = 4;
+        vis.rate_max = 30;
         vis.spectrum = VisualizerSpectrumConfig{
             .n_disp_bins = 32,
             .scale = VisualizerSpectrumScale::MEL,
             .f_min = 40,
             .f_max = 16000,
-            .rate_max = 30,
         };
         vis_role = &client.add_visualizer(VisualizerRoleConfig{.support = vis});
     }
@@ -689,20 +689,31 @@ int main(int argc, char* argv[]) {
             state.vis_beat = false;
         }
 
-        void on_visualizer_frame(const VisualizerFrame& frame) override {
+        void on_loudness(int64_t /*client_timestamp*/, uint16_t loudness) override {
             std::lock_guard<std::mutex> lock(state.mutex);
-            if (frame.loudness.has_value()) {
-                state.vis_loudness = *frame.loudness;
-            }
-            if (frame.peak_freq.has_value()) {
-                state.vis_peak_freq = *frame.peak_freq;
-            }
-            if (!frame.spectrum.empty()) {
-                state.vis_spectrum = frame.spectrum;
-            }
+            state.vis_loudness = loudness;
         }
 
-        void on_beat(int64_t /*client_timestamp*/) override {
+        void on_f_peak(int64_t /*client_timestamp*/, uint16_t frequency_hz,
+                       uint16_t /*amplitude*/) override {
+            std::lock_guard<std::mutex> lock(state.mutex);
+            state.vis_peak_freq = frequency_hz;
+        }
+
+        void on_spectrum(int64_t /*client_timestamp*/,
+                         const std::vector<uint16_t>& bins) override {
+            std::lock_guard<std::mutex> lock(state.mutex);
+            state.vis_spectrum = bins;
+        }
+
+        void on_beat(int64_t /*client_timestamp*/, bool /*downbeat*/) override {
+            std::lock_guard<std::mutex> lock(state.mutex);
+            int64_t current_us = now_us();
+            state.vis_beat = true;
+            state.vis_beat_expire_us = current_us + 100000;  // 100ms flash
+        }
+
+        void on_peak(int64_t /*client_timestamp*/, uint8_t /*strength*/) override {
             std::lock_guard<std::mutex> lock(state.mutex);
             int64_t current_us = now_us();
             state.vis_beat = true;

--- a/examples/tui_client/main.cpp
+++ b/examples/tui_client/main.cpp
@@ -530,6 +530,7 @@ int main(int argc, char* argv[]) {
     (void)controller;
 
     // Visualizer support (disabled with -V flag)
+#ifdef SENDSPIN_ENABLE_VISUALIZER
     VisualizerRole* vis_role = nullptr;
     if (enable_visualizer) {
         VisualizerSupportObject vis;
@@ -546,6 +547,9 @@ int main(int argc, char* argv[]) {
         };
         vis_role = &client.add_visualizer(VisualizerRoleConfig{.support = vis});
     }
+#else
+    (void)enable_visualizer;
+#endif
 
     // --- Listener implementations ---
 
@@ -654,6 +658,7 @@ int main(int argc, char* argv[]) {
         }
     };
 
+#ifdef SENDSPIN_ENABLE_VISUALIZER
     struct TuiVisualizerListener : VisualizerRoleListener {
         TuiState& state;
         explicit TuiVisualizerListener(TuiState& s) : state(s) {}
@@ -720,6 +725,7 @@ int main(int argc, char* argv[]) {
             state.vis_beat_expire_us = current_us + 100000;  // 100ms flash
         }
     };
+#endif
 
     struct HostNetworkProvider : SendspinNetworkProvider {
         bool is_network_ready() override { return true; }
@@ -739,16 +745,20 @@ int main(int argc, char* argv[]) {
 #endif
     TuiMetadataListener metadata_listener(state);
     TuiClientListener client_listener(state);
+#ifdef SENDSPIN_ENABLE_VISUALIZER
     TuiVisualizerListener visualizer_listener(state);
+#endif
     HostNetworkProvider network_provider;
 
     player.set_listener(&player_listener);
     metadata.set_listener(&metadata_listener);
     client.set_listener(&client_listener);
     client.set_network_provider(&network_provider);
+#ifdef SENDSPIN_ENABLE_VISUALIZER
     if (vis_role) {
         vis_role->set_listener(&visualizer_listener);
     }
+#endif
 
     // Start the server
     if (!client.start_server()) {

--- a/examples/tui_client/main.cpp
+++ b/examples/tui_client/main.cpp
@@ -537,7 +537,7 @@ int main(int argc, char* argv[]) {
         vis.types = {VisualizerDataType::BEAT, VisualizerDataType::LOUDNESS,
                      VisualizerDataType::F_PEAK, VisualizerDataType::SPECTRUM,
                      VisualizerDataType::PEAK};
-        vis.buffer_capacity = 8192;
+        vis.buffer_capacity = 32768;
         vis.rate_max = 30;
         vis.spectrum = VisualizerSpectrumConfig{
             .n_disp_bins = 32,

--- a/examples/tui_client/main.cpp
+++ b/examples/tui_client/main.cpp
@@ -682,6 +682,7 @@ int main(int argc, char* argv[]) {
             std::fill(state.vis_display_spectrum.begin(), state.vis_display_spectrum.end(), 0.0f);
             state.vis_display_loudness = 0.0f;
             state.vis_beat = false;
+            state.vis_peak = false;
         }
 
         void on_visualizer_stream_clear() override {
@@ -692,6 +693,7 @@ int main(int argc, char* argv[]) {
             std::fill(state.vis_display_spectrum.begin(), state.vis_display_spectrum.end(), 0.0f);
             state.vis_display_loudness = 0.0f;
             state.vis_beat = false;
+            state.vis_peak = false;
         }
 
         void on_loudness(int64_t /*client_timestamp*/, uint16_t loudness) override {
@@ -721,8 +723,8 @@ int main(int argc, char* argv[]) {
         void on_peak(int64_t /*client_timestamp*/, uint8_t /*strength*/) override {
             std::lock_guard<std::mutex> lock(state.mutex);
             int64_t current_us = now_us();
-            state.vis_beat = true;
-            state.vis_beat_expire_us = current_us + 100000;  // 100ms flash
+            state.vis_peak = true;
+            state.vis_peak_expire_us = current_us + 100000;  // 100ms flash
         }
     };
 #endif
@@ -859,9 +861,12 @@ int main(int argc, char* argv[]) {
                     state.vis_display_loudness = current + alpha * (target - current);
                 }
 
-                // Expire beat flash
+                // Expire beat and peak flashes
                 if (state.vis_beat && current_us >= state.vis_beat_expire_us) {
                     state.vis_beat = false;
+                }
+                if (state.vis_peak && current_us >= state.vis_peak_expire_us) {
+                    state.vis_peak = false;
                 }
             }
 

--- a/examples/tui_client/tui.cpp
+++ b/examples/tui_client/tui.cpp
@@ -70,6 +70,7 @@ struct TuiSnapshot {
     std::vector<float> vis_display_spectrum;
     float vis_display_loudness{0.0f};
     bool vis_beat{false};
+    bool vis_peak{false};
 };
 
 static TuiSnapshot take_snapshot(TuiState& state) {
@@ -113,6 +114,7 @@ static TuiSnapshot take_snapshot(TuiState& state) {
     snap.vis_display_spectrum = state.vis_display_spectrum;
     snap.vis_display_loudness = state.vis_display_loudness;
     snap.vis_beat = state.vis_beat;
+    snap.vis_peak = state.vis_peak;
     return snap;
 }
 
@@ -503,25 +505,25 @@ static Element render_visualizer(const TuiSnapshot& snap) {
         text(" " + std::to_string(static_cast<int>(loudness_pct * 100)) + "% "),
     });
 
-    // Peak frequency
+    // Dominant frequency (f_peak). Labeled "Freq" to avoid confusion with the onset
+    // "Peak" blinker below, which is the separate `peak` energy-onset visualizer type.
     auto peak_row = hbox({
-        text("  Peak:     ") | bold,
+        text("  Freq:     ") | bold,
         text(std::to_string(snap.vis_peak_freq) + " Hz"),
     });
 
-    // Beat indicator
-    Element beat_elem;
-    if (snap.vis_beat) {
-        beat_elem = hbox({
-            text("  "),
-            text("\xe2\x97\x8f Beat") | bold | color(Color::Yellow),
-        });
-    } else {
-        beat_elem = hbox({
-            text("  "),
-            text("\xe2\x97\x8b Beat") | dim,
-        });
-    }
+    // Beat (musical pulse) on the far left, energy-onset peak blinker on the far right.
+    Element beat_label = snap.vis_beat ? text("\xe2\x97\x8f Beat") | bold | color(Color::Yellow)
+                                       : text("\xe2\x97\x8b Beat") | dim;
+    Element peak_label = snap.vis_peak ? text("Peak \xe2\x97\x8f") | bold | color(Color::Red)
+                                       : text("Peak \xe2\x97\x8b") | dim;
+    auto beat_elem = hbox({
+        text("  "),
+        beat_label,
+        filler(),
+        peak_label,
+        text("  "),
+    });
 
     auto info_panel = window(text(" Analysis ") | bold, vbox({
         loudness_row,

--- a/examples/tui_client/tui.h
+++ b/examples/tui_client/tui.h
@@ -98,6 +98,8 @@ struct TuiState {
     float vis_display_loudness{0.0f};            // smoothed loudness for display
     bool vis_beat{false};
     int64_t vis_beat_expire_us{0};
+    bool vis_peak{false};         // energy-onset (peak) blinker
+    int64_t vis_peak_expire_us{0};
 
     // Tab state
     bool show_visualizer{false};

--- a/include/sendspin/config.h
+++ b/include/sendspin/config.h
@@ -200,10 +200,11 @@ struct ArtworkRoleConfig {
 
 /// @brief Visualizer data stream types
 enum class VisualizerDataType : uint8_t {
-    BEAT,      // Beat detection events
+    BEAT,      // Musical beat events from tempo/beat tracking
     LOUDNESS,  // Overall loudness level
-    F_PEAK,    // Peak frequency
+    F_PEAK,    // Dominant frequency and amplitude
     SPECTRUM,  // Full frequency spectrum bins
+    PEAK,      // Energy onset (transient) events
 };
 
 /// @brief Frequency scale used for spectrum visualization bins
@@ -213,24 +214,25 @@ enum class VisualizerSpectrumScale : uint8_t {
     LIN,  // Linear scale
 };
 
-/// @brief Spectrum visualization parameters: bin count, frequency range, scale, and rate cap
+/// @brief Spectrum visualization parameters: bin count, frequency range, and scale
 struct VisualizerSpectrumConfig {
     uint8_t n_disp_bins;
     VisualizerSpectrumScale scale;
     uint16_t f_min;
     uint16_t f_max;
-    uint16_t rate_max;
 };
 
 /// @brief Visualizer capabilities advertised to the server during the hello handshake
 struct VisualizerSupportObject {
-    /// @brief Data types the client wants to receive.
-    /// The order here does not need to match the wire order: VisualizerRole normalizes this
-    /// list internally to LOUDNESS, F_PEAK, SPECTRUM, then BEAT (duplicates removed) before it
-    /// is sent, so the server always packs per-frame fields in the order the client parses them.
+    /// @brief Data types the client wants to receive
     std::vector<VisualizerDataType> types{};
+    /// @brief Max total size in bytes of buffered visualizer binary messages, counting each
+    /// message's full wire size (message-type byte + timestamp + data)
     size_t buffer_capacity{};
-    uint8_t batch_max{};
+    /// @brief Maximum periodic visualization frames per second (applies to LOUDNESS, F_PEAK,
+    /// SPECTRUM). Event types (BEAT, PEAK) are not throttled. Set to the display refresh rate
+    uint16_t rate_max{};
+    /// @brief Spectrum configuration, required if types includes SPECTRUM
     std::optional<VisualizerSpectrumConfig> spectrum;
 };
 

--- a/include/sendspin/config.h
+++ b/include/sendspin/config.h
@@ -228,10 +228,12 @@ struct VisualizerSpectrumConfig {
 struct VisualizerSupportObject {
     /// @brief Data types the client wants to receive
     std::vector<VisualizerDataType> types{};
-    /// @brief Max total size in bytes of buffered visualizer binary messages, counting each
-    /// message's full wire size (message-type byte + timestamp + data). This is also the total
-    /// RAM budget for the internal ring buffer; because each entry carries per-entry overhead,
-    /// roughly a third of it holds actual wire data
+    /// @brief Total RAM budget in bytes for the internal ring buffer (the exact allocation size).
+    /// This is not the amount of wire data that fits: each entry stores its full wire message
+    /// (message-type byte + timestamp + data) plus an aligned per-entry ItemHeader, so for the
+    /// small visualizer entries only roughly a third of this budget holds actual wire data. The
+    /// client advertises that effective (~1/3) capacity to the server, not this raw budget, so the
+    /// server's flow control does not overrun the ring
     size_t buffer_capacity{};
     /// @brief Maximum periodic visualization frames per second (applies to LOUDNESS, F_PEAK,
     /// SPECTRUM). Event types (BEAT, PEAK) are not throttled. Set to the display refresh rate

--- a/include/sendspin/config.h
+++ b/include/sendspin/config.h
@@ -216,6 +216,8 @@ enum class VisualizerSpectrumScale : uint8_t {
 
 /// @brief Spectrum visualization parameters: bin count, frequency range, and scale
 struct VisualizerSpectrumConfig {
+    /// @brief Number of display bins (bars on a graphical equalizer). Capped at 255 by the
+    /// uint8_t width; typical equalizer bin counts are well below this
     uint8_t n_disp_bins;
     VisualizerSpectrumScale scale;
     uint16_t f_min;
@@ -227,7 +229,9 @@ struct VisualizerSupportObject {
     /// @brief Data types the client wants to receive
     std::vector<VisualizerDataType> types{};
     /// @brief Max total size in bytes of buffered visualizer binary messages, counting each
-    /// message's full wire size (message-type byte + timestamp + data)
+    /// message's full wire size (message-type byte + timestamp + data). This is also the total
+    /// RAM budget for the internal ring buffer; because each entry carries per-entry overhead,
+    /// roughly a third of it holds actual wire data
     size_t buffer_capacity{};
     /// @brief Maximum periodic visualization frames per second (applies to LOUDNESS, F_PEAK,
     /// SPECTRUM). Event types (BEAT, PEAK) are not throttled. Set to the display refresh rate

--- a/include/sendspin/visualizer_role.h
+++ b/include/sendspin/visualizer_role.h
@@ -34,36 +34,66 @@ class SendspinClient;
 
 /// @brief Visualizer stream parameters sent by the server in stream/start messages
 struct ServerVisualizerStreamObject {
+    /// @brief Data types the server will stream
     std::vector<VisualizerDataType> types{};
-    uint8_t batch_max{};
+    /// @brief Periodic frames per second the server will emit
+    uint16_t rate_max{};
+    /// @brief True if the server's beat tracker also identifies bar starts (downbeats).
+    /// Only meaningful when types includes BEAT
+    bool tracks_downbeats{false};
+    /// @brief Spectrum configuration, present when types includes SPECTRUM
     std::optional<VisualizerSpectrumConfig> spectrum;
 };
 
-/// @brief A parsed visualizer frame with client-domain timestamp
-struct VisualizerFrame {
-    int64_t timestamp{};  ///< Client timestamp in microseconds
-    std::optional<uint16_t> loudness;
-    std::optional<uint16_t> peak_freq;
-    std::vector<uint16_t> spectrum{};
+/// @brief Format change request sent to the server via stream/request-format.
+/// All fields are optional; omitted fields keep their current value on the server
+struct VisualizerFormatRequest {
+    std::optional<std::vector<VisualizerDataType>> types;
+    std::optional<uint16_t> rate_max;
+    std::optional<VisualizerSpectrumConfig> spectrum;
 };
 
 /// @brief Listener for visualizer role events
 ///
-/// THREAD SAFETY: on_visualizer_frame() and on_beat() fire on a dedicated drain thread.
-/// Implementations must be thread-safe for these two methods (copy data quickly, defer heavy
-/// processing). on_visualizer_stream_start/end/clear fire on the main loop thread.
+/// Data values (loudness, spectrum bins, f_peak amplitude) use the full uint16 range
+/// 0-65535, where 0 = silence (-60 dB) and 65535 = full scale (0 dB), A-weighted and
+/// mapped linearly in dB across that range.
+///
+/// THREAD SAFETY: the per-type data callbacks (on_loudness, on_beat, on_f_peak,
+/// on_spectrum, on_peak) fire on a dedicated drain thread at each frame's display
+/// timestamp. Implementations must be thread-safe for these methods (copy data quickly,
+/// defer heavy processing). on_visualizer_stream_start/end/clear fire on the main loop
+/// thread.
 class VisualizerRoleListener {
 public:
     virtual ~VisualizerRoleListener() = default;
 
-    /// @brief Called with a parsed visualizer frame at the correct playback timestamp
-    /// Fires on the drain thread.
-    virtual void on_visualizer_frame(const VisualizerFrame& /*frame*/) {}
+    /// @brief Called with an overall A-weighted loudness value. Fires on the drain thread
+    virtual void on_loudness(int64_t /*client_timestamp*/, uint16_t /*loudness*/) {}
 
-    /// @brief Called on beat events. Fires on the drain thread
-    virtual void on_beat(int64_t /*client_timestamp*/) {}
+    /// @brief Called on musical beat events. Fires on the drain thread
+    /// @param downbeat True if this beat is a bar start; always false unless the stream
+    ///                 was started with tracks_downbeats
+    virtual void on_beat(int64_t /*client_timestamp*/, bool /*downbeat*/) {}
 
-    /// @brief Called when a visualizer stream starts. Fires on the main loop thread
+    /// @brief Called with the dominant FFT frequency. Fires on the drain thread
+    /// @param frequency_hz Dominant frequency in Hz (0 = no peak detected)
+    /// @param amplitude Amplitude of the dominant frequency (0 when no peak detected)
+    virtual void on_f_peak(int64_t /*client_timestamp*/, uint16_t /*frequency_hz*/,
+                           uint16_t /*amplitude*/) {}
+
+    /// @brief Called with spectrum magnitudes per display bin, low to high frequency.
+    /// Fires on the drain thread
+    /// @note The vector is reused across calls; copy it if it must outlive the callback
+    virtual void on_spectrum(int64_t /*client_timestamp*/, const std::vector<uint16_t>& /*bins*/) {}
+
+    /// @brief Called on energy onset (transient) events, independent of musical timing.
+    /// Fires on the drain thread
+    /// @param strength Onset strength 0-255 for scaling flash intensity
+    virtual void on_peak(int64_t /*client_timestamp*/, uint8_t /*strength*/) {}
+
+    /// @brief Called when a visualizer stream starts or its configuration changes.
+    /// Fires on the main loop thread
     virtual void on_visualizer_stream_start(const ServerVisualizerStreamObject& /*stream*/) {}
 
     /// @brief Called when a visualizer stream ends. Fires on the main loop thread
@@ -76,24 +106,25 @@ public:
 /**
  * @brief Visualizer role that receives real-time audio visualization data from the server
  *
- * Receives timestamped spectrum, loudness, peak frequency, and beat data from the server
- * and delivers frames to the platform through VisualizerRoleListener callbacks at the
- * correct playback timestamp. A dedicated drain thread handles timing and delivery of
- * data callbacks; lifecycle callbacks fire on the main loop thread.
+ * Receives timestamped loudness, beat, dominant-frequency, spectrum, and onset data from
+ * the server and delivers each datum to the platform through VisualizerRoleListener
+ * callbacks at the correct playback timestamp. A dedicated drain thread handles timing and
+ * delivery of data callbacks; lifecycle callbacks fire on the main loop thread.
  *
  * Usage:
- * 1. Implement VisualizerRoleListener with on_visualizer_frame() and/or on_beat()
- * 2. Build a VisualizerSupportObject describing supported data types and buffer capacity
+ * 1. Implement VisualizerRoleListener with the data callbacks you need
+ * 2. Build a VisualizerSupportObject describing supported data types, buffer capacity,
+ *    and frame rate cap
  * 3. Add the role to the client via SendspinClient::add_visualizer()
  * 4. Call set_listener() with your listener implementation
  *
  * @code
  * struct MyVisualizerListener : VisualizerRoleListener {
- *     void on_visualizer_frame(const VisualizerFrame& frame) override {
- *         display.update_spectrum(frame.spectrum);
+ *     void on_spectrum(int64_t client_timestamp, const std::vector<uint16_t>& bins) override {
+ *         display.update_spectrum(bins);
  *     }
- *     void on_beat(int64_t client_timestamp) override {
- *         display.flash_beat();
+ *     void on_beat(int64_t client_timestamp, bool downbeat) override {
+ *         display.flash_beat(downbeat);
  *     }
  * };
  *
@@ -101,7 +132,13 @@ public:
  * VisualizerRoleConfig config;
  * config.support.types = {VisualizerDataType::SPECTRUM, VisualizerDataType::BEAT};
  * config.support.buffer_capacity = 4096;
- * config.support.batch_max = 4;
+ * config.support.rate_max = 30;
+ * config.support.spectrum = VisualizerSpectrumConfig{
+ *     .n_disp_bins = 32,
+ *     .scale = VisualizerSpectrumScale::MEL,
+ *     .f_min = 40,
+ *     .f_max = 16000,
+ * };
  * auto& visualizer = client.add_visualizer(config);
  * visualizer.set_listener(&listener);
  * @endcode
@@ -118,6 +155,13 @@ public:
     /// @brief Sets the listener for visualizer events
     /// @note The listener must outlive this role
     void set_listener(VisualizerRoleListener* listener);
+
+    /// @brief Requests a different stream format from the server via stream/request-format
+    ///
+    /// If a visualizer stream is active, the server responds with a stream/start carrying
+    /// the new configuration; otherwise it remembers the request for the next stream.
+    /// @param request Fields to change; omitted fields keep their current value
+    void request_format(const VisualizerFormatRequest& request);
 
 private:
     std::unique_ptr<Impl> impl_;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -903,6 +903,18 @@ SS_HOT void SendspinClient::process_binary_message(const uint8_t* payload, size_
     const uint8_t* data = payload + 1;
     size_t data_len = len - 1;
 
+    // The visualizer role has an expanded 8-slot allocation (IDs 16-23), so it is
+    // dispatched by ID range before the standard 4-slot role decoding below
+    if (binary_type >= SENDSPIN_BINARY_VISUALIZER_FIRST &&
+        binary_type <= SENDSPIN_BINARY_VISUALIZER_LAST) {
+#ifdef SENDSPIN_ENABLE_VISUALIZER
+        if (this->visualizer_) {
+            this->visualizer_->impl_->handle_binary(binary_type, data, data_len);
+        }
+#endif
+        return;
+    }
+
     switch (role) {
         case SENDSPIN_ROLE_PLAYER: {
 #ifdef SENDSPIN_ENABLE_PLAYER
@@ -920,14 +932,6 @@ SS_HOT void SendspinClient::process_binary_message(const uint8_t* payload, size_
 #ifdef SENDSPIN_ENABLE_ARTWORK
             if (this->artwork_) {
                 this->artwork_->impl_->handle_binary(slot, data, data_len);
-            }
-#endif
-            break;
-        }
-        case SENDSPIN_ROLE_VISUALIZER: {
-#ifdef SENDSPIN_ENABLE_VISUALIZER
-            if (this->visualizer_) {
-                this->visualizer_->impl_->handle_binary(binary_type, data, data_len);
             }
 #endif
             break;

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -660,8 +660,8 @@ bool process_stream_start_message(JsonObject root, StreamStartMessage* stream_ms
             vis_obj.rate_max = *v;
         }
 
-        if (vis_json["tracks_downbeats"].is<bool>()) {
-            vis_obj.tracks_downbeats = vis_json["tracks_downbeats"].as<bool>();
+        if (auto v = read_bool_field(vis_json["tracks_downbeats"], "tracks_downbeats")) {
+            vis_obj.tracks_downbeats = *v;
         }
 
         // Parse spectrum config if present. Every field is required by the spec; if any is

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -664,30 +664,24 @@ bool process_stream_start_message(JsonObject root, StreamStartMessage* stream_ms
             vis_obj.tracks_downbeats = vis_json["tracks_downbeats"].as<bool>();
         }
 
-        // Parse spectrum config if present
+        // Parse spectrum config if present. Every field is required by the spec; if any is
+        // absent or malformed, leave the config unset so the SPECTRUM validation below rejects
+        // the stream rather than acting on a fabricated default.
         if (vis_json["spectrum"].is<JsonObject>()) {
             JsonObject spec_json = vis_json["spectrum"];
-            VisualizerSpectrumConfig spec_cfg{};
-            if (auto v = read_uint_field<uint8_t>(spec_json["n_disp_bins"], "n_disp_bins", 1)) {
-                spec_cfg.n_disp_bins = *v;
+            auto n_disp_bins = read_uint_field<uint8_t>(spec_json["n_disp_bins"], "n_disp_bins", 1);
+            auto scale =
+                read_enum_field(spec_json["scale"], "scale", visualizer_spectrum_scale_from_string);
+            auto f_min = read_uint_field<uint16_t>(spec_json["f_min"], "f_min");
+            auto f_max = read_uint_field<uint16_t>(spec_json["f_max"], "f_max");
+            if (n_disp_bins && scale && f_min && f_max) {
+                vis_obj.spectrum = VisualizerSpectrumConfig{*n_disp_bins, *scale, *f_min, *f_max};
             }
-            // Absent or unknown scale falls back to MEL (read_enum_field warns on an unknown
-            // value; an absent field is silent).
-            spec_cfg.scale =
-                read_enum_field(spec_json["scale"], "scale", visualizer_spectrum_scale_from_string)
-                    .value_or(VisualizerSpectrumScale::MEL);
-            if (auto v = read_uint_field<uint16_t>(spec_json["f_min"], "f_min")) {
-                spec_cfg.f_min = *v;
-            }
-            if (auto v = read_uint_field<uint16_t>(spec_json["f_max"], "f_max")) {
-                spec_cfg.f_max = *v;
-            }
-            vis_obj.spectrum = spec_cfg;
         }
 
-        // If SPECTRUM is advertised, a valid spectrum config with a non-zero bin count must be
-        // present; otherwise the expected size of binary spectrum messages is indeterminate
-        // and they could not be validated.
+        // If SPECTRUM is advertised, a fully valid spectrum config must be present; otherwise the
+        // expected size of binary spectrum messages is indeterminate and they could not be
+        // validated.
         bool advertises_spectrum = false;
         for (auto type : vis_obj.types) {
             if (type == VisualizerDataType::SPECTRUM) {
@@ -695,8 +689,7 @@ bool process_stream_start_message(JsonObject root, StreamStartMessage* stream_ms
                 break;
             }
         }
-        if (advertises_spectrum &&
-            (!vis_obj.spectrum.has_value() || vis_obj.spectrum->n_disp_bins == 0)) {
+        if (advertises_spectrum && !vis_obj.spectrum.has_value()) {
             SS_LOGE(TAG, "Invalid stream/start message: SPECTRUM advertised without valid spectrum "
                          "config");
             return false;

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -681,7 +681,8 @@ bool process_stream_start_message(JsonObject root, StreamStartMessage* stream_ms
 
         // If SPECTRUM is advertised, a fully valid spectrum config must be present; otherwise the
         // expected size of binary spectrum messages is indeterminate and they could not be
-        // validated.
+        // validated. The defect is local to the visualizer object, so drop only that object and
+        // let a well-formed player/artwork start in the same message go through.
         bool advertises_spectrum = false;
         for (auto type : vis_obj.types) {
             if (type == VisualizerDataType::SPECTRUM) {
@@ -690,12 +691,11 @@ bool process_stream_start_message(JsonObject root, StreamStartMessage* stream_ms
             }
         }
         if (advertises_spectrum && !vis_obj.spectrum.has_value()) {
-            SS_LOGE(TAG, "Invalid stream/start message: SPECTRUM advertised without valid spectrum "
-                         "config");
-            return false;
+            SS_LOGE(TAG, "Ignoring visualizer stream config: SPECTRUM advertised without valid "
+                         "spectrum config");
+        } else {
+            stream_msg->visualizer = std::move(vis_obj);
         }
-
-        stream_msg->visualizer = std::move(vis_obj);
     }
 
     return true;
@@ -810,6 +810,15 @@ void apply_color_state_deltas(ServerColorStateObject* current, const ServerColor
 
 // Message formatting
 
+// Writes a spectrum config as the "spectrum" key of a visualizer JSON object. Shared between
+// client/hello and stream/request-format so the two serializations cannot silently diverge.
+static void write_visualizer_spectrum(JsonObject vis_json, const VisualizerSpectrumConfig& spec) {
+    vis_json["spectrum"]["n_disp_bins"] = spec.n_disp_bins;
+    vis_json["spectrum"]["scale"] = to_cstr(spec.scale);
+    vis_json["spectrum"]["f_min"] = spec.f_min;
+    vis_json["spectrum"]["f_max"] = spec.f_max;
+}
+
 std::string format_client_hello_message(const ClientHelloMessage* msg) {
     JsonDocument doc = make_json_document();
     JsonObject root = doc.to<JsonObject>();
@@ -878,11 +887,7 @@ std::string format_client_hello_message(const ClientHelloMessage* msg) {
         vis_json["buffer_capacity"] = vis.buffer_capacity;
         vis_json["rate_max"] = vis.rate_max;
         if (vis.spectrum.has_value()) {
-            const auto& spec = vis.spectrum.value();
-            vis_json["spectrum"]["n_disp_bins"] = spec.n_disp_bins;
-            vis_json["spectrum"]["scale"] = to_cstr(spec.scale);
-            vis_json["spectrum"]["f_min"] = spec.f_min;
-            vis_json["spectrum"]["f_max"] = spec.f_max;
+            write_visualizer_spectrum(vis_json, vis.spectrum.value());
         }
     }
 
@@ -960,22 +965,23 @@ std::string format_stream_request_format_message(const StreamRequestFormatMessag
 
     if (msg->visualizer.has_value()) {
         const auto& vis = msg->visualizer.value();
-        JsonObject vis_json = root["payload"]["visualizer"].to<JsonObject>();
-        if (vis.types.has_value()) {
-            JsonArray types_list = vis_json["types"].to<JsonArray>();
-            for (const auto& type : vis.types.value()) {
-                types_list.add(to_cstr(type));
+        // Only create the "visualizer" key when at least one field is set: an all-empty request
+        // must emit no key at all, since a present-but-empty object could read as "reset to
+        // defaults" rather than "no change" on the server.
+        if (vis.types.has_value() || vis.rate_max.has_value() || vis.spectrum.has_value()) {
+            JsonObject vis_json = root["payload"]["visualizer"].to<JsonObject>();
+            if (vis.types.has_value()) {
+                JsonArray types_list = vis_json["types"].to<JsonArray>();
+                for (const auto& type : vis.types.value()) {
+                    types_list.add(to_cstr(type));
+                }
             }
-        }
-        if (vis.rate_max.has_value()) {
-            vis_json["rate_max"] = vis.rate_max.value();
-        }
-        if (vis.spectrum.has_value()) {
-            const auto& spec = vis.spectrum.value();
-            vis_json["spectrum"]["n_disp_bins"] = spec.n_disp_bins;
-            vis_json["spectrum"]["scale"] = to_cstr(spec.scale);
-            vis_json["spectrum"]["f_min"] = spec.f_min;
-            vis_json["spectrum"]["f_max"] = spec.f_max;
+            if (vis.rate_max.has_value()) {
+                vis_json["rate_max"] = vis.rate_max.value();
+            }
+            if (vis.spectrum.has_value()) {
+                write_visualizer_spectrum(vis_json, vis.spectrum.value());
+            }
         }
     }
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -649,19 +649,9 @@ bool process_stream_start_message(JsonObject root, StreamStartMessage* stream_ms
         if (vis_json["types"].is<JsonArray>()) {
             JsonArray types_array = vis_json["types"].as<JsonArray>();
             for (JsonVariant type_var : types_array) {
-                if (type_var.is<const char*>()) {
-                    std::string type_str = type_var.as<std::string>();
-                    if (type_str == "loudness") {
-                        vis_obj.types.push_back(VisualizerDataType::LOUDNESS);
-                    } else if (type_str == "f_peak") {
-                        vis_obj.types.push_back(VisualizerDataType::F_PEAK);
-                    } else if (type_str == "spectrum") {
-                        vis_obj.types.push_back(VisualizerDataType::SPECTRUM);
-                    } else if (type_str == "beat") {
-                        vis_obj.types.push_back(VisualizerDataType::BEAT);
-                    } else if (type_str == "peak") {
-                        vis_obj.types.push_back(VisualizerDataType::PEAK);
-                    }
+                if (auto type =
+                        read_enum_field(type_var, "types", visualizer_data_type_from_string)) {
+                    vis_obj.types.push_back(*type);
                 }
             }
         }
@@ -681,14 +671,11 @@ bool process_stream_start_message(JsonObject root, StreamStartMessage* stream_ms
             if (auto v = read_uint_field<uint8_t>(spec_json["n_disp_bins"], "n_disp_bins", 1)) {
                 spec_cfg.n_disp_bins = *v;
             }
-            std::string scale_str = spec_json["scale"].as<std::string>();
-            if (scale_str == "log") {
-                spec_cfg.scale = VisualizerSpectrumScale::LOG;
-            } else if (scale_str == "lin") {
-                spec_cfg.scale = VisualizerSpectrumScale::LIN;
-            } else {
-                spec_cfg.scale = VisualizerSpectrumScale::MEL;
-            }
+            // Absent or unknown scale falls back to MEL (read_enum_field warns on an unknown
+            // value; an absent field is silent).
+            spec_cfg.scale =
+                read_enum_field(spec_json["scale"], "scale", visualizer_spectrum_scale_from_string)
+                    .value_or(VisualizerSpectrumScale::MEL);
             if (auto v = read_uint_field<uint16_t>(spec_json["f_min"], "f_min")) {
                 spec_cfg.f_min = *v;
             }

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -659,13 +659,19 @@ bool process_stream_start_message(JsonObject root, StreamStartMessage* stream_ms
                         vis_obj.types.push_back(VisualizerDataType::SPECTRUM);
                     } else if (type_str == "beat") {
                         vis_obj.types.push_back(VisualizerDataType::BEAT);
+                    } else if (type_str == "peak") {
+                        vis_obj.types.push_back(VisualizerDataType::PEAK);
                     }
                 }
             }
         }
 
-        if (auto v = read_uint_field<uint8_t>(vis_json["batch_max"], "batch_max")) {
-            vis_obj.batch_max = *v;
+        if (auto v = read_uint_field<uint16_t>(vis_json["rate_max"], "rate_max")) {
+            vis_obj.rate_max = *v;
+        }
+
+        if (vis_json["tracks_downbeats"].is<bool>()) {
+            vis_obj.tracks_downbeats = vis_json["tracks_downbeats"].as<bool>();
         }
 
         // Parse spectrum config if present
@@ -689,15 +695,12 @@ bool process_stream_start_message(JsonObject root, StreamStartMessage* stream_ms
             if (auto v = read_uint_field<uint16_t>(spec_json["f_max"], "f_max")) {
                 spec_cfg.f_max = *v;
             }
-            if (auto v = read_uint_field<uint16_t>(spec_json["rate_max"], "rate_max")) {
-                spec_cfg.rate_max = *v;
-            }
             vis_obj.spectrum = spec_cfg;
         }
 
         // If SPECTRUM is advertised, a valid spectrum config with a non-zero bin count must be
-        // present; otherwise raw_frame_size is indeterminate and subsequent binary visualizer
-        // frames would misparse.
+        // present; otherwise the expected size of binary spectrum messages is indeterminate
+        // and they could not be validated.
         bool advertises_spectrum = false;
         for (auto type : vis_obj.types) {
             if (type == VisualizerDataType::SPECTRUM) {
@@ -887,22 +890,19 @@ std::string format_client_hello_message(const ClientHelloMessage* msg) {
 
     if (msg->visualizer_support.has_value()) {
         const auto& vis = msg->visualizer_support.value();
-        JsonArray types_list =
-            root["payload"]["visualizer@_draft_r1_support"]["types"].to<JsonArray>();
+        JsonObject vis_json = root["payload"]["visualizer@v1_support"].to<JsonObject>();
+        JsonArray types_list = vis_json["types"].to<JsonArray>();
         for (const auto& type : vis.types) {
             types_list.add(to_cstr(type));
         }
-        root["payload"]["visualizer@_draft_r1_support"]["buffer_capacity"] = vis.buffer_capacity;
-        root["payload"]["visualizer@_draft_r1_support"]["batch_max"] = vis.batch_max;
+        vis_json["buffer_capacity"] = vis.buffer_capacity;
+        vis_json["rate_max"] = vis.rate_max;
         if (vis.spectrum.has_value()) {
             const auto& spec = vis.spectrum.value();
-            root["payload"]["visualizer@_draft_r1_support"]["spectrum"]["n_disp_bins"] =
-                spec.n_disp_bins;
-            root["payload"]["visualizer@_draft_r1_support"]["spectrum"]["scale"] =
-                to_cstr(spec.scale);
-            root["payload"]["visualizer@_draft_r1_support"]["spectrum"]["f_min"] = spec.f_min;
-            root["payload"]["visualizer@_draft_r1_support"]["spectrum"]["f_max"] = spec.f_max;
-            root["payload"]["visualizer@_draft_r1_support"]["spectrum"]["rate_max"] = spec.rate_max;
+            vis_json["spectrum"]["n_disp_bins"] = spec.n_disp_bins;
+            vis_json["spectrum"]["scale"] = to_cstr(spec.scale);
+            vis_json["spectrum"]["f_min"] = spec.f_min;
+            vis_json["spectrum"]["f_max"] = spec.f_max;
         }
     }
 
@@ -975,6 +975,27 @@ std::string format_stream_request_format_message(const StreamRequestFormatMessag
         }
         if (artwork.media_height.has_value()) {
             root["payload"]["artwork"]["media_height"] = artwork.media_height.value();
+        }
+    }
+
+    if (msg->visualizer.has_value()) {
+        const auto& vis = msg->visualizer.value();
+        JsonObject vis_json = root["payload"]["visualizer"].to<JsonObject>();
+        if (vis.types.has_value()) {
+            JsonArray types_list = vis_json["types"].to<JsonArray>();
+            for (const auto& type : vis.types.value()) {
+                types_list.add(to_cstr(type));
+            }
+        }
+        if (vis.rate_max.has_value()) {
+            vis_json["rate_max"] = vis.rate_max.value();
+        }
+        if (vis.spectrum.has_value()) {
+            const auto& spec = vis.spectrum.value();
+            vis_json["spectrum"]["n_disp_bins"] = spec.n_disp_bins;
+            vis_json["spectrum"]["scale"] = to_cstr(spec.scale);
+            vis_json["spectrum"]["f_min"] = spec.f_min;
+            vis_json["spectrum"]["f_max"] = spec.f_max;
         }
     }
 

--- a/src/protocol_messages.h
+++ b/src/protocol_messages.h
@@ -521,6 +521,25 @@ inline const char* to_cstr(VisualizerDataType type) {
     }
 }
 
+inline std::optional<VisualizerDataType> visualizer_data_type_from_string(const std::string& str) {
+    if (str == "beat") {
+        return VisualizerDataType::BEAT;
+    }
+    if (str == "loudness") {
+        return VisualizerDataType::LOUDNESS;
+    }
+    if (str == "f_peak") {
+        return VisualizerDataType::F_PEAK;
+    }
+    if (str == "spectrum") {
+        return VisualizerDataType::SPECTRUM;
+    }
+    if (str == "peak") {
+        return VisualizerDataType::PEAK;
+    }
+    return std::nullopt;
+}
+
 inline const char* to_cstr(VisualizerSpectrumScale scale) {
     switch (scale) {
         case VisualizerSpectrumScale::MEL:
@@ -532,6 +551,20 @@ inline const char* to_cstr(VisualizerSpectrumScale scale) {
         default:
             return "mel";
     }
+}
+
+inline std::optional<VisualizerSpectrumScale> visualizer_spectrum_scale_from_string(
+    const std::string& str) {
+    if (str == "mel") {
+        return VisualizerSpectrumScale::MEL;
+    }
+    if (str == "log") {
+        return VisualizerSpectrumScale::LOG;
+    }
+    if (str == "lin") {
+        return VisualizerSpectrumScale::LIN;
+    }
+    return std::nullopt;
 }
 
 // --- metadata_role.h ---

--- a/src/protocol_messages.h
+++ b/src/protocol_messages.h
@@ -42,10 +42,11 @@ namespace sendspin {
 ///
 /// Bits 7-2 encode the role (upper 6 bits of the type byte); bits 1-0 encode
 /// the slot. Each role therefore has 4 slots (IDs = role << 2 through role << 2 + 3).
+/// The visualizer role has an expanded 8-slot allocation (IDs 16-23, bits 2-0 as slot)
+/// and is dispatched by ID range rather than through this enum.
 enum SendspinBinaryRole : uint8_t {
-    SENDSPIN_ROLE_PLAYER = 1,      // 000001xx (IDs 4-7)
-    SENDSPIN_ROLE_ARTWORK = 2,     // 000010xx (IDs 8-11)
-    SENDSPIN_ROLE_VISUALIZER = 4,  // 000100xx (IDs 16-19)
+    SENDSPIN_ROLE_PLAYER = 1,   // 000001xx (IDs 4-7)
+    SENDSPIN_ROLE_ARTWORK = 2,  // 000010xx (IDs 8-11)
 };
 
 /// @brief Extracts the role field from a standard 4-slot binary message type byte
@@ -63,10 +64,17 @@ inline uint8_t get_binary_slot(uint8_t type) {
 
 /// @brief Binary message type byte values for known message kinds
 enum SendspinBinaryType : uint8_t {
-    SENDSPIN_BINARY_PLAYER_AUDIO = 4,      // Player slot 0: encoded audio chunk
-    SENDSPIN_BINARY_ARTWORK_IMAGE = 8,     // Artwork slot 0: image data
-    SENDSPIN_BINARY_VISUALIZER = 16,       // Visualizer slot 0: loudness, f_peak, spectrum
-    SENDSPIN_BINARY_VISUALIZER_BEAT = 17,  // Visualizer slot 1: beat events
+    SENDSPIN_BINARY_PLAYER_AUDIO = 4,   // Player slot 0: encoded audio chunk
+    SENDSPIN_BINARY_ARTWORK_IMAGE = 8,  // Artwork slot 0: image data
+    // Visualizer expanded allocation (IDs 16-23); each data type is its own message
+    // carrying exactly one frame of [timestamp:8][data]
+    SENDSPIN_BINARY_VISUALIZER_LOUDNESS = 16,  // uint16 A-weighted loudness
+    SENDSPIN_BINARY_VISUALIZER_BEAT = 17,      // uint8 flags (bit 0 = downbeat)
+    SENDSPIN_BINARY_VISUALIZER_F_PEAK = 18,    // uint16 freq Hz + uint16 amplitude
+    SENDSPIN_BINARY_VISUALIZER_SPECTRUM = 19,  // uint16[n_disp_bins] magnitudes
+    SENDSPIN_BINARY_VISUALIZER_PEAK = 20,      // uint8 onset strength
+    SENDSPIN_BINARY_VISUALIZER_FIRST = 16,     // Start of visualizer ID range
+    SENDSPIN_BINARY_VISUALIZER_LAST = 23,      // End of visualizer ID range (21-23 reserved)
 };
 
 /// @brief JSON message types sent from the server to the client
@@ -106,7 +114,7 @@ inline const char* to_cstr(SendspinRole role) {
         case SendspinRole::ARTWORK:
             return "artwork@v1";
         case SendspinRole::VISUALIZER:
-            return "visualizer@_draft_r1";
+            return "visualizer@v1";
         case SendspinRole::COLOR:
             return "color@v1";
         default:
@@ -506,6 +514,8 @@ inline const char* to_cstr(VisualizerDataType type) {
             return "f_peak";
         case VisualizerDataType::SPECTRUM:
             return "spectrum";
+        case VisualizerDataType::PEAK:
+            return "peak";
         default:
             return "unknown";
     }
@@ -616,10 +626,12 @@ struct StreamStartMessage {
     std::optional<ServerVisualizerStreamObject> visualizer;
 };
 
-/// @brief Outgoing stream/request_format message used for codec and artwork format negotiation
+/// @brief Outgoing stream/request_format message used for codec, artwork, and visualizer
+/// format negotiation
 struct StreamRequestFormatMessage {
     std::optional<ServerPlayerStreamObject> player;
     std::optional<ClientArtworkRequestObject> artwork;
+    std::optional<VisualizerFormatRequest> visualizer;
 };
 
 /// @brief Parsed stream/end message listing which roles the stream end applies to

--- a/src/protocol_messages.h
+++ b/src/protocol_messages.h
@@ -52,12 +52,19 @@ enum SendspinBinaryRole : uint8_t {
 /// @brief Extracts the role field from a standard 4-slot binary message type byte
 /// @param type Binary message type byte.
 /// @return Role portion of the type (bits 7-2).
+/// @warning Valid only for the standard 4-slot roles (PLAYER/ARTWORK, IDs 4-11). The visualizer
+///          range (IDs 16-23) is dispatched by range in SendspinClient::process_binary_message
+///          and must not be routed through this helper: get_binary_role(16) yields 4, which
+///          matches no SendspinBinaryRole enumerator.
 inline uint8_t get_binary_role(uint8_t type) {
     return type >> 2;
 }
 /// @brief Extracts the slot field from a standard 4-slot binary message type byte
 /// @param type Binary message type byte.
 /// @return Slot portion of the type (bits 1-0).
+/// @warning Valid only for the standard 4-slot roles (PLAYER/ARTWORK, IDs 4-11). It masks bits
+///          1-0, so it cannot address the visualizer's 8-slot range (e.g. IDs 16 and 20 both
+///          alias to slot 0); those messages are dispatched by range, not by slot.
 inline uint8_t get_binary_slot(uint8_t type) {
     return type & 0x03;
 }

--- a/src/visualizer_role.cpp
+++ b/src/visualizer_role.cpp
@@ -82,10 +82,10 @@ VisualizerRole::Impl::Impl(VisualizerRoleConfig config, SendspinClient* client)
     if (this->visualizer_support.has_value()) {
         this->drain_task = std::make_unique<DrainTask>();
 
-        // The ring buffer needs more space than the raw data capacity because each entry
-        // has internal overhead: an 8-byte ItemHeader aligned to 8 bytes. Allocate 3x the
-        // advertised capacity to account for this, since visualizer entries are small.
-        size_t capacity = this->visualizer_support->buffer_capacity * 3;
+        // buffer_capacity is the total RAM budget for the ring buffer. Each entry carries an
+        // 8-byte ItemHeader aligned to 8 bytes, so with the small visualizer entries roughly a
+        // third of this storage holds actual wire data and the rest is per-entry overhead.
+        size_t capacity = this->visualizer_support->buffer_capacity;
         if (this->drain_task->ring_storage.allocate(capacity)) {
             this->drain_task->ring_buffer.create(capacity, this->drain_task->ring_storage.data());
         }

--- a/src/visualizer_role.cpp
+++ b/src/visualizer_role.cpp
@@ -45,7 +45,20 @@ static constexpr uint8_t BEAT_FLAG_DOWNBEAT = 0x01;
 
 // Event flag bits for drain thread signaling
 static constexpr uint32_t COMMAND_STOP = (1 << 0);
-static constexpr uint32_t COMMAND_FLUSH = (1 << 1);
+static constexpr uint32_t COMMAND_FLUSH = (1 << 1);  // Drain to empty (producer already stopped)
+static constexpr uint32_t COMMAND_CLEAR = (1 << 2);  // Discard up to the clear marker entry
+
+// Sentinel entry marking a stream/start or stream/clear boundary in the ring buffer. Entries
+// before the marker predate the boundary and are discarded; entries after it survive. The value
+// is outside the visualizer wire-type range (16-23) so it can never collide with a real message,
+// and the entry is a single byte so the drain loop's minimum-size check drops any leftover marker
+// encountered in normal flow.
+static constexpr uint8_t ENTRY_TYPE_CLEAR_MARKER = 0xFF;
+
+/// @brief Timeout for enqueueing the clear marker. The drain thread is concurrently discarding,
+/// so a full buffer frees quickly; if this still times out the boundary is lost and the drain
+/// falls back to discarding everything it finds (matching the player's marker semantics).
+static constexpr uint32_t MARKER_ENQUEUE_TIMEOUT_MS = 100U;
 
 /// @brief Timeout for blocking ring buffer receive in drain thread (allows periodic command checks)
 static constexpr uint32_t DRAIN_RECEIVE_TIMEOUT_MS = 50U;
@@ -66,6 +79,23 @@ static int64_t read_be64(const uint8_t* p) {
 
 static uint16_t read_be16(const uint8_t* p) {
     return static_cast<uint16_t>(p[0]) << 8 | static_cast<uint16_t>(p[1]);
+}
+
+/// @brief Maps a negotiated data type to its binary wire-type byte
+static uint8_t wire_type_for(sendspin::VisualizerDataType type) {
+    switch (type) {
+        case sendspin::VisualizerDataType::LOUDNESS:
+            return sendspin::SENDSPIN_BINARY_VISUALIZER_LOUDNESS;
+        case sendspin::VisualizerDataType::BEAT:
+            return sendspin::SENDSPIN_BINARY_VISUALIZER_BEAT;
+        case sendspin::VisualizerDataType::F_PEAK:
+            return sendspin::SENDSPIN_BINARY_VISUALIZER_F_PEAK;
+        case sendspin::VisualizerDataType::SPECTRUM:
+            return sendspin::SENDSPIN_BINARY_VISUALIZER_SPECTRUM;
+        case sendspin::VisualizerDataType::PEAK:
+            return sendspin::SENDSPIN_BINARY_VISUALIZER_PEAK;
+    }
+    return 0;
 }
 
 namespace sendspin {
@@ -171,12 +201,20 @@ void VisualizerRole::Impl::handle_binary(uint8_t binary_type, const uint8_t* dat
         return;
     }
 
+    // Admit only wire types the active stream negotiated in stream/start. The mask is written by
+    // handle_stream_start on this same thread, so a message is always judged against the config
+    // in force when it arrived. The caller guarantees binary_type is in the visualizer range.
+    uint8_t type_bit = 1U << (binary_type - SENDSPIN_BINARY_VISUALIZER_FIRST);
+    if ((this->negotiated_types_mask & type_bit) == 0) {
+        return;
+    }
+
     // Forward the raw message verbatim: [wire_type][server_ts(8)][payload]. Like the player and
     // artwork roles, the network thread stays dumb -- it records the message and hands it to the
-    // drain thread, which owns all structural validation and per-type truncation. The only check
-    // here is that a timestamp is present, since the drain thread needs it to schedule the entry.
-    // No size cap is applied: the ring buffer records each entry's length, so an oversized message
-    // is self-limiting (it either fits or is dropped when acquire() fails).
+    // drain thread, which owns all structural validation and per-type truncation. The only other
+    // check here is that a timestamp is present, since the drain thread needs it to schedule the
+    // entry. No size cap is applied: the ring buffer records each entry's length, so an oversized
+    // message is self-limiting (it either fits or is dropped when acquire() fails).
     if (len < TIMESTAMP_SIZE) {
         return;
     }
@@ -202,23 +240,25 @@ void VisualizerRole::Impl::handle_binary(uint8_t binary_type, const uint8_t* dat
 void VisualizerRole::Impl::handle_stream_start(const ServerVisualizerStreamObject& stream) {
     // Cache stream config for handle_binary (same thread) and the drain thread
     uint8_t bin_count = 0;
+    uint8_t types_mask = 0;
     bool has_spectrum = false;
     for (auto type : stream.types) {
         if (type == VisualizerDataType::SPECTRUM) {
             has_spectrum = true;
         }
+        types_mask |= 1U << (wire_type_for(type) - SENDSPIN_BINARY_VISUALIZER_FIRST);
     }
     if (has_spectrum && stream.spectrum.has_value()) {
         bin_count = stream.spectrum->n_disp_bins;
     }
     this->spectrum_bin_count = bin_count;
     this->tracks_downbeats = stream.tracks_downbeats;
+    this->negotiated_types_mask = types_mask;
     this->stream_active = true;
 
-    // Signal drain thread to flush old data
-    if (this->drain_task) {
-        this->drain_task->event_flags.set(COMMAND_FLUSH);
-    }
+    // Mark the config boundary: buffered entries predate this (re)start and must be discarded,
+    // while entries arriving after it belong to the new config and must survive.
+    this->signal_clear_marker();
 
     // Write the config to the inbox slot for the main thread, then push the event. Both lock the
     // same shared Inbox mutex, in this order, so a consumer that later takes the START event is
@@ -229,6 +269,7 @@ void VisualizerRole::Impl::handle_stream_start(const ServerVisualizerStreamObjec
 
 void VisualizerRole::Impl::handle_stream_end() {
     this->stream_active = false;
+    this->negotiated_types_mask = 0;
 
     if (this->drain_task) {
         this->drain_task->event_flags.set(COMMAND_FLUSH);
@@ -239,10 +280,9 @@ void VisualizerRole::Impl::handle_stream_end() {
 
 void VisualizerRole::Impl::handle_stream_clear() {
     // Per spec, stream/clear discards buffered data but the stream stays active; data
-    // received after this message continues to flow.
-    if (this->drain_task) {
-        this->drain_task->event_flags.set(COMMAND_FLUSH);
-    }
+    // received after this message continues to flow. The marker separates the two: a blind
+    // flush would race this thread and drop post-clear frames it has already enqueued.
+    this->signal_clear_marker();
 
     this->enqueue_stream_event(VisualizerEventType::STREAM_CLEAR);
 }
@@ -291,6 +331,7 @@ void VisualizerRole::Impl::handle_stream_ring_event(VisualizerEventType event) c
 
 void VisualizerRole::Impl::cleanup() {
     this->stream_active = false;
+    this->negotiated_types_mask = 0;
 
     if (this->drain_task) {
         this->drain_task->event_flags.set(COMMAND_FLUSH);
@@ -377,6 +418,47 @@ void VisualizerRole::Impl::flush_ring_buffer() const {
     }
 }
 
+void VisualizerRole::Impl::signal_clear_marker() const {
+    // Network-thread side of a clear boundary. Set the flag before enqueueing the marker (like
+    // PlayerRole::handle_stream_clear) so the drain thread starts discarding -- freeing ring
+    // space -- while we wait for the marker slot.
+    if (!this->drain_task || !this->drain_task->ring_buffer.is_created()) {
+        return;
+    }
+    this->drain_task->event_flags.set(COMMAND_CLEAR);
+
+    void* dest = this->drain_task->ring_buffer.acquire(1, MARKER_ENQUEUE_TIMEOUT_MS);
+    if (dest == nullptr) {
+        // Boundary lost: the drain thread will discard to empty instead, so frames enqueued
+        // after this point may be dropped along with the old ones (brief visual gap, no harm).
+        SS_LOGW(TAG, "Failed to enqueue clear marker; clear boundary may be imprecise");
+        return;
+    }
+    static_cast<uint8_t*>(dest)[0] = ENTRY_TYPE_CLEAR_MARKER;
+    this->drain_task->ring_buffer.commit(dest);
+}
+
+void VisualizerRole::Impl::discard_to_clear_marker() const {
+    // Drain-thread side of a clear boundary: discard entries up to and including the marker.
+    // Stopping at the marker preserves frames the network thread enqueued after the clear,
+    // which per spec must survive. If the buffer empties without a marker, either the marker
+    // could not be enqueued or it was already consumed in normal flow (it is a 1-byte entry,
+    // dropped by the drain loop's minimum-size check); nothing is left to discard either way.
+    if (!this->drain_task) {
+        return;
+    }
+    size_t item_size = 0;
+    void* item = nullptr;
+    while ((item = this->drain_task->ring_buffer.receive(&item_size, 0)) != nullptr) {
+        bool is_marker =
+            item_size == 1 && static_cast<const uint8_t*>(item)[0] == ENTRY_TYPE_CLEAR_MARKER;
+        this->drain_task->ring_buffer.return_item(item);
+        if (is_marker) {
+            return;
+        }
+    }
+}
+
 void VisualizerRole::Impl::drain_thread_func(VisualizerRole::Impl* self) {
     SS_LOGD(TAG, "Drain thread started");
 
@@ -408,12 +490,17 @@ void VisualizerRole::Impl::drain_thread_func(VisualizerRole::Impl* self) {
 
     while (true) {
         // Non-blocking check for commands
-        uint32_t cmd = flags.wait(COMMAND_STOP | COMMAND_FLUSH, false, true, 0);
+        uint32_t cmd = flags.wait(COMMAND_STOP | COMMAND_FLUSH | COMMAND_CLEAR, false, true, 0);
         if (cmd & COMMAND_STOP) {
             break;
         }
-        if (cmd & COMMAND_FLUSH) {
-            self->flush_ring_buffer();
+        if (cmd & (COMMAND_FLUSH | COMMAND_CLEAR)) {
+            if (cmd & COMMAND_FLUSH) {
+                self->flush_ring_buffer();
+            }
+            if (cmd & COMMAND_CLEAR) {
+                self->discard_to_clear_marker();
+            }
             continue;
         }
 
@@ -430,7 +517,9 @@ void VisualizerRole::Impl::drain_thread_func(VisualizerRole::Impl* self) {
             continue;
         }
 
-        // Entry format: [wire_type][server_ts(8)][payload]
+        // Entry format: [wire_type][server_ts(8)][payload]. This also drops any leftover 1-byte
+        // clear marker whose COMMAND_CLEAR was already handled (everything before it was consumed
+        // in order, so the boundary it marks has already been honored).
         if (item_size < ENTRY_TYPE_SIZE + TIMESTAMP_SIZE) {
             rb.return_item(item);
             continue;
@@ -450,14 +539,22 @@ void VisualizerRole::Impl::drain_thread_func(VisualizerRole::Impl* self) {
         if (client_ts > now) {
             uint32_t wait_ms = static_cast<uint32_t>((client_ts - now) / US_PER_MS);
             if (wait_ms > 0) {
-                cmd = flags.wait(COMMAND_STOP | COMMAND_FLUSH, false, true, wait_ms);
+                cmd =
+                    flags.wait(COMMAND_STOP | COMMAND_FLUSH | COMMAND_CLEAR, false, true, wait_ms);
                 if (cmd & COMMAND_STOP) {
                     rb.return_item(item);
                     break;
                 }
-                if (cmd & COMMAND_FLUSH) {
+                if (cmd & (COMMAND_FLUSH | COMMAND_CLEAR)) {
+                    // The held item was popped before the signal, so it predates the boundary
+                    // and is discarded along with the buffered pre-boundary entries.
                     rb.return_item(item);
-                    self->flush_ring_buffer();
+                    if (cmd & COMMAND_FLUSH) {
+                        self->flush_ring_buffer();
+                    }
+                    if (cmd & COMMAND_CLEAR) {
+                        self->discard_to_clear_marker();
+                    }
                     continue;
                 }
             }

--- a/src/visualizer_role.cpp
+++ b/src/visualizer_role.cpp
@@ -292,7 +292,7 @@ void VisualizerRole::Impl::handle_stream_end() {
     this->enqueue_stream_event(VisualizerEventType::STREAM_END);
 }
 
-void VisualizerRole::Impl::handle_stream_clear() {
+void VisualizerRole::Impl::handle_stream_clear() const {
     // Per spec, stream/clear discards buffered data but the stream stays active; data
     // received after this message continues to flow. The marker separates the two: a blind
     // flush would race this thread and drop post-clear frames it has already enqueued.
@@ -399,12 +399,12 @@ VisualizerDelivery decode_visualizer_message(uint8_t wire_type, const uint8_t* p
         case SENDSPIN_BINARY_VISUALIZER_SPECTRUM:
             // Deliver exactly the negotiated n_disp_bins. Drop the frame if SPECTRUM was not
             // negotiated (bin count 0) or the payload is short; ignore any trailing bytes.
-            if (configured_bins == 0 || payload_len < 2U * configured_bins) {
+            if (configured_bins == 0 || payload_len < static_cast<size_t>(configured_bins) * 2) {
                 break;
             }
             spectrum_out.resize(configured_bins);
             for (uint8_t b = 0; b < configured_bins; ++b) {
-                spectrum_out[b] = read_be16(payload + 2 * b);
+                spectrum_out[b] = read_be16(payload + static_cast<size_t>(b) * 2);
             }
             out.kind = VisualizerDelivery::Kind::SPECTRUM;
             break;
@@ -489,7 +489,7 @@ void VisualizerRole::Impl::drain_thread_func(VisualizerRole::Impl* self) {
     // payload drop, or a future wire type that forgets), the destructor returns it. Stack-only.
     struct SlotGuard {
         SpscRingBuffer& rb;
-        void* item;
+        void* item = nullptr;
         bool released = false;
         void release() {
             if (!this->released) {

--- a/src/visualizer_role.cpp
+++ b/src/visualizer_role.cpp
@@ -29,8 +29,9 @@ static const char* const TAG = "sendspin.visualizer";
 // ============================================================================
 
 // Each ring buffer entry preserves the full wire message: [wire_type(1)][server_ts(8)][payload].
-// This matches the spec's buffer_capacity accounting, which counts each message's full wire
-// size (message-type byte + timestamp + data).
+// buffer_capacity is the ring's total RAM budget, not a wire-data quota: on top of these bytes
+// each entry costs an aligned per-entry ItemHeader, so effective wire-data capacity is smaller
+// (see the buffer_capacity note in config.h).
 static constexpr size_t ENTRY_TYPE_SIZE = 1;
 static constexpr size_t TIMESTAMP_SIZE = 8;
 
@@ -42,6 +43,13 @@ static constexpr size_t PEAK_PAYLOAD_SIZE = 1;      // uint8 strength
 
 /// @brief Bit 0 of the beat flags byte marks a downbeat (bar start)
 static constexpr uint8_t BEAT_FLAG_DOWNBEAT = 0x01;
+
+// buffer_capacity is the ring's RAM budget, but each entry costs an 8-byte ItemHeader plus 8-byte
+// alignment on top of its wire message, so the smallest entries (beat/peak, 10 wire bytes -> 24
+// stored) leave only ~1/3 of the budget for actual wire data. Advertise that effective fraction to
+// the server (not the raw budget) so its flow control never sends more than the ring can hold. This
+// mirrors the player role's conservative buffer advertisement.
+static constexpr size_t BUFFER_ADVERTISE_DIVISOR = 3;
 
 // Event flag bits for drain thread signaling
 static constexpr uint32_t COMMAND_STOP = (1 << 0);
@@ -182,7 +190,13 @@ void VisualizerRole::Impl::stop() const {
 void VisualizerRole::Impl::build_hello_fields(ClientHelloMessage& msg) {
     if (this->visualizer_support.has_value()) {
         msg.supported_roles.push_back(SendspinRole::VISUALIZER);
-        msg.visualizer_support = this->visualizer_support.value();
+        // Advertise the effective wire-data capacity, not the raw RAM budget: the ring is sized at
+        // buffer_capacity bytes but per-entry overhead leaves only ~1/3 for wire data (see
+        // BUFFER_ADVERTISE_DIVISOR). The RAM allocation in the constructor still uses the full
+        // value.
+        VisualizerSupportObject advertised = this->visualizer_support.value();
+        advertised.buffer_capacity /= BUFFER_ADVERTISE_DIVISOR;
+        msg.visualizer_support = std::move(advertised);
     }
 }
 

--- a/src/visualizer_role.cpp
+++ b/src/visualizer_role.cpp
@@ -28,22 +28,20 @@ static const char* const TAG = "sendspin.visualizer";
 // Entry format constants
 // ============================================================================
 
-// Type tag in first byte of each ring buffer entry
-static constexpr uint8_t ENTRY_BEAT = 0x00;
-static constexpr uint8_t ENTRY_FRAME = 0x80;  // bit 7 distinguishes frame from beat
-
-// Frame field flags packed into bits 0-2 of the type byte
-static constexpr uint8_t FLAG_HAS_LOUDNESS = (1 << 0);
-static constexpr uint8_t FLAG_HAS_F_PEAK = (1 << 1);
-static constexpr uint8_t FLAG_HAS_SPECTRUM = (1 << 2);
-
-/// @brief Mask to extract the flags portion (bits 0-6) from a frame type byte
-static constexpr uint8_t FRAME_FLAGS_MASK = 0x7FU;
-
-// Entry header sizes (before the 8-byte server timestamp)
-static constexpr size_t FRAME_HEADER_SIZE = 2;  // type+flags byte, bin_count byte
-static constexpr size_t BEAT_HEADER_SIZE = 1;   // type byte only
+// Each ring buffer entry preserves the full wire message: [wire_type(1)][server_ts(8)][payload].
+// This matches the spec's buffer_capacity accounting, which counts each message's full wire
+// size (message-type byte + timestamp + data).
+static constexpr size_t ENTRY_TYPE_SIZE = 1;
 static constexpr size_t TIMESTAMP_SIZE = 8;
+
+// Minimum payload bytes after the timestamp, per wire message type
+static constexpr size_t LOUDNESS_PAYLOAD_SIZE = 2;  // uint16 value
+static constexpr size_t BEAT_PAYLOAD_SIZE = 1;      // uint8 flags
+static constexpr size_t F_PEAK_PAYLOAD_SIZE = 4;    // uint16 freq + uint16 amp
+static constexpr size_t PEAK_PAYLOAD_SIZE = 1;      // uint8 strength
+
+/// @brief Bit 0 of the beat flags byte marks a downbeat (bar start)
+static constexpr uint8_t BEAT_FLAG_DOWNBEAT = 0x01;
 
 // Event flag bits for drain thread signaling
 static constexpr uint32_t COMMAND_STOP = (1 << 0);
@@ -72,55 +70,6 @@ static uint16_t read_be16(const uint8_t* p) {
 
 namespace sendspin {
 
-namespace {
-
-// The server packs per-frame fields in the order of the `types` list advertised in the
-// client's hello (see ClientHelloMessage::visualizer_support), but the drain thread parser
-// always reads fields in a fixed order: LOUDNESS, then F_PEAK, then SPECTRUM (see
-// drain_thread_func below). If the advertised order did not match, the server would pack
-// fields in an order the parser cannot decode correctly. Reorder (and de-duplicate) the
-// advertised types here so the wire order always matches the parser, regardless of what
-// order the caller populated VisualizerRoleConfig::support.types in. BEAT is not a per-frame
-// field (it arrives as a separate binary message type), so it is kept but sorted last. Any
-// type the parser does not recognize is dropped, since the fixed-order parser cannot decode a
-// field it does not understand.
-std::vector<VisualizerDataType> normalize_type_order(const std::vector<VisualizerDataType>& types) {
-    bool has_loudness = false;
-    bool has_f_peak = false;
-    bool has_spectrum = false;
-    bool has_beat = false;
-
-    for (auto type : types) {
-        if (type == VisualizerDataType::LOUDNESS) {
-            has_loudness = true;
-        } else if (type == VisualizerDataType::F_PEAK) {
-            has_f_peak = true;
-        } else if (type == VisualizerDataType::SPECTRUM) {
-            has_spectrum = true;
-        } else if (type == VisualizerDataType::BEAT) {
-            has_beat = true;
-        }
-    }
-
-    std::vector<VisualizerDataType> ordered;
-    ordered.reserve(types.size());
-    if (has_loudness) {
-        ordered.push_back(VisualizerDataType::LOUDNESS);
-    }
-    if (has_f_peak) {
-        ordered.push_back(VisualizerDataType::F_PEAK);
-    }
-    if (has_spectrum) {
-        ordered.push_back(VisualizerDataType::SPECTRUM);
-    }
-    if (has_beat) {
-        ordered.push_back(VisualizerDataType::BEAT);
-    }
-    return ordered;
-}
-
-}  // namespace
-
 // ============================================================================
 // Impl constructor / destructor
 // ============================================================================
@@ -131,15 +80,11 @@ VisualizerRole::Impl::Impl(VisualizerRoleConfig config, SendspinClient* client)
       client(client),
       event_state(std::make_unique<EventState>()) {
     if (this->visualizer_support.has_value()) {
-        // Normalize the advertised type order so the server packs fields in the order the
-        // drain thread parser expects. See normalize_type_order() above for the constraint.
-        this->visualizer_support->types = normalize_type_order(this->visualizer_support->types);
-
         this->drain_task = std::make_unique<DrainTask>();
 
         // The ring buffer needs more space than the raw data capacity because each entry
-        // has internal overhead: an 8-byte ItemHeader plus our 1-2 byte entry header, all
-        // aligned to 8 bytes. Allocate 3x the advertised capacity to account for this.
+        // has internal overhead: an 8-byte ItemHeader aligned to 8 bytes. Allocate 3x the
+        // advertised capacity to account for this, since visualizer entries are small.
         size_t capacity = this->visualizer_support->buffer_capacity * 3;
         if (this->drain_task->ring_storage.allocate(capacity)) {
             this->drain_task->ring_buffer.create(capacity, this->drain_task->ring_storage.data());
@@ -162,6 +107,10 @@ VisualizerRole::~VisualizerRole() = default;
 
 void VisualizerRole::set_listener(VisualizerRoleListener* listener) {
     this->impl_->listener = listener;
+}
+
+void VisualizerRole::request_format(const VisualizerFormatRequest& request) {
+    this->impl_->request_format(request);
 }
 
 // ============================================================================
@@ -207,6 +156,12 @@ void VisualizerRole::Impl::build_hello_fields(ClientHelloMessage& msg) {
     }
 }
 
+void VisualizerRole::Impl::request_format(const VisualizerFormatRequest& request) const {
+    StreamRequestFormatMessage msg{};
+    msg.visualizer = request;
+    this->client->send_text(format_stream_request_format_message(&msg));
+}
+
 // ============================================================================
 // Binary handling (network thread)
 // ============================================================================
@@ -216,70 +171,58 @@ void VisualizerRole::Impl::handle_binary(uint8_t binary_type, const uint8_t* dat
         return;
     }
 
-    // Build the frame flags byte from cached config
-    uint8_t flags = ENTRY_FRAME;
-    if (this->has_loudness) {
-        flags |= FLAG_HAS_LOUDNESS;
+    // Every visualizer message is one frame: [server_ts(8)][payload]
+    if (len < TIMESTAMP_SIZE) {
+        return;
     }
-    if (this->has_f_peak) {
-        flags |= FLAG_HAS_F_PEAK;
-    }
-    if (this->has_spectrum) {
-        flags |= FLAG_HAS_SPECTRUM;
-    }
+    size_t payload_len = len - TIMESTAMP_SIZE;
 
-    if (binary_type == SENDSPIN_BINARY_VISUALIZER_BEAT) {
-        // Beat format: [num_beats(1)][per-beat: server_timestamp(8)]
-        if (len < 1) {
-            return;
-        }
-        uint8_t num_beats = data[0];
-        size_t offset = 1;
-
-        for (uint8_t i = 0; i < num_beats; ++i) {
-            if (offset + TIMESTAMP_SIZE > len) {
-                break;
+    switch (binary_type) {
+        case SENDSPIN_BINARY_VISUALIZER_LOUDNESS:
+            if (payload_len < LOUDNESS_PAYLOAD_SIZE) {
+                return;
             }
-
-            // Build beat entry: [ENTRY_BEAT][8-byte server_ts]
-            uint8_t entry[BEAT_HEADER_SIZE + TIMESTAMP_SIZE];
-            entry[0] = ENTRY_BEAT;
-            std::memcpy(entry + BEAT_HEADER_SIZE, data + offset, TIMESTAMP_SIZE);
-
-            this->drain_task->ring_buffer.send(entry, sizeof(entry), 0);
-            offset += TIMESTAMP_SIZE;
-        }
-    } else {
-        // Visualizer data format: [num_frames(1)][per-frame: timestamp(8) + fields...]
-        if (len < 1) {
-            return;
-        }
-        uint8_t num_frames = data[0];
-        size_t offset = 1;
-        size_t wire_frame_size = TIMESTAMP_SIZE + this->raw_frame_size;
-        size_t entry_size = FRAME_HEADER_SIZE + TIMESTAMP_SIZE + this->raw_frame_size;
-
-        for (uint8_t i = 0; i < num_frames; ++i) {
-            if (offset + wire_frame_size > len) {
-                break;
+            break;
+        case SENDSPIN_BINARY_VISUALIZER_BEAT:
+            if (payload_len < BEAT_PAYLOAD_SIZE) {
+                return;
             }
-
-            // Build frame entry: [flags][bin_count][8-byte server_ts][raw field bytes]
-            // Use acquire+commit to avoid double-copy
-            void* dest = this->drain_task->ring_buffer.acquire(entry_size, 0);
-            if (dest == nullptr) {
-                break;  // Buffer full, drop remaining frames
+            break;
+        case SENDSPIN_BINARY_VISUALIZER_F_PEAK:
+            if (payload_len < F_PEAK_PAYLOAD_SIZE) {
+                return;
             }
-
-            auto* entry = static_cast<uint8_t*>(dest);
-            entry[0] = flags;
-            entry[1] = this->spectrum_bin_count;
-            std::memcpy(entry + FRAME_HEADER_SIZE, data + offset, wire_frame_size);
-
-            this->drain_task->ring_buffer.commit(dest);
-            offset += wire_frame_size;
+            break;
+        case SENDSPIN_BINARY_VISUALIZER_SPECTRUM: {
+            uint8_t bin_count = this->spectrum_bin_count;
+            if (bin_count == 0 || payload_len < 2U * bin_count) {
+                return;
+            }
+            // Truncate any trailing bytes so the drain thread delivers exactly n_disp_bins
+            len = TIMESTAMP_SIZE + 2U * bin_count;
+            break;
         }
+        case SENDSPIN_BINARY_VISUALIZER_PEAK:
+            if (payload_len < PEAK_PAYLOAD_SIZE) {
+                return;
+            }
+            break;
+        default:
+            return;  // Reserved types 21-23
     }
+
+    // Build entry: [wire_type][server_ts(8)][payload]. Use acquire+commit to avoid double-copy.
+    size_t entry_size = ENTRY_TYPE_SIZE + len;
+    void* dest = this->drain_task->ring_buffer.acquire(entry_size, 0);
+    if (dest == nullptr) {
+        return;  // Buffer full, drop
+    }
+
+    auto* entry = static_cast<uint8_t*>(dest);
+    entry[0] = binary_type;
+    std::memcpy(entry + ENTRY_TYPE_SIZE, data, len);
+
+    this->drain_task->ring_buffer.commit(dest);
 }
 
 // ============================================================================
@@ -287,29 +230,19 @@ void VisualizerRole::Impl::handle_binary(uint8_t binary_type, const uint8_t* dat
 // ============================================================================
 
 void VisualizerRole::Impl::handle_stream_start(const ServerVisualizerStreamObject& stream) {
-    // Cache stream config for handle_binary (same thread)
-    this->has_loudness = false;
-    this->has_f_peak = false;
-    this->has_spectrum = false;
-    this->spectrum_bin_count = 0;
-
+    // Cache stream config for handle_binary (same thread) and the drain thread
+    uint8_t bin_count = 0;
+    bool has_spectrum = false;
     for (auto type : stream.types) {
-        if (type == VisualizerDataType::LOUDNESS) {
-            this->has_loudness = true;
-        }
-        if (type == VisualizerDataType::F_PEAK) {
-            this->has_f_peak = true;
-        }
         if (type == VisualizerDataType::SPECTRUM) {
-            this->has_spectrum = true;
+            has_spectrum = true;
         }
     }
-    if (this->has_spectrum && stream.spectrum.has_value()) {
-        this->spectrum_bin_count = stream.spectrum->n_disp_bins;
+    if (has_spectrum && stream.spectrum.has_value()) {
+        bin_count = stream.spectrum->n_disp_bins;
     }
-
-    this->raw_frame_size = (this->has_loudness ? 2 : 0) + (this->has_f_peak ? 2 : 0) +
-                           (this->has_spectrum ? 2 * this->spectrum_bin_count : 0);
+    this->spectrum_bin_count = bin_count;
+    this->tracks_downbeats = stream.tracks_downbeats;
     this->stream_active = true;
 
     // Signal drain thread to flush old data
@@ -335,8 +268,8 @@ void VisualizerRole::Impl::handle_stream_end() {
 }
 
 void VisualizerRole::Impl::handle_stream_clear() {
-    this->stream_active = false;
-
+    // Per spec, stream/clear discards buffered data but the stream stays active; data
+    // received after this message continues to flow.
     if (this->drain_task) {
         this->drain_task->event_flags.set(COMMAND_FLUSH);
     }
@@ -426,9 +359,9 @@ void VisualizerRole::Impl::drain_thread_func(VisualizerRole::Impl* self) {
     auto& rb = self->drain_task->ring_buffer;
     auto& flags = self->drain_task->event_flags;
 
-    // Reused across iterations to avoid a heap alloc/free per frame. The spectrum vector's
-    // capacity grows to the largest bin_count seen and is resized (not reallocated) after that.
-    VisualizerFrame frame{};
+    // Reused across iterations to avoid a heap alloc/free per frame. The vector's capacity
+    // grows to the largest bin count seen and is resized (not reallocated) after that.
+    std::vector<uint16_t> spectrum_bins;
 
     while (true) {
         // Non-blocking check for commands
@@ -454,17 +387,14 @@ void VisualizerRole::Impl::drain_thread_func(VisualizerRole::Impl* self) {
             continue;
         }
 
-        auto* raw = static_cast<const uint8_t*>(item);
-        uint8_t type_byte = raw[0];
-        bool is_frame = (type_byte & ENTRY_FRAME) != 0;
-
-        // Read server timestamp
-        size_t ts_offset = is_frame ? FRAME_HEADER_SIZE : BEAT_HEADER_SIZE;
-        if (item_size < ts_offset + TIMESTAMP_SIZE) {
+        // Entry format: [wire_type][server_ts(8)][payload]
+        if (item_size < ENTRY_TYPE_SIZE + TIMESTAMP_SIZE) {
             rb.return_item(item);
             continue;
         }
-        int64_t server_ts = read_be64(raw + ts_offset);
+        auto* raw = static_cast<const uint8_t*>(item);
+        uint8_t wire_type = raw[0];
+        int64_t server_ts = read_be64(raw + ENTRY_TYPE_SIZE);
         int64_t client_ts = self->client->get_client_time(server_ts);
 
         if (client_ts == 0) {
@@ -497,48 +427,55 @@ void VisualizerRole::Impl::drain_thread_func(VisualizerRole::Impl* self) {
             continue;
         }
 
-        // Parse and deliver
-        if (is_frame && self->listener) {
-            uint8_t frame_flags = type_byte & FRAME_FLAGS_MASK;
-            uint8_t bin_count = raw[1];
-            const uint8_t* fields = raw + FRAME_HEADER_SIZE + TIMESTAMP_SIZE;
-            size_t data_len = item_size - FRAME_HEADER_SIZE - TIMESTAMP_SIZE;
-            size_t offset = 0;
+        if (self->listener == nullptr) {
+            rb.return_item(item);
+            continue;
+        }
 
-            // Reset all fields so no stale data from a previous frame leaks through.
-            frame.timestamp = client_ts;
-            frame.loudness.reset();
-            frame.peak_freq.reset();
+        // Parse and deliver. Payload lengths were validated in handle_binary before queueing.
+        const uint8_t* payload = raw + ENTRY_TYPE_SIZE + TIMESTAMP_SIZE;
+        size_t payload_len = item_size - ENTRY_TYPE_SIZE - TIMESTAMP_SIZE;
 
-            if ((frame_flags & FLAG_HAS_LOUDNESS) && offset + 2 <= data_len) {
-                frame.loudness = read_be16(fields + offset);
-                offset += 2;
+        switch (wire_type) {
+            case SENDSPIN_BINARY_VISUALIZER_LOUDNESS: {
+                uint16_t loudness = read_be16(payload);
+                rb.return_item(item);
+                self->listener->on_loudness(client_ts, loudness);
+                break;
             }
-            if ((frame_flags & FLAG_HAS_F_PEAK) && offset + 2 <= data_len) {
-                frame.peak_freq = read_be16(fields + offset);
-                offset += 2;
+            case SENDSPIN_BINARY_VISUALIZER_BEAT: {
+                // Bit 0 is only meaningful when the stream tracks downbeats
+                bool downbeat = self->tracks_downbeats && (payload[0] & BEAT_FLAG_DOWNBEAT) != 0;
+                rb.return_item(item);
+                self->listener->on_beat(client_ts, downbeat);
+                break;
             }
-            if ((frame_flags & FLAG_HAS_SPECTRUM) && bin_count > 0) {
-                // assign() zero-initializes all bin_count elements and reuses the existing
-                // allocation when capacity suffices (no per-frame heap churn). Zeroing up front
-                // means a short or corrupt entry that exits the fill loop early cannot leak
-                // stale bins from a previous frame through the reused vector.
-                frame.spectrum.assign(bin_count, 0);
-                for (uint8_t b = 0; b < bin_count && offset + 2 <= data_len; ++b) {
-                    frame.spectrum[b] = read_be16(fields + offset);
-                    offset += 2;
+            case SENDSPIN_BINARY_VISUALIZER_F_PEAK: {
+                uint16_t freq = read_be16(payload);
+                uint16_t amp = read_be16(payload + 2);
+                rb.return_item(item);
+                self->listener->on_f_peak(client_ts, freq, amp);
+                break;
+            }
+            case SENDSPIN_BINARY_VISUALIZER_SPECTRUM: {
+                size_t bin_count = payload_len / 2;
+                spectrum_bins.resize(bin_count);
+                for (size_t b = 0; b < bin_count; ++b) {
+                    spectrum_bins[b] = read_be16(payload + 2 * b);
                 }
-            } else {
-                frame.spectrum.clear();
+                rb.return_item(item);
+                self->listener->on_spectrum(client_ts, spectrum_bins);
+                break;
             }
-
-            rb.return_item(item);
-            self->listener->on_visualizer_frame(frame);
-        } else if (!is_frame && self->listener) {
-            rb.return_item(item);
-            self->listener->on_beat(client_ts);
-        } else {
-            rb.return_item(item);
+            case SENDSPIN_BINARY_VISUALIZER_PEAK: {
+                uint8_t strength = payload[0];
+                rb.return_item(item);
+                self->listener->on_peak(client_ts, strength);
+                break;
+            }
+            default:
+                rb.return_item(item);
+                break;
         }
     }
 

--- a/src/visualizer_role.cpp
+++ b/src/visualizer_role.cpp
@@ -171,44 +171,14 @@ void VisualizerRole::Impl::handle_binary(uint8_t binary_type, const uint8_t* dat
         return;
     }
 
-    // Every visualizer message is one frame: [server_ts(8)][payload]
+    // Forward the raw message verbatim: [wire_type][server_ts(8)][payload]. Like the player and
+    // artwork roles, the network thread stays dumb -- it records the message and hands it to the
+    // drain thread, which owns all structural validation and per-type truncation. The only check
+    // here is that a timestamp is present, since the drain thread needs it to schedule the entry.
+    // No size cap is applied: the ring buffer records each entry's length, so an oversized message
+    // is self-limiting (it either fits or is dropped when acquire() fails).
     if (len < TIMESTAMP_SIZE) {
         return;
-    }
-    size_t payload_len = len - TIMESTAMP_SIZE;
-
-    switch (binary_type) {
-        case SENDSPIN_BINARY_VISUALIZER_LOUDNESS:
-            if (payload_len < LOUDNESS_PAYLOAD_SIZE) {
-                return;
-            }
-            break;
-        case SENDSPIN_BINARY_VISUALIZER_BEAT:
-            if (payload_len < BEAT_PAYLOAD_SIZE) {
-                return;
-            }
-            break;
-        case SENDSPIN_BINARY_VISUALIZER_F_PEAK:
-            if (payload_len < F_PEAK_PAYLOAD_SIZE) {
-                return;
-            }
-            break;
-        case SENDSPIN_BINARY_VISUALIZER_SPECTRUM: {
-            uint8_t bin_count = this->spectrum_bin_count;
-            if (bin_count == 0 || payload_len < 2U * bin_count) {
-                return;
-            }
-            // Truncate any trailing bytes so the drain thread delivers exactly n_disp_bins
-            len = TIMESTAMP_SIZE + 2U * bin_count;
-            break;
-        }
-        case SENDSPIN_BINARY_VISUALIZER_PEAK:
-            if (payload_len < PEAK_PAYLOAD_SIZE) {
-                return;
-            }
-            break;
-        default:
-            return;  // Reserved types 21-23
     }
 
     // Build entry: [wire_type][server_ts(8)][payload]. Use acquire+commit to avoid double-copy.
@@ -363,6 +333,25 @@ void VisualizerRole::Impl::drain_thread_func(VisualizerRole::Impl* self) {
     // grows to the largest bin count seen and is resized (not reallocated) after that.
     std::vector<uint16_t> spectrum_bins;
 
+    // RAII guard so the ring-buffer slot is returned exactly once on every exit path. Each branch
+    // calls release() to hand the slot back *before* invoking the listener callback, so a slow
+    // callback never blocks the network producer; if a branch exits without releasing (a short-
+    // payload drop, or a future wire type that forgets), the destructor returns it. Stack-only.
+    struct SlotGuard {
+        SpscRingBuffer& rb;
+        void* item;
+        bool released = false;
+        void release() {
+            if (!this->released) {
+                this->rb.return_item(this->item);
+                this->released = true;
+            }
+        }
+        ~SlotGuard() {
+            this->release();
+        }
+    };
+
     while (true) {
         // Non-blocking check for commands
         uint32_t cmd = flags.wait(COMMAND_STOP | COMMAND_FLUSH, false, true, 0);
@@ -432,50 +421,69 @@ void VisualizerRole::Impl::drain_thread_func(VisualizerRole::Impl* self) {
             continue;
         }
 
-        // Parse and deliver. Payload lengths were validated in handle_binary before queueing.
+        // Parse and deliver. The network thread forwards messages verbatim, so every branch
+        // validates its own payload length here before reading.
         const uint8_t* payload = raw + ENTRY_TYPE_SIZE + TIMESTAMP_SIZE;
         size_t payload_len = item_size - ENTRY_TYPE_SIZE - TIMESTAMP_SIZE;
 
+        SlotGuard guard{rb, item};
+
         switch (wire_type) {
             case SENDSPIN_BINARY_VISUALIZER_LOUDNESS: {
+                if (payload_len < LOUDNESS_PAYLOAD_SIZE) {
+                    break;
+                }
                 uint16_t loudness = read_be16(payload);
-                rb.return_item(item);
+                guard.release();
                 self->listener->on_loudness(client_ts, loudness);
                 break;
             }
             case SENDSPIN_BINARY_VISUALIZER_BEAT: {
+                if (payload_len < BEAT_PAYLOAD_SIZE) {
+                    break;
+                }
                 // Bit 0 is only meaningful when the stream tracks downbeats
                 bool downbeat = self->tracks_downbeats && (payload[0] & BEAT_FLAG_DOWNBEAT) != 0;
-                rb.return_item(item);
+                guard.release();
                 self->listener->on_beat(client_ts, downbeat);
                 break;
             }
             case SENDSPIN_BINARY_VISUALIZER_F_PEAK: {
+                if (payload_len < F_PEAK_PAYLOAD_SIZE) {
+                    break;
+                }
                 uint16_t freq = read_be16(payload);
                 uint16_t amp = read_be16(payload + 2);
-                rb.return_item(item);
+                guard.release();
                 self->listener->on_f_peak(client_ts, freq, amp);
                 break;
             }
             case SENDSPIN_BINARY_VISUALIZER_SPECTRUM: {
-                size_t bin_count = payload_len / 2;
-                spectrum_bins.resize(bin_count);
-                for (size_t b = 0; b < bin_count; ++b) {
+                // Deliver exactly the negotiated n_disp_bins. Drop the frame if SPECTRUM was not
+                // negotiated (bin count 0) or the payload is short; ignore any trailing bytes.
+                uint8_t configured = self->spectrum_bin_count;
+                if (configured == 0 || payload_len < 2U * configured) {
+                    break;
+                }
+                spectrum_bins.resize(configured);
+                for (uint8_t b = 0; b < configured; ++b) {
                     spectrum_bins[b] = read_be16(payload + 2 * b);
                 }
-                rb.return_item(item);
+                guard.release();
                 self->listener->on_spectrum(client_ts, spectrum_bins);
                 break;
             }
             case SENDSPIN_BINARY_VISUALIZER_PEAK: {
+                if (payload_len < PEAK_PAYLOAD_SIZE) {
+                    break;
+                }
                 uint8_t strength = payload[0];
-                rb.return_item(item);
+                guard.release();
                 self->listener->on_peak(client_ts, strength);
                 break;
             }
             default:
-                rb.return_item(item);
-                break;
+                break;  // Reserved types 21-23; guard returns the slot
         }
     }
 

--- a/src/visualizer_role.cpp
+++ b/src/visualizer_role.cpp
@@ -312,6 +312,60 @@ void VisualizerRole::Impl::cleanup() {
 // Drain thread helpers
 // ============================================================================
 
+VisualizerDelivery decode_visualizer_message(uint8_t wire_type, const uint8_t* payload,
+                                             size_t payload_len, uint8_t configured_bins,
+                                             bool tracks_downbeats,
+                                             std::vector<uint16_t>& spectrum_out) {
+    VisualizerDelivery out;
+    switch (wire_type) {
+        case SENDSPIN_BINARY_VISUALIZER_LOUDNESS:
+            if (payload_len < LOUDNESS_PAYLOAD_SIZE) {
+                break;
+            }
+            out.kind = VisualizerDelivery::Kind::LOUDNESS;
+            out.loudness = read_be16(payload);
+            break;
+        case SENDSPIN_BINARY_VISUALIZER_BEAT:
+            if (payload_len < BEAT_PAYLOAD_SIZE) {
+                break;
+            }
+            out.kind = VisualizerDelivery::Kind::BEAT;
+            // Bit 0 is only meaningful when the stream tracks downbeats
+            out.downbeat = tracks_downbeats && (payload[0] & BEAT_FLAG_DOWNBEAT) != 0;
+            break;
+        case SENDSPIN_BINARY_VISUALIZER_F_PEAK:
+            if (payload_len < F_PEAK_PAYLOAD_SIZE) {
+                break;
+            }
+            out.kind = VisualizerDelivery::Kind::F_PEAK;
+            out.frequency_hz = read_be16(payload);
+            out.amplitude = read_be16(payload + 2);
+            break;
+        case SENDSPIN_BINARY_VISUALIZER_SPECTRUM:
+            // Deliver exactly the negotiated n_disp_bins. Drop the frame if SPECTRUM was not
+            // negotiated (bin count 0) or the payload is short; ignore any trailing bytes.
+            if (configured_bins == 0 || payload_len < 2U * configured_bins) {
+                break;
+            }
+            spectrum_out.resize(configured_bins);
+            for (uint8_t b = 0; b < configured_bins; ++b) {
+                spectrum_out[b] = read_be16(payload + 2 * b);
+            }
+            out.kind = VisualizerDelivery::Kind::SPECTRUM;
+            break;
+        case SENDSPIN_BINARY_VISUALIZER_PEAK:
+            if (payload_len < PEAK_PAYLOAD_SIZE) {
+                break;
+            }
+            out.kind = VisualizerDelivery::Kind::PEAK;
+            out.strength = payload[0];
+            break;
+        default:
+            break;  // Reserved types 21-23
+    }
+    return out;
+}
+
 void VisualizerRole::Impl::flush_ring_buffer() const {
     if (!this->drain_task) {
         return;
@@ -421,69 +475,36 @@ void VisualizerRole::Impl::drain_thread_func(VisualizerRole::Impl* self) {
             continue;
         }
 
-        // Parse and deliver. The network thread forwards messages verbatim, so every branch
-        // validates its own payload length here before reading.
+        // Decode and deliver. The network thread forwards messages verbatim, so decode validates
+        // each payload's length before reading. Copy out of the slot, release it via the guard,
+        // then deliver -- so a slow listener callback never blocks the network producer.
         const uint8_t* payload = raw + ENTRY_TYPE_SIZE + TIMESTAMP_SIZE;
         size_t payload_len = item_size - ENTRY_TYPE_SIZE - TIMESTAMP_SIZE;
 
         SlotGuard guard{rb, item};
+        VisualizerDelivery out =
+            decode_visualizer_message(wire_type, payload, payload_len, self->spectrum_bin_count,
+                                      self->tracks_downbeats, spectrum_bins);
+        guard.release();
 
-        switch (wire_type) {
-            case SENDSPIN_BINARY_VISUALIZER_LOUDNESS: {
-                if (payload_len < LOUDNESS_PAYLOAD_SIZE) {
-                    break;
-                }
-                uint16_t loudness = read_be16(payload);
-                guard.release();
-                self->listener->on_loudness(client_ts, loudness);
+        switch (out.kind) {
+            case VisualizerDelivery::Kind::LOUDNESS:
+                self->listener->on_loudness(client_ts, out.loudness);
                 break;
-            }
-            case SENDSPIN_BINARY_VISUALIZER_BEAT: {
-                if (payload_len < BEAT_PAYLOAD_SIZE) {
-                    break;
-                }
-                // Bit 0 is only meaningful when the stream tracks downbeats
-                bool downbeat = self->tracks_downbeats && (payload[0] & BEAT_FLAG_DOWNBEAT) != 0;
-                guard.release();
-                self->listener->on_beat(client_ts, downbeat);
+            case VisualizerDelivery::Kind::BEAT:
+                self->listener->on_beat(client_ts, out.downbeat);
                 break;
-            }
-            case SENDSPIN_BINARY_VISUALIZER_F_PEAK: {
-                if (payload_len < F_PEAK_PAYLOAD_SIZE) {
-                    break;
-                }
-                uint16_t freq = read_be16(payload);
-                uint16_t amp = read_be16(payload + 2);
-                guard.release();
-                self->listener->on_f_peak(client_ts, freq, amp);
+            case VisualizerDelivery::Kind::F_PEAK:
+                self->listener->on_f_peak(client_ts, out.frequency_hz, out.amplitude);
                 break;
-            }
-            case SENDSPIN_BINARY_VISUALIZER_SPECTRUM: {
-                // Deliver exactly the negotiated n_disp_bins. Drop the frame if SPECTRUM was not
-                // negotiated (bin count 0) or the payload is short; ignore any trailing bytes.
-                uint8_t configured = self->spectrum_bin_count;
-                if (configured == 0 || payload_len < 2U * configured) {
-                    break;
-                }
-                spectrum_bins.resize(configured);
-                for (uint8_t b = 0; b < configured; ++b) {
-                    spectrum_bins[b] = read_be16(payload + 2 * b);
-                }
-                guard.release();
+            case VisualizerDelivery::Kind::SPECTRUM:
                 self->listener->on_spectrum(client_ts, spectrum_bins);
                 break;
-            }
-            case SENDSPIN_BINARY_VISUALIZER_PEAK: {
-                if (payload_len < PEAK_PAYLOAD_SIZE) {
-                    break;
-                }
-                uint8_t strength = payload[0];
-                guard.release();
-                self->listener->on_peak(client_ts, strength);
+            case VisualizerDelivery::Kind::PEAK:
+                self->listener->on_peak(client_ts, out.strength);
                 break;
-            }
-            default:
-                break;  // Reserved types 21-23; guard returns the slot
+            case VisualizerDelivery::Kind::NONE:
+                break;
         }
     }
 

--- a/src/visualizer_role_impl.h
+++ b/src/visualizer_role_impl.h
@@ -113,6 +113,8 @@ struct VisualizerRole::Impl {
 
     void stop() const;
     void flush_ring_buffer() const;
+    void signal_clear_marker() const;
+    void discard_to_clear_marker() const;
     void enqueue_stream_event(VisualizerEventType event) const;
 
     static void drain_thread_func(VisualizerRole::Impl* self);
@@ -136,6 +138,11 @@ struct VisualizerRole::Impl {
     std::atomic<uint8_t> spectrum_bin_count{0};
     std::atomic<bool> tracks_downbeats{false};
     std::atomic<bool> stream_active{false};
+    // Bitmask of negotiated wire types, bit N = wire type SENDSPIN_BINARY_VISUALIZER_FIRST + N.
+    // Written by handle_stream_start and read by handle_binary on the same network thread, so
+    // admission is always judged against the config in force when a message arrives; atomic only
+    // because cleanup() clears it from the main thread.
+    std::atomic<uint8_t> negotiated_types_mask{0};
 };
 
 }  // namespace sendspin

--- a/src/visualizer_role_impl.h
+++ b/src/visualizer_role_impl.h
@@ -76,6 +76,7 @@ struct VisualizerRole::Impl {
     void handle_stream_clear();
     void handle_stream_ring_event(VisualizerEventType event) const;
     void cleanup();
+    void request_format(const VisualizerFormatRequest& request) const;
 
     // ========================================
     // Internal helpers
@@ -103,11 +104,8 @@ struct VisualizerRole::Impl {
     VisualizerRoleListener* listener{nullptr};
 
     // Atomic fields (written by network thread, read by drain thread / cleanup)
-    std::atomic<size_t> raw_frame_size{0};
-    std::atomic<bool> has_f_peak{false};
-    std::atomic<bool> has_loudness{false};
-    std::atomic<bool> has_spectrum{false};
     std::atomic<uint8_t> spectrum_bin_count{0};
+    std::atomic<bool> tracks_downbeats{false};
     std::atomic<bool> stream_active{false};
 };
 

--- a/src/visualizer_role_impl.h
+++ b/src/visualizer_role_impl.h
@@ -102,7 +102,7 @@ struct VisualizerRole::Impl {
     void handle_binary(uint8_t binary_type, const uint8_t* data, size_t len);
     void handle_stream_start(const ServerVisualizerStreamObject& stream);
     void handle_stream_end();
-    void handle_stream_clear();
+    void handle_stream_clear() const;
     void handle_stream_ring_event(VisualizerEventType event) const;
     void cleanup();
     void request_format(const VisualizerFormatRequest& request) const;

--- a/src/visualizer_role_impl.h
+++ b/src/visualizer_role_impl.h
@@ -24,9 +24,11 @@
 #include "sendspin/visualizer_role.h"
 
 #include <atomic>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <thread>
+#include <vector>
 
 namespace sendspin {
 
@@ -39,6 +41,33 @@ enum class VisualizerEventType : uint8_t {
     STREAM_END,
     STREAM_CLEAR,
 };
+
+/// @brief Result of decoding one visualizer wire message, ready to hand to the listener.
+/// A kind of None means the entry was malformed, short, or non-deliverable and should be dropped.
+/// For Spectrum, the decoded bins are written into the caller-supplied scratch vector.
+struct VisualizerDelivery {
+    enum class Kind : uint8_t { NONE, LOUDNESS, BEAT, F_PEAK, SPECTRUM, PEAK };
+    Kind kind{Kind::NONE};
+    uint16_t loudness{0};
+    bool downbeat{false};
+    uint16_t frequency_hz{0};
+    uint16_t amplitude{0};
+    uint8_t strength{0};
+};
+
+/// @brief Validates and decodes one visualizer entry payload. Pure drain-thread logic with no I/O,
+/// factored out so it can be unit tested independently of the client and drain thread.
+/// @param wire_type        SENDSPIN_BINARY_VISUALIZER_* type byte.
+/// @param payload          Bytes following the entry's wire-type byte and 8-byte timestamp.
+/// @param payload_len      Number of payload bytes available.
+/// @param configured_bins  Negotiated spectrum n_disp_bins (0 if SPECTRUM was not negotiated).
+/// @param tracks_downbeats Whether the active stream reports downbeats.
+/// @param spectrum_out     Scratch vector reused for SPECTRUM bins; resized to configured_bins.
+/// @return What to deliver; Kind::None if the entry is malformed, short, or non-deliverable.
+VisualizerDelivery decode_visualizer_message(uint8_t wire_type, const uint8_t* payload,
+                                             size_t payload_len, uint8_t configured_bins,
+                                             bool tracks_downbeats,
+                                             std::vector<uint16_t>& spectrum_out);
 
 /// @brief Private implementation of the visualizer role
 struct VisualizerRole::Impl {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(sendspin_tests
     test_network_info.cpp
     test_spsc_ring_buffer.cpp
     test_inbox.cpp
+    test_visualizer_role.cpp
 )
 
 # Reach the library's private headers (protocol_messages.h, time_filter.h, ...).

--- a/tests/test_protocol.cpp
+++ b/tests/test_protocol.cpp
@@ -377,8 +377,8 @@ TEST(Protocol, ServerHelloRejectsInvalidVersion) {
 }
 
 // If a visualizer stream advertises SPECTRUM in its `types`, a valid spectrum config with a non-zero
-// bin count must be present. Otherwise raw_frame_size would be indeterminate and subsequent binary
-// visualizer frames would misparse, so the whole stream/start is rejected.
+// bin count must be present. Otherwise the expected size of binary spectrum messages would be
+// indeterminate, so the whole stream/start is rejected.
 TEST(Protocol, StreamStartRejectsSpectrumWithoutValidConfig) {
     // (a) SPECTRUM advertised but no spectrum object at all.
     {
@@ -415,12 +415,14 @@ TEST(Protocol, StreamStartRejectsSpectrumWithoutValidConfig) {
     JsonDocument doc_ok;
     JsonObject root_ok;
     ASSERT_TRUE(parse(R"({"type":"stream/start","payload":{"visualizer":{"types":["spectrum"],)"
-                      R"("spectrum":{"n_disp_bins":32,"scale":"log","f_min":20,"f_max":20000,)"
-                      R"("rate_max":30}}}})",
+                      R"("rate_max":30,)"
+                      R"("spectrum":{"n_disp_bins":32,"scale":"log","f_min":20,"f_max":20000}}}})",
                       doc_ok, root_ok));
     StreamStartMessage ok;
     ASSERT_TRUE(process_stream_start_message(root_ok, &ok));
     ASSERT_TRUE(ok.visualizer.has_value());
+    EXPECT_EQ(ok.visualizer->rate_max, 30);
+    EXPECT_FALSE(ok.visualizer->tracks_downbeats);
     ASSERT_TRUE(ok.visualizer->spectrum.has_value());
     EXPECT_EQ(ok.visualizer->spectrum->n_disp_bins, 32);
 }
@@ -567,6 +569,79 @@ TEST(Protocol, FormatClientHelloDeviceInfoFieldsPresent) {
     EXPECT_STREQ(doc["payload"]["device_info"]["manufacturer"], "ESPHome");
     EXPECT_STREQ(doc["payload"]["device_info"]["software_version"], "1.2.3");
     EXPECT_STREQ(doc["payload"]["device_info"]["mac_address"], "aa:bb:cc:dd:ee:ff");
+}
+
+// The visualizer@v1 support object serializes with the spec's field layout: types (including
+// the event types), buffer_capacity, top-level rate_max, and a spectrum object without a
+// nested rate cap.
+TEST(Protocol, FormatClientHelloVisualizerSupport) {
+    ClientHelloMessage msg;
+    msg.client_id = "abc";
+    msg.name = "Speaker";
+    msg.version = 1;
+    msg.supported_roles.push_back(SendspinRole::VISUALIZER);
+    VisualizerSupportObject vis{};
+    vis.types = {VisualizerDataType::BEAT, VisualizerDataType::LOUDNESS,
+                 VisualizerDataType::F_PEAK, VisualizerDataType::SPECTRUM,
+                 VisualizerDataType::PEAK};
+    vis.buffer_capacity = 8192;
+    vis.rate_max = 60;
+    vis.spectrum = VisualizerSpectrumConfig{
+        .n_disp_bins = 32,
+        .scale = VisualizerSpectrumScale::MEL,
+        .f_min = 40,
+        .f_max = 16000,
+    };
+    msg.visualizer_support = vis;
+
+    JsonDocument doc;
+    ASSERT_FALSE(deserializeJson(doc, format_client_hello_message(&msg)));
+    EXPECT_STREQ(doc["payload"]["supported_roles"][0], "visualizer@v1");
+    JsonObject support = doc["payload"]["visualizer@v1_support"];
+    ASSERT_TRUE(support["types"].is<JsonArray>());
+    EXPECT_EQ(support["types"].size(), 5U);
+    EXPECT_STREQ(support["types"][4], "peak");
+    EXPECT_EQ(support["buffer_capacity"].as<int>(), 8192);
+    EXPECT_EQ(support["rate_max"].as<int>(), 60);
+    EXPECT_EQ(support["spectrum"]["n_disp_bins"].as<int>(), 32);
+    EXPECT_STREQ(support["spectrum"]["scale"], "mel");
+    EXPECT_EQ(support["spectrum"]["f_min"].as<int>(), 40);
+    EXPECT_EQ(support["spectrum"]["f_max"].as<int>(), 16000);
+    EXPECT_FALSE(support["spectrum"]["rate_max"].is<int>());
+    EXPECT_FALSE(support["batch_max"].is<int>());
+}
+
+// stream/request-format serializes the visualizer object with only the fields the caller set;
+// omitted optionals keep their current server-side value and must not emit keys.
+TEST(Protocol, FormatStreamRequestFormatVisualizer) {
+    StreamRequestFormatMessage msg;
+    VisualizerFormatRequest req{};
+    req.rate_max = 24;
+    msg.visualizer = req;
+
+    JsonDocument doc;
+    ASSERT_FALSE(deserializeJson(doc, format_stream_request_format_message(&msg)));
+    EXPECT_STREQ(doc["type"], "stream/request-format");
+    EXPECT_EQ(doc["payload"]["visualizer"]["rate_max"].as<int>(), 24);
+    EXPECT_FALSE(doc["payload"]["visualizer"]["types"].is<JsonArray>());
+    EXPECT_FALSE(doc["payload"]["visualizer"]["spectrum"].is<JsonObject>());
+
+    // Full request: all fields emitted.
+    VisualizerFormatRequest full{};
+    full.types = std::vector<VisualizerDataType>{VisualizerDataType::SPECTRUM};
+    full.rate_max = 30;
+    full.spectrum = VisualizerSpectrumConfig{
+        .n_disp_bins = 16,
+        .scale = VisualizerSpectrumScale::LOG,
+        .f_min = 20,
+        .f_max = 20000,
+    };
+    msg.visualizer = full;
+    JsonDocument doc2;
+    ASSERT_FALSE(deserializeJson(doc2, format_stream_request_format_message(&msg)));
+    EXPECT_STREQ(doc2["payload"]["visualizer"]["types"][0], "spectrum");
+    EXPECT_EQ(doc2["payload"]["visualizer"]["spectrum"]["n_disp_bins"].as<int>(), 16);
+    EXPECT_STREQ(doc2["payload"]["visualizer"]["spectrum"]["scale"], "log");
 }
 
 // Unset optional identity fields must not emit their keys.

--- a/tests/test_protocol.cpp
+++ b/tests/test_protocol.cpp
@@ -378,8 +378,9 @@ TEST(Protocol, ServerHelloRejectsInvalidVersion) {
 
 // If a visualizer stream advertises SPECTRUM in its `types`, a valid spectrum config with a non-zero
 // bin count must be present. Otherwise the expected size of binary spectrum messages would be
-// indeterminate, so the whole stream/start is rejected.
-TEST(Protocol, StreamStartRejectsSpectrumWithoutValidConfig) {
+// indeterminate, so the visualizer object is dropped -- but only the visualizer object: the message
+// itself still parses so a well-formed player/artwork start alongside it is not lost.
+TEST(Protocol, StreamStartDropsSpectrumWithoutValidConfig) {
     // (a) SPECTRUM advertised but no spectrum object at all.
     {
         JsonDocument doc;
@@ -388,7 +389,8 @@ TEST(Protocol, StreamStartRejectsSpectrumWithoutValidConfig) {
             R"({"type":"stream/start","payload":{"visualizer":{"types":["spectrum"]}}})", doc,
             root));
         StreamStartMessage msg;
-        EXPECT_FALSE(process_stream_start_message(root, &msg));
+        EXPECT_TRUE(process_stream_start_message(root, &msg));
+        EXPECT_FALSE(msg.visualizer.has_value());
     }
     // (b) spectrum object present but n_disp_bins is zero.
     {
@@ -398,7 +400,8 @@ TEST(Protocol, StreamStartRejectsSpectrumWithoutValidConfig) {
                           R"("spectrum":{"n_disp_bins":0}}}})",
                           doc, root));
         StreamStartMessage msg;
-        EXPECT_FALSE(process_stream_start_message(root, &msg));
+        EXPECT_TRUE(process_stream_start_message(root, &msg));
+        EXPECT_FALSE(msg.visualizer.has_value());
     }
     // (c) n_disp_bins present but not an integer.
     {
@@ -408,7 +411,23 @@ TEST(Protocol, StreamStartRejectsSpectrumWithoutValidConfig) {
                           R"("spectrum":{"n_disp_bins":"32"}}}})",
                           doc, root));
         StreamStartMessage msg;
-        EXPECT_FALSE(process_stream_start_message(root, &msg));
+        EXPECT_TRUE(process_stream_start_message(root, &msg));
+        EXPECT_FALSE(msg.visualizer.has_value());
+    }
+    // (d) a valid player start in the same message survives the malformed visualizer object.
+    {
+        JsonDocument doc;
+        JsonObject root;
+        ASSERT_TRUE(parse(R"({"type":"stream/start","payload":{)"
+                          R"("player":{"codec":"pcm","sample_rate":48000,"channels":2,)"
+                          R"("bit_depth":16},)"
+                          R"("visualizer":{"types":["spectrum"]}}})",
+                          doc, root));
+        StreamStartMessage msg;
+        EXPECT_TRUE(process_stream_start_message(root, &msg));
+        EXPECT_FALSE(msg.visualizer.has_value());
+        ASSERT_TRUE(msg.player.has_value());
+        EXPECT_EQ(msg.player->sample_rate, 48000U);
     }
 
     // Control: SPECTRUM advertised with a valid config is accepted.
@@ -642,6 +661,13 @@ TEST(Protocol, FormatStreamRequestFormatVisualizer) {
     EXPECT_STREQ(doc2["payload"]["visualizer"]["types"][0], "spectrum");
     EXPECT_EQ(doc2["payload"]["visualizer"]["spectrum"]["n_disp_bins"].as<int>(), 16);
     EXPECT_STREQ(doc2["payload"]["visualizer"]["spectrum"]["scale"], "log");
+
+    // All-empty request: no "visualizer" key at all. A present-but-empty object could read as
+    // "reset to defaults" rather than "no change" on the server.
+    msg.visualizer = VisualizerFormatRequest{};
+    JsonDocument doc3;
+    ASSERT_FALSE(deserializeJson(doc3, format_stream_request_format_message(&msg)));
+    EXPECT_FALSE(doc3["payload"]["visualizer"].is<JsonObject>());
 }
 
 // Unset optional identity fields must not emit their keys.

--- a/tests/test_visualizer_role.cpp
+++ b/tests/test_visualizer_role.cpp
@@ -204,12 +204,14 @@ namespace {
 
 // A visualizer Impl with a real ring buffer and no client (handle_binary never touches it).
 // Heap-allocated because Impl holds atomics and so is neither copyable nor movable. The stream is
-// marked active so handle_binary will accept messages.
+// marked active and all defined wire types are marked negotiated so handle_binary will accept
+// messages (bits 0-4 = wire types 16-20).
 std::unique_ptr<VisualizerRole::Impl> make_impl() {
     VisualizerRoleConfig config;
     config.support.buffer_capacity = 4096;
     auto impl = std::make_unique<VisualizerRole::Impl>(std::move(config), nullptr);
     impl->stream_active = true;
+    impl->negotiated_types_mask = 0x1F;
     return impl;
 }
 
@@ -285,18 +287,110 @@ TEST(VisualizerHandleBinary, ForwardsOversizedMessageWithoutCapping) {
     EXPECT_EQ(entry.size(), data.size() + 1);  // stored at full length, uncapped
 }
 
-TEST(VisualizerHandleBinary, ForwardsReservedTypeVerbatim) {
-    // The network thread is type-agnostic; reserved types are forwarded and dropped later by the
-    // drain thread's decode step.
+TEST(VisualizerHandleBinary, DropsUnnegotiatedType) {
+    // Only wire types the stream/start negotiated are admitted; a defined-but-unnegotiated type
+    // and a reserved type (which can never be negotiated) are both dropped at the network thread.
+    auto impl = make_impl();
+    impl->negotiated_types_mask =
+        1U << (SENDSPIN_BINARY_VISUALIZER_LOUDNESS - SENDSPIN_BINARY_VISUALIZER_FIRST);
+
+    std::vector<uint8_t> data;
+    put_be64(data, 1);
+    put_be16(data, 0x0042);
+
+    impl->handle_binary(SENDSPIN_BINARY_VISUALIZER_BEAT, data.data(), data.size());
+    impl->handle_binary(21, data.data(), data.size());  // reserved type
+
+    std::vector<uint8_t> entry;
+    EXPECT_FALSE(pop_entry(*impl, entry));
+
+    // Control: the negotiated type is still forwarded.
+    impl->handle_binary(SENDSPIN_BINARY_VISUALIZER_LOUDNESS, data.data(), data.size());
+    ASSERT_TRUE(pop_entry(*impl, entry));
+    EXPECT_EQ(entry[0], SENDSPIN_BINARY_VISUALIZER_LOUDNESS);
+}
+
+TEST(VisualizerHandleBinary, StreamStartNegotiatesTypes) {
+    // handle_stream_start derives the admission mask from the advertised types.
+    auto impl = make_impl();
+    impl->negotiated_types_mask = 0;
+
+    ServerVisualizerStreamObject stream;
+    stream.types = {VisualizerDataType::BEAT};
+    impl->handle_stream_start(stream);
+
+    // stream/start enqueues a 1-byte boundary marker; consume it first.
+    std::vector<uint8_t> entry;
+    ASSERT_TRUE(pop_entry(*impl, entry));
+    ASSERT_EQ(entry.size(), 1U);
+
+    std::vector<uint8_t> data;
+    put_be64(data, 1);
+    data.push_back(0x01);
+
+    impl->handle_binary(SENDSPIN_BINARY_VISUALIZER_BEAT, data.data(), data.size());
+    ASSERT_TRUE(pop_entry(*impl, entry));
+    EXPECT_EQ(entry[0], SENDSPIN_BINARY_VISUALIZER_BEAT);
+
+    impl->handle_binary(SENDSPIN_BINARY_VISUALIZER_LOUDNESS, data.data(), data.size());
+    EXPECT_FALSE(pop_entry(*impl, entry));
+}
+
+// ============================================================================
+// Clear-boundary marker: stream/clear (and stream/start) enqueue a sentinel so
+// the drain thread discards exactly the entries that predate the boundary.
+// ============================================================================
+
+TEST(VisualizerClearMarker, StreamClearEnqueuesMarker) {
+    auto impl = make_impl();
+
+    impl->handle_stream_clear();
+
+    // The marker is a single 0xFF byte, outside the visualizer wire-type range.
+    std::vector<uint8_t> entry;
+    ASSERT_TRUE(pop_entry(*impl, entry));
+    ASSERT_EQ(entry.size(), 1U);
+    EXPECT_EQ(entry[0], 0xFF);
+}
+
+TEST(VisualizerClearMarker, DiscardPreservesPostClearFrames) {
+    auto impl = make_impl();
+
+    std::vector<uint8_t> pre;
+    put_be64(pre, 1);
+    put_be16(pre, 0x0001);
+    impl->handle_binary(SENDSPIN_BINARY_VISUALIZER_LOUDNESS, pre.data(), pre.size());
+
+    impl->handle_stream_clear();
+
+    std::vector<uint8_t> post;
+    put_be64(post, 2);
+    put_be16(post, 0x0002);
+    impl->handle_binary(SENDSPIN_BINARY_VISUALIZER_LOUDNESS, post.data(), post.size());
+
+    impl->discard_to_clear_marker();
+
+    // The pre-clear frame and the marker are gone; the post-clear frame survives.
+    std::vector<uint8_t> entry;
+    ASSERT_TRUE(pop_entry(*impl, entry));
+    EXPECT_EQ(entry[0], SENDSPIN_BINARY_VISUALIZER_LOUDNESS);
+    EXPECT_EQ(entry.back(), 0x02);
+    EXPECT_FALSE(pop_entry(*impl, entry));
+}
+
+TEST(VisualizerClearMarker, DiscardDrainsToEmptyWithoutMarker) {
+    // If the marker is missing (failed enqueue or already consumed), the discard degrades to
+    // draining whatever is buffered.
     auto impl = make_impl();
 
     std::vector<uint8_t> data;
     put_be64(data, 1);
-    data.push_back(0x00);
+    put_be16(data, 0x0001);
+    impl->handle_binary(SENDSPIN_BINARY_VISUALIZER_LOUDNESS, data.data(), data.size());
+    impl->handle_binary(SENDSPIN_BINARY_VISUALIZER_LOUDNESS, data.data(), data.size());
 
-    impl->handle_binary(21, data.data(), data.size());
+    impl->discard_to_clear_marker();
 
     std::vector<uint8_t> entry;
-    ASSERT_TRUE(pop_entry(*impl, entry));
-    EXPECT_EQ(entry[0], 21);
+    EXPECT_FALSE(pop_entry(*impl, entry));
 }

--- a/tests/test_visualizer_role.cpp
+++ b/tests/test_visualizer_role.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <deque>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -206,10 +207,19 @@ namespace {
 // Heap-allocated because Impl holds atomics and so is neither copyable nor movable. The stream is
 // marked active and all defined wire types are marked negotiated so handle_binary will accept
 // messages (bits 0-4 = wire types 16-20).
+//
+// handle_stream_start writes the stream config into an InboxSlot, which asserts it has been bound
+// to an Inbox first. Give each Impl its own Inbox with program lifetime: Inbox is non-movable, so
+// a deque (which never relocates existing elements) provides a stable address that outlives the
+// returned Impl, which only holds a pointer to it.
 std::unique_ptr<VisualizerRole::Impl> make_impl() {
+    static std::deque<Inbox> inboxes;
+
     VisualizerRoleConfig config;
     config.support.buffer_capacity = 4096;
     auto impl = std::make_unique<VisualizerRole::Impl>(std::move(config), nullptr);
+    inboxes.emplace_back();
+    impl->attach_inbox(inboxes.back());
     impl->stream_active = true;
     impl->negotiated_types_mask = 0x1F;
     return impl;

--- a/tests/test_visualizer_role.cpp
+++ b/tests/test_visualizer_role.cpp
@@ -1,0 +1,302 @@
+// Copyright 2026 Sendspin Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "protocol_messages.h"
+#include "visualizer_role_impl.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+using namespace sendspin;
+
+namespace {
+
+// Appends val as 8 big-endian bytes (the server timestamp prefix of every visualizer message).
+void put_be64(std::vector<uint8_t>& out, int64_t val) {
+    auto u = static_cast<uint64_t>(val);
+    for (int i = 7; i >= 0; --i) {
+        out.push_back(static_cast<uint8_t>((u >> (8 * i)) & 0xFF));
+    }
+}
+
+void put_be16(std::vector<uint8_t>& out, uint16_t val) {
+    out.push_back(static_cast<uint8_t>(val >> 8));
+    out.push_back(static_cast<uint8_t>(val & 0xFF));
+}
+
+}  // namespace
+
+// ============================================================================
+// decode_visualizer_message: the drain thread's per-type validation and parsing
+// ============================================================================
+
+TEST(VisualizerDecode, LoudnessDecodesBigEndian) {
+    std::vector<uint8_t> payload;
+    put_be16(payload, 0x1234);
+    std::vector<uint16_t> bins;
+
+    auto out = decode_visualizer_message(SENDSPIN_BINARY_VISUALIZER_LOUDNESS, payload.data(),
+                                         payload.size(), 0, false, bins);
+    EXPECT_EQ(out.kind, VisualizerDelivery::Kind::LOUDNESS);
+    EXPECT_EQ(out.loudness, 0x1234);
+}
+
+TEST(VisualizerDecode, LoudnessTooShortDropped) {
+    std::vector<uint8_t> payload = {0x12};  // 1 byte, needs 2
+    std::vector<uint16_t> bins;
+    auto out = decode_visualizer_message(SENDSPIN_BINARY_VISUALIZER_LOUDNESS, payload.data(),
+                                         payload.size(), 0, false, bins);
+    EXPECT_EQ(out.kind, VisualizerDelivery::Kind::NONE);
+}
+
+TEST(VisualizerDecode, BeatDownbeatGatedOnTracksDownbeats) {
+    std::vector<uint8_t> payload = {0x01};  // downbeat bit set
+    std::vector<uint16_t> bins;
+
+    // Stream tracks downbeats: bit 0 is meaningful.
+    auto tracked = decode_visualizer_message(SENDSPIN_BINARY_VISUALIZER_BEAT, payload.data(),
+                                             payload.size(), 0, true, bins);
+    EXPECT_EQ(tracked.kind, VisualizerDelivery::Kind::BEAT);
+    EXPECT_TRUE(tracked.downbeat);
+
+    // Stream does not track downbeats: the bit must be ignored.
+    auto untracked = decode_visualizer_message(SENDSPIN_BINARY_VISUALIZER_BEAT, payload.data(),
+                                               payload.size(), 0, false, bins);
+    EXPECT_EQ(untracked.kind, VisualizerDelivery::Kind::BEAT);
+    EXPECT_FALSE(untracked.downbeat);
+}
+
+TEST(VisualizerDecode, BeatWithoutDownbeatBit) {
+    std::vector<uint8_t> payload = {0x00};
+    std::vector<uint16_t> bins;
+    auto out = decode_visualizer_message(SENDSPIN_BINARY_VISUALIZER_BEAT, payload.data(),
+                                         payload.size(), 0, true, bins);
+    EXPECT_EQ(out.kind, VisualizerDelivery::Kind::BEAT);
+    EXPECT_FALSE(out.downbeat);
+}
+
+TEST(VisualizerDecode, BeatEmptyDropped) {
+    std::vector<uint16_t> bins;
+    auto out = decode_visualizer_message(SENDSPIN_BINARY_VISUALIZER_BEAT, nullptr, 0, 0, true, bins);
+    EXPECT_EQ(out.kind, VisualizerDelivery::Kind::NONE);
+}
+
+TEST(VisualizerDecode, FPeakDecodesFreqAndAmplitude) {
+    std::vector<uint8_t> payload;
+    put_be16(payload, 440);
+    put_be16(payload, 0xBEEF);
+    std::vector<uint16_t> bins;
+
+    auto out = decode_visualizer_message(SENDSPIN_BINARY_VISUALIZER_F_PEAK, payload.data(),
+                                         payload.size(), 0, false, bins);
+    EXPECT_EQ(out.kind, VisualizerDelivery::Kind::F_PEAK);
+    EXPECT_EQ(out.frequency_hz, 440);
+    EXPECT_EQ(out.amplitude, 0xBEEF);
+}
+
+TEST(VisualizerDecode, FPeakTooShortDropped) {
+    std::vector<uint8_t> payload = {0x01, 0xB8, 0x00};  // 3 bytes, needs 4
+    std::vector<uint16_t> bins;
+    auto out = decode_visualizer_message(SENDSPIN_BINARY_VISUALIZER_F_PEAK, payload.data(),
+                                         payload.size(), 0, false, bins);
+    EXPECT_EQ(out.kind, VisualizerDelivery::Kind::NONE);
+}
+
+TEST(VisualizerDecode, SpectrumDeliversNegotiatedBinCount) {
+    std::vector<uint8_t> payload;
+    put_be16(payload, 10);
+    put_be16(payload, 20);
+    put_be16(payload, 30);
+    std::vector<uint16_t> bins;
+
+    auto out = decode_visualizer_message(SENDSPIN_BINARY_VISUALIZER_SPECTRUM, payload.data(),
+                                         payload.size(), 3, false, bins);
+    EXPECT_EQ(out.kind, VisualizerDelivery::Kind::SPECTRUM);
+    ASSERT_EQ(bins.size(), 3U);
+    EXPECT_EQ(bins[0], 10);
+    EXPECT_EQ(bins[1], 20);
+    EXPECT_EQ(bins[2], 30);
+}
+
+TEST(VisualizerDecode, SpectrumIgnoresTrailingBytes) {
+    // 3 bins on the wire, but only 2 were negotiated: deliver 2 and ignore the rest.
+    std::vector<uint8_t> payload;
+    put_be16(payload, 10);
+    put_be16(payload, 20);
+    put_be16(payload, 30);
+    std::vector<uint16_t> bins;
+
+    auto out = decode_visualizer_message(SENDSPIN_BINARY_VISUALIZER_SPECTRUM, payload.data(),
+                                         payload.size(), 2, false, bins);
+    EXPECT_EQ(out.kind, VisualizerDelivery::Kind::SPECTRUM);
+    ASSERT_EQ(bins.size(), 2U);
+    EXPECT_EQ(bins[0], 10);
+    EXPECT_EQ(bins[1], 20);
+}
+
+TEST(VisualizerDecode, SpectrumShortPayloadDropped) {
+    // Negotiated 4 bins (8 bytes) but only 3 bins present.
+    std::vector<uint8_t> payload;
+    put_be16(payload, 10);
+    put_be16(payload, 20);
+    put_be16(payload, 30);
+    std::vector<uint16_t> bins;
+
+    auto out = decode_visualizer_message(SENDSPIN_BINARY_VISUALIZER_SPECTRUM, payload.data(),
+                                         payload.size(), 4, false, bins);
+    EXPECT_EQ(out.kind, VisualizerDelivery::Kind::NONE);
+}
+
+TEST(VisualizerDecode, SpectrumNotNegotiatedDropped) {
+    std::vector<uint8_t> payload;
+    put_be16(payload, 10);
+    std::vector<uint16_t> bins;
+
+    auto out = decode_visualizer_message(SENDSPIN_BINARY_VISUALIZER_SPECTRUM, payload.data(),
+                                         payload.size(), 0, false, bins);
+    EXPECT_EQ(out.kind, VisualizerDelivery::Kind::NONE);
+}
+
+TEST(VisualizerDecode, PeakDecodesStrength) {
+    std::vector<uint8_t> payload = {200};
+    std::vector<uint16_t> bins;
+    auto out = decode_visualizer_message(SENDSPIN_BINARY_VISUALIZER_PEAK, payload.data(),
+                                         payload.size(), 0, false, bins);
+    EXPECT_EQ(out.kind, VisualizerDelivery::Kind::PEAK);
+    EXPECT_EQ(out.strength, 200);
+}
+
+TEST(VisualizerDecode, PeakEmptyDropped) {
+    std::vector<uint16_t> bins;
+    auto out = decode_visualizer_message(SENDSPIN_BINARY_VISUALIZER_PEAK, nullptr, 0, 0, false, bins);
+    EXPECT_EQ(out.kind, VisualizerDelivery::Kind::NONE);
+}
+
+TEST(VisualizerDecode, ReservedTypeDropped) {
+    std::vector<uint8_t> payload = {0, 0, 0, 0};
+    std::vector<uint16_t> bins;
+    auto out = decode_visualizer_message(21, payload.data(), payload.size(), 0, false, bins);
+    EXPECT_EQ(out.kind, VisualizerDelivery::Kind::NONE);
+}
+
+// ============================================================================
+// handle_binary: the network thread forwards messages verbatim into the ring
+// buffer, doing no per-type parsing or capping.
+// ============================================================================
+
+namespace {
+
+// A visualizer Impl with a real ring buffer and no client (handle_binary never touches it).
+// Heap-allocated because Impl holds atomics and so is neither copyable nor movable. The stream is
+// marked active so handle_binary will accept messages.
+std::unique_ptr<VisualizerRole::Impl> make_impl() {
+    VisualizerRoleConfig config;
+    config.support.buffer_capacity = 4096;
+    auto impl = std::make_unique<VisualizerRole::Impl>(std::move(config), nullptr);
+    impl->stream_active = true;
+    return impl;
+}
+
+// Pops one entry from the ring buffer, or returns false if none is waiting.
+bool pop_entry(VisualizerRole::Impl& impl, std::vector<uint8_t>& out) {
+    size_t size = 0;
+    void* item = impl.drain_task->ring_buffer.receive(&size, 0);
+    if (item == nullptr) {
+        return false;
+    }
+    const auto* bytes = static_cast<const uint8_t*>(item);
+    out.assign(bytes, bytes + size);
+    impl.drain_task->ring_buffer.return_item(item);
+    return true;
+}
+
+}  // namespace
+
+TEST(VisualizerHandleBinary, ForwardsMessageVerbatim) {
+    auto impl = make_impl();
+
+    // data = [server_ts(8)][loudness(2)]
+    std::vector<uint8_t> data;
+    put_be64(data, 123456);
+    put_be16(data, 0xABCD);
+
+    impl->handle_binary(SENDSPIN_BINARY_VISUALIZER_LOUDNESS, data.data(), data.size());
+
+    std::vector<uint8_t> entry;
+    ASSERT_TRUE(pop_entry(*impl, entry));
+    // Entry = [wire_type][data...]
+    ASSERT_EQ(entry.size(), data.size() + 1);
+    EXPECT_EQ(entry[0], SENDSPIN_BINARY_VISUALIZER_LOUDNESS);
+    EXPECT_TRUE(std::equal(data.begin(), data.end(), entry.begin() + 1));
+}
+
+TEST(VisualizerHandleBinary, DropsMessageWithoutTimestamp) {
+    auto impl = make_impl();
+
+    std::vector<uint8_t> data(7, 0);  // fewer than the 8 timestamp bytes
+    impl->handle_binary(SENDSPIN_BINARY_VISUALIZER_LOUDNESS, data.data(), data.size());
+
+    std::vector<uint8_t> entry;
+    EXPECT_FALSE(pop_entry(*impl, entry));
+}
+
+TEST(VisualizerHandleBinary, DropsWhenStreamInactive) {
+    auto impl = make_impl();
+    impl->stream_active = false;
+
+    std::vector<uint8_t> data;
+    put_be64(data, 1);
+    put_be16(data, 0);
+    impl->handle_binary(SENDSPIN_BINARY_VISUALIZER_LOUDNESS, data.data(), data.size());
+
+    std::vector<uint8_t> entry;
+    EXPECT_FALSE(pop_entry(*impl, entry));
+}
+
+TEST(VisualizerHandleBinary, ForwardsOversizedMessageWithoutCapping) {
+    auto impl = make_impl();
+
+    // A loudness message with trailing junk: the network thread does not truncate.
+    std::vector<uint8_t> data;
+    put_be64(data, 1);
+    put_be16(data, 0x1111);
+    data.insert(data.end(), 64, 0xEE);  // trailing bytes
+
+    impl->handle_binary(SENDSPIN_BINARY_VISUALIZER_LOUDNESS, data.data(), data.size());
+
+    std::vector<uint8_t> entry;
+    ASSERT_TRUE(pop_entry(*impl, entry));
+    EXPECT_EQ(entry.size(), data.size() + 1);  // stored at full length, uncapped
+}
+
+TEST(VisualizerHandleBinary, ForwardsReservedTypeVerbatim) {
+    // The network thread is type-agnostic; reserved types are forwarded and dropped later by the
+    // drain thread's decode step.
+    auto impl = make_impl();
+
+    std::vector<uint8_t> data;
+    put_be64(data, 1);
+    data.push_back(0x00);
+
+    impl->handle_binary(21, data.data(), data.size());
+
+    std::vector<uint8_t> entry;
+    ASSERT_TRUE(pop_entry(*impl, entry));
+    EXPECT_EQ(entry[0], 21);
+}


### PR DESCRIPTION
Replaces the draft `visualizer@_draft_r1` role with the finalized `visualizer@v1` protocol, and hardens the message-handling paths.

## Protocol changes

- One frame per binary message. Each datum is its own message `[type][timestamp:8][data]` with per-type IDs (16 loudness, 17 beat, 18 f_peak, 19 spectrum, 20 peak; 21-23 reserved), replacing the draft's batched multi-datum frames. The client dispatches the 16-23 ID range to the visualizer role ahead of the shared 4-slot binary switch.
- `rate_max` moves to the top level of the support object; `tracks_downbeats` is carried in stream/start; batching / `batch_max` is removed.
- Adds a visualizer object to `stream/request-format`, exposed as a public `VisualizerRole::request_format()`.

## API

- Per-type listener callbacks (`on_loudness`, `on_beat`, `on_f_peak`, `on_spectrum`, `on_peak`) instead of a combined frame struct. All five are scheduled through the drain thread and dropped if more than 20 ms late.
- Roles remain compile-time gated behind `SENDSPIN_ENABLE_VISUALIZER`.

## Correctness / hardening
- `stream/clear` no longer races the producer. A 1-byte sentinel marker plus a `COMMAND_CLEAR` (discard-to-marker) replaces the blind drain-to-empty flush, so frames received after a clear survive. Applied to `stream/start` as well. Drain-to-empty is kept only for `stream/end` / cleanup, where the producer is already stopped.
- A malformed spectrum config in `stream/start` drops only the visualizer object, so a valid `player/artwork` start in the same message is preserved.
- `handle_binary` admits only wire types negotiated in stream/start.
- An all-empty `VisualizerFormatRequest` emits no "visualizer" key (avoids "reset to defaults" ambiguity).
- Spectrum-config serialization is shared between `client/hello` and `stream/request-format` so the two cannot diverge; enum parsing goes through `read_enum_field`; the network thread stays minimal, with all structural validation on the drain thread.

## Examples / docs

- `tui_client` renders all five data types (separate onset blinker vs. beat indicator) and is guarded to build with the role disabled.
- Integration guide and internals updated for the new listener API and drain-thread signaling.

## Testing

New `test_visualizer_role.cpp` (decode validation, network-thread admission, clear-marker behavior) plus protocol tests.

Closes #83