### PR TITLE
Fix documentation drift in the visualizer and artwork docs

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -121,7 +121,7 @@ The slot/channel number for each entry is its position (index) in `preferred_for
 
 ### Visualizer Role (Audio Visualization)
 
-Receives real-time beat, loudness, peak frequency, onset, and spectrum data synchronized to playback.
+Receives real-time beat, loudness, dominant-frequency, onset, and spectrum data synchronized to playback.
 
 ```cpp
 VisualizerSupportObject vis_support;
@@ -143,6 +143,23 @@ vis_support.spectrum = VisualizerSpectrumConfig{
 
 auto& visualizer = client.add_visualizer({.support = vis_support});
 ```
+
+The advertised support object is the starting format. To change it at runtime, call
+`request_format()` with only the fields you want to change; omitted fields keep their
+current value on the server:
+
+```cpp
+visualizer.request_format({.rate_max = 15});  // Halve the frame rate
+
+visualizer.request_format({
+    .types = {{VisualizerDataType::BEAT, VisualizerDataType::LOUDNESS}},
+});
+```
+
+While a stream is active the server replies with a fresh `stream/start`, so
+`on_visualizer_stream_start()` fires again with the updated
+`ServerVisualizerStreamObject`. If no stream is active, the server remembers the request
+and applies it to the next stream.
 
 ### Color Role (Audio-Derived Color Palette)
 
@@ -944,10 +961,11 @@ These represent commands the server can send to the player. The player advertise
 
 | Value | Description |
 |---|---|
-| `BEAT` | Beat detection events |
-| `LOUDNESS` | Loudness level |
-| `F_PEAK` | Peak frequency |
-| `SPECTRUM` | Frequency spectrum bins |
+| `BEAT` | Musical beat events from tempo/beat tracking |
+| `LOUDNESS` | Overall loudness level |
+| `F_PEAK` | Dominant frequency and its amplitude |
+| `SPECTRUM` | Full frequency spectrum bins |
+| `PEAK` | Energy onset (transient) events |
 
 ### VisualizerSpectrumScale
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -146,8 +146,7 @@ Used for:
 - **`std::atomic<bool>`** on `SendspinConnection::message_dispatch_enabled_`: allows the main loop to instantly suppress message delivery from the network thread.
 - **`std::atomic<bool/uint8_t>`** on `VisualizerRole::Impl`: network thread writes stream config atomically; drain thread reads it.
 - **`std::atomic<bool>`** on `ArtworkRole::Impl::stream_active`: guards `handle_binary()` from writing when no stream is active.
-- **`std::atomic<uint8_t>`** on `ArtworkRole::Impl::SlotBuffer::write_idx`: tracks which of two double-buffers the network thread writes to next.
-- **`std::atomic<bool>`** on `ArtworkRole::Impl::SlotBuffer::drain_active`: set by the decode thread while decoding, checked by the network thread to avoid overwriting an in-use buffer.
+- **`std::mutex`** on `ArtworkRole::Impl::DrainTask::slot_mutex`: guards every field of `SlotBuffer` (shared across all slots; artwork is not a hot path, so contention is negligible). Under that lock `write_idx` tracks which of the two per-slot buffers the network thread writes to next, `drain_active`/`drain_buf_idx` record which buffer the decode thread is decoding, `write_generation[]` lets the decode thread detect a buffer overwritten before it could be claimed, and `ack_state`/`has_parked`/`parked` hold the per-slot frame-done gate.
 - **`std::atomic<uint8_t>`** on `SendspinClient::high_performance_ref_count_`: ref-counted high-performance networking requests from time sync and playback.
 
 ## Message Flow


### PR DESCRIPTION
Three documentation defect fixes.

## What changed

**`VisualizerDataType` enum table** (`docs/integration-guide.md`)

The table was missing the `PEAK` row entirely, and described `F_PEAK` as "Peak frequency" when it carries the dominant frequency *and* its amplitude (see `VisualizerRoleListener::on_f_peak`). Row descriptions now match the enum comments in `include/sendspin/config.h`, and the row order matches declaration order.

**`VisualizerRole::request_format()`** (`docs/integration-guide.md`)

`request_format()` and its `VisualizerFormatRequest` struct are public API with no mention anywhere in the guide. Added a snippet in the Visualizer Role section showing a rate-only change and a types change, plus the note that an active stream gets a fresh `stream/start` (so `on_visualizer_stream_start()` fires again with the updated config) while an idle server remembers the request for the next stream.

**`SlotBuffer` synchronization** (`docs/internals.md`, "Other Primitives")

The list claimed `ArtworkRole::Impl::SlotBuffer::write_idx` and `drain_active` are `std::atomic`. They are plain `uint8_t`/`bool`; every `SlotBuffer` field is guarded by `DrainTask::slot_mutex` (see the `SlotBuffer` doc comment in `src/artwork_role_impl.h`). Replaced the two false bullets with one mutex bullet covering all the fields it guards.

## Notes for reviewers

- Both designated-initializer forms in the new snippet were compile-tested under `-std=c++20` against the real `VisualizerFormatRequest` layout. `.types = {{...}}` needs the double braces (outer for the `optional`, inner for the `vector`); that is what the snippet uses.
- The Visualizer Role intro sentence said "peak frequency"; changed to "dominant-frequency" for consistency with the corrected `F_PEAK` description.
- The neighboring `ArtworkRole::Impl::stream_active` bullet was checked and left alone; it is a real `std::atomic<bool>`.