### PR TITLE
Fix stale documentation to match current code

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -713,7 +713,7 @@ Main client configuration passed to the `SendspinClient` constructor.
 | `httpd_priority` | `unsigned` | `5` | FreeRTOS priority for the HTTP server task (ESP-IDF only) |
 | `websocket_priority` | `unsigned` | `5` | FreeRTOS priority for the WebSocket client task (ESP-IDF only) |
 | `server_port` | `uint16_t` | `8928` | WebSocket server port |
-| `server_max_connections` | `uint8_t` | `2` | Maximum simultaneous WebSocket connections (default supports the handoff protocol) |
+| `server_max_connections` | `uint8_t` | `4` | Maximum simultaneous WebSocket connections (one established, two unproven, and one spare so a surplus peer can be rejected with a goodbye) |
 | `httpd_ctrl_port` | `uint16_t` | `0` | ESP-IDF httpd control port; `0` uses `ESP_HTTPD_DEF_CTRL_PORT + 1` to avoid conflict with the web_server component |
 | `time_burst_size` | `uint8_t` | `8` | Number of messages per time sync burst |
 | `time_burst_interval_ms` | `int64_t` | `10000` | Milliseconds between time sync bursts |

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -84,7 +84,7 @@ TASK_ERROR           (1 << 11)  Allocation or decode failure
 TASK_IDLE            (1 << 12)  Waiting for work
 ```
 
-The sync task, visualizer drain thread, and artwork decode thread all use event flags for command signaling from the main loop and status reporting back. The artwork decode thread uses a simpler subset: `COMMAND_STOP` and `COMMAND_FLUSH`. The visualizer drain thread adds `COMMAND_CLEAR`, which discards buffered entries up to a 1-byte marker the network thread enqueues on `stream/start` and `stream/clear` (mirroring the sync task's clear-marker chunk) so frames received after the boundary survive; its `COMMAND_FLUSH` (drain to empty) is only used when the producer is already stopped (`stream/end`, cleanup).
+The sync task, visualizer drain thread, and artwork decode thread all use event flags for command signaling from the main loop and status reporting back. The artwork decode thread uses a simpler subset: just `COMMAND_STOP`. The visualizer drain thread adds `COMMAND_FLUSH` and `COMMAND_CLEAR`. `COMMAND_CLEAR` discards buffered entries up to a 1-byte marker the network thread enqueues on `stream/start` and `stream/clear` (mirroring the sync task's clear-marker chunk) so frames received after the boundary survive; `COMMAND_FLUSH` (drain to empty) is only used when the producer is already stopped (`stream/end`, cleanup).
 
 ### ThreadSafeQueue (`src/platform/thread_safe_queue.h`)
 
@@ -403,7 +403,7 @@ Two-dimensional state vector: `[offset, drift]`.
 - First measurement establishes the offset baseline.
 - Second measurement estimates initial drift from finite differences.
 - Subsequent measurements: predict offset forward by `drift * dt`, then correct using the new measurement.
-- Adaptive forgetting: if the residual exceeds `2.0 * max_error`, the covariance is inflated by a forgetting factor (1.1) to recover from step changes.
+- Adaptive forgetting: if the residual exceeds `3.0 * max_error`, the covariance is inflated by a forgetting factor (2.0) to recover from step changes.
 - Drift compensation is only enabled after 100 samples and only when drift significance exceeds its noise floor.
 
 The filter is protected by `state_mutex_` so that `compute_client_time()` can be called from the sync task thread while `update()` runs from the main loop thread.

--- a/examples/basic_client/README.md
+++ b/examples/basic_client/README.md
@@ -33,6 +33,6 @@ macOS has mDNS support built in; no extra dependencies needed.
 
 The client listens on port 8928 by default. When mDNS is enabled it advertises `_sendspin._tcp` with the configured port so Sendspin servers on the local network discover and connect automatically; otherwise tell the server to connect with `ws://<this-host>:8928/sendspin`, replacing `8928` if you passed `-p`.
 
-If PortAudio is available, audio is played through the default output device. Otherwise, audio is discarded (NullAudioSink).
+If PortAudio is available, audio is played through the default output device. Otherwise, decoded audio is discarded (its byte count is tallied but nothing is played).
 
 Press Ctrl+C to stop.


### PR DESCRIPTION
- server_max_connections default is 4, not 2 (config.h)
- Kalman adaptive-forgetting cutoff/factor are 3.0/2.0, not 2.0/1.1
- artwork decode thread uses only COMMAND_STOP; COMMAND_FLUSH is visualizer-only
- drop reference to nonexistent NullAudioSink in basic_client README