### PR TITLE
Silence a GCC dangling-reference warning in controller parsing

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -550,8 +550,9 @@ bool process_server_state_controller(JsonObject root,
     // command is a non-compliant value rather than a forward-compatible one: drop and log it.
     if (controller_object["supported_commands"].is<JsonArray>()) {
         std::vector<SendspinControllerCommand> commands;
-        for (JsonVariantConst command_var :
-             controller_object["supported_commands"].as<JsonArrayConst>()) {
+        JsonArrayConst commands_array =
+            controller_object["supported_commands"].as<JsonArrayConst>();
+        for (JsonVariantConst command_var : commands_array) {
             if (auto command = read_enum_field(command_var, "supported_commands",
                                                controller_command_from_string)) {
                 commands.push_back(*command);


### PR DESCRIPTION
Bind the `supported_commands` array to a named local before iterating it
in `process_server_state_controller()`, so GCC stops emitting
`-Wdangling-reference` there.

## Why

The warning fires on every ESP-IDF build of the component (including via
ESPHome), and is present in released v0.7.1 and on current `main`:

```text
src/protocol.cpp:554:73: warning: possibly dangling reference to a temporary [-Wdangling-reference]
  554 |              controller_object["supported_commands"].as<JsonArrayConst>()) {
      |                                                                         ^
src/protocol.cpp:554:52: note: 'MemberProxy<JsonObject, RamString>' temporary created here
```

The range initializer chained `.as<JsonArrayConst>()` off the
`MemberProxy` temporary returned by `operator[]`. Only the final
temporary in such a chain gets lifetime extension in C++20, so the proxy
is destroyed at the end of the full-expression while the loop body is
still running.

**It was benign.** `JsonArrayConst` stores only a `const ArrayData*` and
a `const ResourceManager*`, both pointing into the `JsonDocument`'s
memory pool, and `JsonArrayConstIterator` holds an `ArrayData::iterator`
plus that same resource pointer. Neither the array nor its iterators
retain anything that points into the dead proxy, so the destroyed
temporary was never read. GCC's heuristic cannot see through the proxy
type, though, so this fixes the code rather than suppressing the
diagnostic.

## How

```diff
-        for (JsonVariantConst command_var :
-             controller_object["supported_commands"].as<JsonArrayConst>()) {
+        JsonArrayConst commands_array =
+            controller_object["supported_commands"].as<JsonArrayConst>();
+        for (JsonVariantConst command_var : commands_array) {
```

This is also what the rest of the file already does. The five other
array loops (`active_roles`, artwork `channels`, visualizer `types`, and
the `roles` lists in `stream/end` and `stream/clear`) each name a local
first; the loop at line 264 ranges over a function parameter. This was
the only chained range initializer left, so the change makes the file
consistent rather than introducing a new idiom.

No behavior change.

## Testing

macOS builds with clang, which does not implement `-Wdangling-reference`
and so never reproduced this. Verified with Homebrew `g++-15` driven at
the host build's exact flags and include set:

- Warning reproduces verbatim before the change, and is gone after it.
- Swept every file in `src/` and `src/host/` with
  `-Wall -Wextra -Wdangling-reference -fsyntax-only`: no
  dangling-reference warnings remain anywhere.
- Host clang build rebuilds clean; `ctest` 123/123 pass.
- `clang-format --dry-run -Werror src/protocol.cpp` clean.
