### PR TITLE
Fix a contradiction in the test-standards skill and add suite granularity rules

### DIFF
--- a/.claude/skills/test-standards/SKILL.md
+++ b/.claude/skills/test-standards/SKILL.md
@@ -65,6 +65,28 @@ logic that ships without a test that could catch its breakage.
   history ("rejects spectrum config missing n_disp_bins", not "regression
   test for the config bug").
 
+## Granularity and independence
+
+- One behavior per test: not one assertion per test, and not one test per
+  bug. Several assertions about the same behavior belong together and
+  splitting them is filler; a long test spanning several behaviors is the
+  opposite failure and gets split along the behaviors it conflates.
+  `MetadataNullClearsAndAbsentPreserves` (`tests/test_protocol.cpp`) asserts
+  three things about the single delta-merge rule it covers.
+- A test name describes the behavior closely enough that a red CI run
+  identifies the break without opening the file (see the naming bullet under
+  "No filler").
+- `ASSERT_*` aborts the test function while `EXPECT_*` continues, so an
+  over-merged test masks later failures behind the first one. Reserve
+  `ASSERT_*` for the point where continuing would be meaningless, such as a
+  parse that must succeed before its result is read.
+- The same behavior over differing inputs belongs in a value-parameterized
+  test (`TEST_P` with `INSTANTIATE_TEST_SUITE_P`) rather than copy-pasted
+  near-duplicate cases. The malformed-input rejection tests in
+  `tests/test_protocol.cpp` are the standing example of that shape.
+- No test depends on execution order, on another test having run first, or on
+  shared mutable global state; each test sets up the world it needs.
+
 ## No test seams in production
 
 - Production code in `src/` and `include/` must not acquire friends,

--- a/.claude/skills/test-standards/SKILL.md
+++ b/.claude/skills/test-standards/SKILL.md
@@ -83,7 +83,8 @@ logic that ships without a test that could catch its breakage.
 - The same behavior over differing inputs belongs in a value-parameterized
   test (`TEST_P` with `INSTANTIATE_TEST_SUITE_P`) rather than copy-pasted
   near-duplicate cases. The malformed-input rejection tests in
-  `tests/test_protocol.cpp` are the standing example of that shape.
+  `tests/test_protocol.cpp` are the standing example of the copy-pasted
+  shape, and are what a parameterized suite would replace.
 - No test depends on execution order, on another test having run first, or on
   shared mutable global state; each test sets up the world it needs.
 

--- a/.claude/skills/test-standards/SKILL.md
+++ b/.claude/skills/test-standards/SKILL.md
@@ -83,6 +83,9 @@ logic that ships without a test that could catch its breakage.
   never assert on a counter that the thread under test would have been the
   one to advance, and never use fixed sleeps as synchronization; use the
   code's own observable outputs or event flags.
+- A sleep that advances wall-clock time toward a real deadline is not
+  synchronization; before calling such a test fragile, compute the margin
+  between its nominal elapsed time and that deadline and state the margin.
 
 ## Sanitizers
 
@@ -91,10 +94,16 @@ logic that ships without a test that could catch its breakage.
 
 ## Honest gaps
 
-- A coverage gap that cannot be closed cheaply (for example, logic needing an
-  injectable clock) is named explicitly in the PR rather than papered over
-  with a test that appears to cover it. Flag apparent coverage that does not
-  actually exercise the gap.
+- A coverage gap that cannot be closed cheaply is named explicitly in the PR
+  rather than papered over with a test that appears to cover it. Flag
+  apparent coverage that does not actually exercise the gap.
+- Naming the gap is the finding. Do not recommend a production seam to close
+  it: an injectable clock, a virtual hook, or a swappable transport added to
+  `src/` or `include/` for a test's benefit is the seam violation above, not
+  the remedy for it. This project has no clock injection seam and a review
+  must not propose introducing one; where a timing decision needs direct
+  coverage, extract it into a pure predicate the test calls with supplied
+  values.
 
 ## Report format
 

--- a/.claude/skills/test-standards/SKILL.md
+++ b/.claude/skills/test-standards/SKILL.md
@@ -80,11 +80,6 @@ logic that ships without a test that could catch its breakage.
   over-merged test masks later failures behind the first one. Reserve
   `ASSERT_*` for the point where continuing would be meaningless, such as a
   parse that must succeed before its result is read.
-- The same behavior over differing inputs belongs in a value-parameterized
-  test (`TEST_P` with `INSTANTIATE_TEST_SUITE_P`) rather than copy-pasted
-  near-duplicate cases. The malformed-input rejection tests in
-  `tests/test_protocol.cpp` are the standing example of the copy-pasted
-  shape, and are what a parameterized suite would replace.
 - No test depends on execution order, on another test having run first, or on
   shared mutable global state; each test sets up the world it needs.
 


### PR DESCRIPTION
Two changes to `.claude/skills/test-standards/SKILL.md`. No test or production
code is touched.

## Do not recommend a production clock seam

"Honest gaps" named an injectable clock as its example of a gap that cannot be
closed cheaply. That reads as a remedy to recommend, and it contradicts "No test
seams in production" stated earlier in the same file. A review of #110 followed
it and asked for a clock seam this project deliberately does not have.

Naming the gap is now the finding, and an extracted pure predicate is the way to
cover a timing decision directly.

The same commit separates a sleep that advances wall-clock time toward a
deadline under test from a sleep used as synchronization, and requires the
margin be computed before a timing test is called fragile.

## Granularity and independence

The checklist judged whether an individual test was strong but said nothing
about how the suite is carved up. A reviewer could not flag a long test covering
several behaviors, or a test that depends on another having run first.

The new section covers one behavior per test, test naming, `ASSERT_*` aborting
where `EXPECT_*` continues, and test independence. It cites
`MetadataNullClearsAndAbsentPreserves` in `tests/test_protocol.cpp` as the
example of several assertions belonging to one behavior.

A bullet recommending value-parameterized tests was written and then dropped:
it pointed at the malformed-input tests in `tests/test_protocol.cpp` as
copy-pasted near-duplicates, and they are not. Those cases each cover a distinct
rule while sharing the control-plus-rejection template this file already
prescribes. The suite has no instance of the pattern that rule described.

`pre-commit run --all-files` passes. Frontmatter is unchanged.