### PR TITLE
Add an outbound binary send primitive to all transports

### DIFF
--- a/src/binary_send_registry.h
+++ b/src/binary_send_registry.h
@@ -1,0 +1,90 @@
+// Copyright 2026 Sendspin Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @file binary_send_registry.h
+/// @brief Owner-scoped keep-alive registry for work queued into a queue with no cancellation
+/// hook (ESP httpd_queue_work); platform-free so its transitions are unit-tested on host
+
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace sendspin {
+
+/// @brief Keeps queued work blocks alive until their worker claims them or their owner's queue
+/// is reclaimed
+///
+/// A Block must carry a `std::shared_ptr<Block> self` member. engage() parks the block's
+/// self-reference (keeping it alive independently of everything else) and records it under an
+/// opaque owner; claim() atomically takes the self-reference back for the worker that is about
+/// to run; reclaim() breaks the self-references of ONE owner's still-engaged blocks. Scoping
+/// discipline is the safety contract: reclaim an owner only once its queue can no longer run
+/// workers (after httpd_stop for that handle), so a claim() against a reclaimed block never
+/// happens with a dangling pointer, and other owners' queued work is never touched.
+template <typename Block>
+class BinarySendRegistry {
+public:
+    /// @brief Parks the block's self-reference and records it under the owner
+    void engage(const std::shared_ptr<Block>& block, const void* owner) {
+        std::lock_guard<std::mutex> lock(this->mutex_);
+        block->self = block;
+        this->entries_.push_back(Entry{owner, block});
+    }
+
+    /// @brief Takes the self-reference back for the worker about to run
+    /// @return The keep-alive reference, or empty if the block is no longer engaged (already
+    ///         claimed, or its owner was reclaimed).
+    std::shared_ptr<Block> claim(Block* raw) {
+        std::lock_guard<std::mutex> lock(this->mutex_);
+        auto it = std::find_if(this->entries_.begin(), this->entries_.end(),
+                               [&](const Entry& e) { return e.block.get() == raw; });
+        if (it == this->entries_.end()) {
+            return {};
+        }
+        std::shared_ptr<Block> keep = std::move(it->block->self);
+        this->entries_.erase(it);
+        return keep;
+    }
+
+    /// @brief Breaks the self-references of every block engaged under the owner
+    /// @return Number of blocks reclaimed.
+    size_t reclaim(const void* owner) {
+        std::lock_guard<std::mutex> lock(this->mutex_);
+        size_t count = 0;
+        for (auto it = this->entries_.begin(); it != this->entries_.end();) {
+            if (it->owner == owner) {
+                it->block->self.reset();
+                it = this->entries_.erase(it);
+                ++count;
+            } else {
+                ++it;
+            }
+        }
+        return count;
+    }
+
+private:
+    struct Entry {
+        const void* owner;
+        std::shared_ptr<Block> block;
+    };
+
+    std::mutex mutex_;
+    std::vector<Entry> entries_;
+};
+
+}  // namespace sendspin

--- a/src/connection.h
+++ b/src/connection.h
@@ -160,7 +160,11 @@ public:
     ///
     /// Unlike the text path's best-effort callback, @p cb fires exactly once for EVERY call --
     /// on success, every failure path, and connection teardown -- because single-in-flight
-    /// transports release their send slot from the completion path.
+    /// transports release their send slot from the completion path. Its execution context is
+    /// transport-dependent: inline on the calling thread for synchronous transports and for
+    /// immediate failures, from the httpd worker for a queued ESP-server send, and from the
+    /// destructor's thread for work that can never run -- so the callback must not perform
+    /// thread-affine work or call back into the connection.
     ///
     /// @param data Pointer to the message bytes (type byte first).
     /// @param len Length of the message in bytes.

--- a/src/connection.h
+++ b/src/connection.h
@@ -152,6 +152,24 @@ public:
     virtual SsErr send_text_message(const std::string& message, SendCompleteCallback cb,
                                     bool allow_before_hello = false) = 0;
 
+    /// @brief Sends a binary message to the server with a completion callback
+    ///
+    /// Callable from role task threads via ConnectionManager::current_shared(). The payload
+    /// must stay valid until @p cb fires or the call returns an error (queuing transports copy
+    /// it first). Binary frames are gated behind the client/hello like the default text path.
+    ///
+    /// Unlike the text path's best-effort callback, @p cb fires exactly once for EVERY call --
+    /// on success, every failure path, and connection teardown -- because single-in-flight
+    /// transports release their send slot from the completion path.
+    ///
+    /// @param data Pointer to the message bytes (type byte first).
+    /// @param len Length of the message in bytes.
+    /// @param cb Callback invoked with the send result.
+    /// @return SsErr::OK if sent/queued successfully; SsErr::NOT_FINISHED if a previous binary
+    ///         send is still in flight on a single-in-flight transport (the caller treats this
+    ///         as "drop this chunk" and owns logging that drop); other codes on failure.
+    virtual SsErr send_binary_message(const uint8_t* data, size_t len, SendCompleteCallback cb) = 0;
+
     /// @brief Sends a client/time synchronization message
     ///
     /// The transport implementation captures `client_transmitted` as close to the actual wire

--- a/src/connection.h
+++ b/src/connection.h
@@ -156,7 +156,9 @@ public:
     ///
     /// Callable from role task threads via ConnectionManager::current_shared(). The payload
     /// must stay valid until @p cb fires or the call returns an error (queuing transports copy
-    /// it first). Binary frames are gated behind the client/hello like the default text path.
+    /// it first). Binary frames are gated behind the client/hello like the default text path:
+    /// asynchronous transports enforce the gate themselves; synchronous transports send inline
+    /// and rely on caller ordering, exactly as their text sends do.
     ///
     /// Unlike the text path's best-effort callback, @p cb fires exactly once for EVERY call --
     /// on success, every failure path, and connection teardown -- because single-in-flight

--- a/src/esp/client_connection.cpp
+++ b/src/esp/client_connection.cpp
@@ -157,6 +157,34 @@ SsErr SendspinClientConnection::send_text_message(const std::string& message,
     return SsErr::OK;
 }
 
+SsErr SendspinClientConnection::send_binary_message(const uint8_t* data, size_t len,
+                                                    SendCompleteCallback cb) {
+    if (!this->is_connected()) {
+        if (cb) {
+            cb(false);
+        }
+        return SsErr::INVALID_STATE;
+    }
+
+    // esp_websocket_client_send_bin is synchronous in the current task, like the text path
+    int sent = esp_websocket_client_send_bin(this->client_, reinterpret_cast<const char*>(data),
+                                             static_cast<int>(len),
+                                             pdMS_TO_TICKS(WEBSOCKET_SEND_TIMEOUT_MS));
+
+    bool success = (sent >= 0);
+
+    if (cb) {
+        cb(success);
+    }
+
+    if (!success) {
+        SS_LOGE(TAG, "Failed to send binary message (timeout or error): %d", sent);
+        return SsErr::FAIL;
+    }
+
+    return SsErr::OK;
+}
+
 bool SendspinClientConnection::send_time_message() {
     if (!this->is_connected()) {
         return false;

--- a/src/esp/client_connection.h
+++ b/src/esp/client_connection.h
@@ -90,6 +90,13 @@ public:
     SsErr send_text_message(const std::string& message, SendCompleteCallback cb,
                             bool allow_before_hello) override;
 
+    /// @brief Sends a binary message to the server, synchronously like the text path
+    /// @param data Pointer to the message bytes.
+    /// @param len Length of the message in bytes.
+    /// @param cb Callback invoked inline in the calling thread with the send result.
+    /// @return SsErr::OK if sent successfully, error code otherwise.
+    SsErr send_binary_message(const uint8_t* data, size_t len, SendCompleteCallback cb) override;
+
     /// @brief Sends a client/time message, capturing the timestamp just before send
     /// @return true if the message was sent successfully, false otherwise.
     bool send_time_message() override;

--- a/src/esp/server_connection.cpp
+++ b/src/esp/server_connection.cpp
@@ -55,6 +55,19 @@ struct SessionLookup {
     std::weak_ptr<SendspinServerConnection> conn;
 };
 
+/// @brief Once-per-connection identity block for queued binary send work (a reusable
+/// SessionLookup: the binary path runs per chunk and must not allocate in steady state)
+///
+/// While a work item is queued, `self` keeps the block alive independently of the connection;
+/// the worker moves `self` into a local before resolving `conn`, so teardown with work in
+/// flight makes the worker a clean no-op. If httpd stops and discards queued work, the engaged
+/// `self` cycle leaks this small block (bounded by client shutdowns); the destructor still
+/// fails the pending completion.
+struct BinarySendLookup {
+    std::weak_ptr<SendspinServerConnection> conn;
+    std::shared_ptr<BinarySendLookup> self;
+};
+
 // ============================================================================
 // SendspinConnection interface implementation
 // ============================================================================
@@ -65,6 +78,15 @@ SendspinServerConnection::SendspinServerConnection(httpd_handle_t server, int so
     int nodelay = 1;
     if (setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay)) < 0) {
         SS_LOGW(TAG, "Failed to turn on TCP_NODELAY, syncing may be inaccurate");
+    }
+}
+
+SendspinServerConnection::~SendspinServerConnection() {
+    // A still-queued worker can never touch this connection again (weak_ptr lock fails), so the
+    // pending completion is failed here; a worker that DID lock blocks destruction until done
+    if (this->binary_send_in_flight_.load(std::memory_order_acquire) && this->binary_send_cb_) {
+        SendCompleteCallback pending = std::move(this->binary_send_cb_);
+        pending(false);
     }
 }
 
@@ -170,6 +192,102 @@ SsErr SendspinServerConnection::send_text_message(const std::string& message,
         return SsErr::FAIL;
     }
     return SsErr::OK;
+}
+
+SsErr SendspinServerConnection::send_binary_message(const uint8_t* data, size_t len,
+                                                    SendCompleteCallback on_complete) {
+    if (!this->is_connected()) {
+        if (on_complete) {
+            on_complete(false);
+        }
+        return SsErr::INVALID_STATE;
+    }
+
+    // Single-in-flight slot: a chunk arriving while the previous is still queued is rejected
+    // and the caller drops it (the spec's stall policy)
+    if (this->binary_send_in_flight_.exchange(true, std::memory_order_acq_rel)) {
+        if (on_complete) {
+            on_complete(false);
+        }
+        return SsErr::NOT_FINISHED;
+    }
+
+    // Grow-only buffer sized by the first payload: chunks are near-constant size, so steady
+    // state allocates nothing and any growth is loud. SPIRAM-preferred like the receive buffer.
+    if (this->binary_send_payload_.size() < len) {
+        bool grown;
+        if (this->binary_send_payload_.data() == nullptr) {
+            grown = this->binary_send_payload_.allocate(len, MemoryLocation::PREFER_EXTERNAL);
+        } else {
+            SS_LOGW(TAG, "Growing binary send slot %zu -> %zu bytes",
+                    this->binary_send_payload_.size(), len);
+            grown = this->binary_send_payload_.realloc(len);
+        }
+        if (!grown) {
+            SS_LOGE(TAG, "Failed to allocate %zu bytes for binary send slot", len);
+            this->binary_send_in_flight_.store(false, std::memory_order_release);
+            if (on_complete) {
+                on_complete(false);
+            }
+            return SsErr::NO_MEM;
+        }
+    }
+
+    std::memcpy(this->binary_send_payload_.data(), data, len);
+    this->binary_send_len_ = len;
+    this->binary_send_cb_ = std::move(on_complete);
+
+    if (this->binary_send_lookup_ == nullptr) {
+        this->binary_send_lookup_ = std::make_shared<BinarySendLookup>();
+        this->binary_send_lookup_->conn =
+            std::static_pointer_cast<SendspinServerConnection>(this->shared_from_this());
+    }
+    // Engage the keep-alive reference for the queued worker (see BinarySendLookup).
+    this->binary_send_lookup_->self = this->binary_send_lookup_;
+
+    if (httpd_queue_work(this->server_, async_send_binary, this->binary_send_lookup_.get()) !=
+        ESP_OK) {
+        SS_LOGE(TAG, "httpd_queue_work failed for binary message");
+        this->binary_send_lookup_->self.reset();
+        SendCompleteCallback pending = std::move(this->binary_send_cb_);
+        this->binary_send_in_flight_.store(false, std::memory_order_release);
+        if (pending) {
+            pending(false);
+        }
+        return SsErr::FAIL;
+    }
+    return SsErr::OK;
+}
+
+void SendspinServerConnection::async_send_binary(void* arg) {
+    auto* lookup = static_cast<BinarySendLookup*>(arg);
+    // Take the keep-alive back first; a successful lock() then blocks destruction until return
+    std::shared_ptr<BinarySendLookup> keep = std::move(lookup->self);
+    auto conn = lookup->conn.lock();
+    if (conn == nullptr) {
+        return;  // Torn down with work queued: the destructor already failed the completion
+    }
+
+    bool success = false;
+    // Same identity and hello gating as async_send_text
+    if (conn->is_connected() && conn->client_hello_sent_) {
+        httpd_ws_frame_t ws_pkt;
+        memset(&ws_pkt, 0, sizeof(httpd_ws_frame_t));
+        ws_pkt.payload = conn->binary_send_payload_.data();
+        ws_pkt.len = conn->binary_send_len_;
+        ws_pkt.type = HTTPD_WS_TYPE_BINARY;
+        success = httpd_ws_send_frame_async(conn->server_, conn->sockfd_, &ws_pkt) == ESP_OK;
+    }
+
+    // The completion fires on every exit path with a live connection (sent, send failed, gated,
+    // or already disconnected) — the slot would wedge otherwise. The callback is moved out and
+    // the slot released before invoking it, so a completion that immediately sends the next
+    // chunk finds the slot free.
+    SendCompleteCallback pending = std::move(conn->binary_send_cb_);
+    conn->binary_send_in_flight_.store(false, std::memory_order_release);
+    if (pending) {
+        pending(success);
+    }
 }
 
 void SendspinServerConnection::trigger_close() {

--- a/src/esp/server_connection.cpp
+++ b/src/esp/server_connection.cpp
@@ -22,6 +22,8 @@
 #include <esp_timer.h>
 
 #include <cstring>
+#include <mutex>
+#include <vector>
 
 namespace sendspin {
 
@@ -60,13 +62,32 @@ struct SessionLookup {
 ///
 /// While a work item is queued, `self` keeps the block alive independently of the connection;
 /// the worker moves `self` into a local before resolving `conn`, so teardown with work in
-/// flight makes the worker a clean no-op. If httpd stops and discards queued work, the engaged
-/// `self` cycle leaks this small block (bounded by client shutdowns); the destructor still
-/// fails the pending completion.
+/// flight makes the worker a clean no-op. httpd_queue_work has no cancellation hook, so work
+/// discarded by httpd_stop would strand the engaged `self` cycle; every engaged block is
+/// therefore tracked in the registry below and reclaimed by
+/// reclaim_orphaned_binary_send_work() once the server is stopped. The destructor still fails
+/// the pending completion.
 struct BinarySendLookup {
     std::weak_ptr<SendspinServerConnection> conn;
     std::shared_ptr<BinarySendLookup> self;
 };
+
+// Engaged lookup blocks with a queued worker that has not yet run. The worker removes its block
+// on entry; reclaim_orphaned_binary_send_work() clears whatever remains after httpd_stop, when
+// no queued worker can ever run again. Guarded by its own mutex: inserts come from role task
+// threads, removals from the httpd worker, the sweep from whichever thread stops the server.
+namespace {
+std::mutex g_engaged_binary_sends_mutex;
+std::vector<std::shared_ptr<BinarySendLookup>> g_engaged_binary_sends;
+}  // namespace
+
+void reclaim_orphaned_binary_send_work() {
+    std::lock_guard<std::mutex> lock(g_engaged_binary_sends_mutex);
+    for (auto& lookup : g_engaged_binary_sends) {
+        lookup->self.reset();
+    }
+    g_engaged_binary_sends.clear();
+}
 
 // ============================================================================
 // SendspinConnection interface implementation
@@ -74,6 +95,9 @@ struct BinarySendLookup {
 
 SendspinServerConnection::SendspinServerConnection(httpd_handle_t server, int sockfd)
     : server_(server), sockfd_(sockfd) {
+    // Allocated here, off the send path; the weak self-reference is bound on the first send
+    // (shared_from_this is unusable inside a constructor)
+    this->binary_send_lookup_ = std::make_shared<BinarySendLookup>();
     // Disabling Nagle's algorithm significantly improves the time syncing accuracy
     int nodelay = 1;
     if (setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay)) < 0) {
@@ -237,17 +261,25 @@ SsErr SendspinServerConnection::send_binary_message(const uint8_t* data, size_t 
     this->binary_send_len_ = len;
     this->binary_send_cb_ = std::move(on_complete);
 
-    if (this->binary_send_lookup_ == nullptr) {
-        this->binary_send_lookup_ = std::make_shared<BinarySendLookup>();
+    if (this->binary_send_lookup_->conn.expired()) {
         this->binary_send_lookup_->conn =
             std::static_pointer_cast<SendspinServerConnection>(this->shared_from_this());
     }
-    // Engage the keep-alive reference for the queued worker (see BinarySendLookup).
+    // Engage the keep-alive reference for the queued worker and track it for reclamation at
+    // server stop (see BinarySendLookup).
     this->binary_send_lookup_->self = this->binary_send_lookup_;
+    {
+        std::lock_guard<std::mutex> lock(g_engaged_binary_sends_mutex);
+        g_engaged_binary_sends.push_back(this->binary_send_lookup_);
+    }
 
     if (httpd_queue_work(this->server_, async_send_binary, this->binary_send_lookup_.get()) !=
         ESP_OK) {
         SS_LOGE(TAG, "httpd_queue_work failed for binary message");
+        {
+            std::lock_guard<std::mutex> lock(g_engaged_binary_sends_mutex);
+            std::erase(g_engaged_binary_sends, this->binary_send_lookup_);
+        }
         this->binary_send_lookup_->self.reset();
         SendCompleteCallback pending = std::move(this->binary_send_cb_);
         this->binary_send_in_flight_.store(false, std::memory_order_release);
@@ -261,8 +293,13 @@ SsErr SendspinServerConnection::send_binary_message(const uint8_t* data, size_t 
 
 void SendspinServerConnection::async_send_binary(void* arg) {
     auto* lookup = static_cast<BinarySendLookup*>(arg);
-    // Take the keep-alive back first; a successful lock() then blocks destruction until return
+    // Take the keep-alive back first; a successful lock() then blocks destruction until return.
+    // Also leave the reclamation registry: this worker is running, so it owns the cleanup.
     std::shared_ptr<BinarySendLookup> keep = std::move(lookup->self);
+    {
+        std::lock_guard<std::mutex> lock(g_engaged_binary_sends_mutex);
+        std::erase(g_engaged_binary_sends, keep);
+    }
     auto conn = lookup->conn.lock();
     if (conn == nullptr) {
         return;  // Torn down with work queued: the destructor already failed the completion

--- a/src/esp/server_connection.cpp
+++ b/src/esp/server_connection.cpp
@@ -14,6 +14,7 @@
 
 #include "server_connection.h"
 
+#include "binary_send_registry.h"
 #include "lwip/sockets.h"  // for setsockopt, IPPROTO_TCP, NODELAY
 #include "platform/compiler.h"
 #include "platform/logging.h"
@@ -22,8 +23,6 @@
 #include <esp_timer.h>
 
 #include <cstring>
-#include <mutex>
-#include <vector>
 
 namespace sendspin {
 
@@ -61,32 +60,25 @@ struct SessionLookup {
 /// SessionLookup: the binary path runs per chunk and must not allocate in steady state)
 ///
 /// While a work item is queued, `self` keeps the block alive independently of the connection;
-/// the worker moves `self` into a local before resolving `conn`, so teardown with work in
-/// flight makes the worker a clean no-op. httpd_queue_work has no cancellation hook, so work
-/// discarded by httpd_stop would strand the engaged `self` cycle; every engaged block is
-/// therefore tracked in the registry below and reclaimed by
-/// reclaim_orphaned_binary_send_work() once the server is stopped. The destructor still fails
-/// the pending completion.
+/// the worker claims it back before resolving `conn`, so teardown with work in flight makes the
+/// worker a clean no-op. httpd_queue_work has no cancellation hook, so work discarded by
+/// httpd_stop would strand the engaged `self` cycle; engaged blocks are therefore tracked in a
+/// registry scoped by their owning httpd handle and reclaimed by
+/// reclaim_orphaned_binary_send_work(handle) once THAT server is stopped -- another live
+/// server's queued work is never touched. The destructor still fails the pending completion.
 struct BinarySendLookup {
     std::weak_ptr<SendspinServerConnection> conn;
     std::shared_ptr<BinarySendLookup> self;
 };
 
-// Engaged lookup blocks with a queued worker that has not yet run. The worker removes its block
-// on entry; reclaim_orphaned_binary_send_work() clears whatever remains after httpd_stop, when
-// no queued worker can ever run again. Guarded by its own mutex: inserts come from role task
-// threads, removals from the httpd worker, the sweep from whichever thread stops the server.
+// Engage/claim/reclaim transitions live in the host-tested registry; this file only decides
+// when to call them. One process-wide instance, keyed by httpd handle.
 namespace {
-std::mutex g_engaged_binary_sends_mutex;
-std::vector<std::shared_ptr<BinarySendLookup>> g_engaged_binary_sends;
+BinarySendRegistry<BinarySendLookup> g_binary_send_registry;
 }  // namespace
 
-void reclaim_orphaned_binary_send_work() {
-    std::lock_guard<std::mutex> lock(g_engaged_binary_sends_mutex);
-    for (auto& lookup : g_engaged_binary_sends) {
-        lookup->self.reset();
-    }
-    g_engaged_binary_sends.clear();
+void reclaim_orphaned_binary_send_work(httpd_handle_t server) {
+    g_binary_send_registry.reclaim(server);
 }
 
 // ============================================================================
@@ -265,22 +257,14 @@ SsErr SendspinServerConnection::send_binary_message(const uint8_t* data, size_t 
         this->binary_send_lookup_->conn =
             std::static_pointer_cast<SendspinServerConnection>(this->shared_from_this());
     }
-    // Engage the keep-alive reference for the queued worker and track it for reclamation at
-    // server stop (see BinarySendLookup).
-    this->binary_send_lookup_->self = this->binary_send_lookup_;
-    {
-        std::lock_guard<std::mutex> lock(g_engaged_binary_sends_mutex);
-        g_engaged_binary_sends.push_back(this->binary_send_lookup_);
-    }
+    // Engage the keep-alive reference for the queued worker, scoped to this connection's httpd
+    // handle for reclamation at that server's stop (see BinarySendLookup).
+    g_binary_send_registry.engage(this->binary_send_lookup_, this->server_);
 
     if (httpd_queue_work(this->server_, async_send_binary, this->binary_send_lookup_.get()) !=
         ESP_OK) {
         SS_LOGE(TAG, "httpd_queue_work failed for binary message");
-        {
-            std::lock_guard<std::mutex> lock(g_engaged_binary_sends_mutex);
-            std::erase(g_engaged_binary_sends, this->binary_send_lookup_);
-        }
-        this->binary_send_lookup_->self.reset();
+        g_binary_send_registry.claim(this->binary_send_lookup_.get());
         SendCompleteCallback pending = std::move(this->binary_send_cb_);
         this->binary_send_in_flight_.store(false, std::memory_order_release);
         if (pending) {
@@ -293,12 +277,11 @@ SsErr SendspinServerConnection::send_binary_message(const uint8_t* data, size_t 
 
 void SendspinServerConnection::async_send_binary(void* arg) {
     auto* lookup = static_cast<BinarySendLookup*>(arg);
-    // Take the keep-alive back first; a successful lock() then blocks destruction until return.
-    // Also leave the reclamation registry: this worker is running, so it owns the cleanup.
-    std::shared_ptr<BinarySendLookup> keep = std::move(lookup->self);
-    {
-        std::lock_guard<std::mutex> lock(g_engaged_binary_sends_mutex);
-        std::erase(g_engaged_binary_sends, keep);
+    // Claim the keep-alive back under the registry lock (serialized against reclaim); a
+    // successful conn.lock() then blocks destruction until return.
+    std::shared_ptr<BinarySendLookup> keep = g_binary_send_registry.claim(lookup);
+    if (keep == nullptr) {
+        return;  // Reclaimed or already claimed; nothing here is safe to touch
     }
     auto conn = lookup->conn.lock();
     if (conn == nullptr) {

--- a/src/esp/server_connection.cpp
+++ b/src/esp/server_connection.cpp
@@ -301,8 +301,9 @@ void SendspinServerConnection::async_send_binary(void* arg) {
 
     // The completion fires on every exit path with a live connection (sent, send failed, gated,
     // or already disconnected) — the slot would wedge otherwise. The callback is moved out and
-    // the slot released before invoking it, so a completion that immediately sends the next
-    // chunk finds the slot free.
+    // the slot released before invoking it, so the source task, once woken by the completion,
+    // finds the slot free for its next send. The callback itself does not re-enter the
+    // connection (the interface forbids it); it only records the result and wakes the task.
     SendCompleteCallback pending = std::move(conn->binary_send_cb_);
     conn->binary_send_in_flight_.store(false, std::memory_order_release);
     if (pending) {

--- a/src/esp/server_connection.h
+++ b/src/esp/server_connection.h
@@ -18,12 +18,16 @@
 #pragma once
 
 #include "connection.h"
+#include "platform/memory.h"
 #include <esp_http_server.h>
 
 #include <atomic>
 #include <functional>
+#include <memory>
 
 namespace sendspin {
+
+struct BinarySendLookup;
 
 /**
  * @brief ESP-IDF HTTP server WebSocket connection representing a single Sendspin server session
@@ -57,7 +61,10 @@ public:
     /// @param sockfd The socket file descriptor for this connection.
     SendspinServerConnection(httpd_handle_t server, int sockfd);
 
-    ~SendspinServerConnection() override = default;
+    /// @brief Fails a still-in-flight binary send whose queued worker can never run anymore
+    /// (teardown half of the send-slot contract: only the worker or this destructor releases
+    /// the slot, never a caller-side timeout)
+    ~SendspinServerConnection() override;
 
     // ========================================
     // SendspinConnection interface implementation
@@ -102,6 +109,17 @@ public:
     /// @return SsErr::OK if queued successfully, error code otherwise.
     SsErr send_text_message(const std::string& message, SendCompleteCallback on_complete,
                             bool allow_before_hello) override;
+
+    /// @brief Sends a binary message through the connection's single-in-flight send slot:
+    /// allocation-free in steady state (per-chunk path), NOT_FINISHED while the previous send
+    /// is in flight, slot released only by the worker's completion or the destructor
+    /// @param data Pointer to the message bytes.
+    /// @param len Length of the message in bytes.
+    /// @param on_complete Callback invoked with the send result.
+    /// @return SsErr::OK if queued; SsErr::NOT_FINISHED when the slot is busy; other codes on
+    ///         failure.
+    SsErr send_binary_message(const uint8_t* data, size_t len,
+                              SendCompleteCallback on_complete) override;
 
     /// @brief Sends a client/time message, stamping the timestamp inside the httpd worker
     ///
@@ -152,10 +170,31 @@ protected:
     ///            destroyed and freed before the worker returns.
     static void async_send_time_text(void* arg);
 
+    /// @brief httpd_queue_work callback that sends the binary frame held in the send slot
+    /// @param arg This connection's BinarySendLookup (lifetime protocol at its definition).
+    static void async_send_binary(void* arg);
+
+    // Struct fields
+
+    /// @brief Binary send slot payload: sized by the first send, grow-only, reused (zero
+    /// steady-state allocation)
+    PlatformBuffer binary_send_payload_;
+
+    /// @brief In-flight completion callback, fired by the worker or the destructor
+    SendCompleteCallback binary_send_cb_;
+
     // Pointer fields
 
     /// @brief The httpd server handle (owned by SendspinWsServer)
     httpd_handle_t server_;
+
+    /// @brief Identity block handed to queued binary send work (see BinarySendLookup)
+    std::shared_ptr<BinarySendLookup> binary_send_lookup_;
+
+    // size_t fields
+
+    /// @brief Length of the payload currently held in the binary send slot
+    size_t binary_send_len_{0};
 
     // 32-bit fields
 
@@ -166,6 +205,11 @@ protected:
 
     /// @brief Set once the httpd session has closed (see mark_closed())
     std::atomic<bool> closed_{false};
+
+    /// @brief True while a binary send occupies the slot (queued or being sent). Written by the
+    /// sending role thread (acquire the slot) and the httpd worker (release it); the destructor
+    /// reads it to detect work that never ran.
+    std::atomic<bool> binary_send_in_flight_{false};
 };
 
 }  // namespace sendspin

--- a/src/esp/server_connection.h
+++ b/src/esp/server_connection.h
@@ -29,6 +29,10 @@ namespace sendspin {
 
 struct BinarySendLookup;
 
+/// @brief Breaks the keep-alive cycles of binary send workers that were queued but will never
+/// run. Call only after httpd_stop() has returned (no worker can run afterwards).
+void reclaim_orphaned_binary_send_work();
+
 /**
  * @brief ESP-IDF HTTP server WebSocket connection representing a single Sendspin server session
  *

--- a/src/esp/server_connection.h
+++ b/src/esp/server_connection.h
@@ -29,9 +29,10 @@ namespace sendspin {
 
 struct BinarySendLookup;
 
-/// @brief Breaks the keep-alive cycles of binary send workers that were queued but will never
-/// run. Call only after httpd_stop() has returned (no worker can run afterwards).
-void reclaim_orphaned_binary_send_work();
+/// @brief Breaks the keep-alive cycles of binary send workers queued on the given server that
+/// will never run. Call only after httpd_stop() for that handle has returned (none of its
+/// workers can run afterwards); other servers' queued work is untouched.
+void reclaim_orphaned_binary_send_work(httpd_handle_t server);
 
 /**
  * @brief ESP-IDF HTTP server WebSocket connection representing a single Sendspin server session
@@ -116,7 +117,8 @@ public:
 
     /// @brief Sends a binary message through the connection's single-in-flight send slot:
     /// allocation-free in steady state (per-chunk path), NOT_FINISHED while the previous send
-    /// is in flight, slot released only by the worker's completion or the destructor
+    /// is in flight; the slot is released on every completion or immediate-failure path, or by
+    /// the destructor for work that can never run
     /// @param data Pointer to the message bytes.
     /// @param len Length of the message in bytes.
     /// @param on_complete Callback invoked with the send result.

--- a/src/esp/ws_server.cpp
+++ b/src/esp/ws_server.cpp
@@ -119,6 +119,9 @@ void SendspinWsServer::stop() {
         SS_LOGD(TAG, "Stopping server");
         httpd_stop(this->server_);
         this->server_ = nullptr;
+        // No queued worker can run once httpd_stop returns; break the keep-alive cycles of any
+        // binary send work httpd discarded so restarts cannot accumulate stranded blocks.
+        reclaim_orphaned_binary_send_work();
     }
 
     // httpd_stop tore down every session (each close_callback dropped its pending entry), so

--- a/src/esp/ws_server.cpp
+++ b/src/esp/ws_server.cpp
@@ -117,11 +117,13 @@ bool SendspinWsServer::start(SendspinClient* client, bool task_stack_in_psram,
 void SendspinWsServer::stop() {
     if (this->server_ != nullptr) {
         SS_LOGD(TAG, "Stopping server");
-        httpd_stop(this->server_);
+        httpd_handle_t stopped = this->server_;
+        httpd_stop(stopped);
         this->server_ = nullptr;
-        // No queued worker can run once httpd_stop returns; break the keep-alive cycles of any
-        // binary send work httpd discarded so restarts cannot accumulate stranded blocks.
-        reclaim_orphaned_binary_send_work();
+        // None of THIS server's queued workers can run once httpd_stop returns; break the
+        // keep-alive cycles of the binary send work it discarded so restarts cannot accumulate
+        // stranded blocks. Scoped by handle: another live server's queued work is untouched.
+        reclaim_orphaned_binary_send_work(stopped);
     }
 
     // httpd_stop tore down every session (each close_callback dropped its pending entry), so

--- a/src/esp/ws_server.cpp
+++ b/src/esp/ws_server.cpp
@@ -118,12 +118,20 @@ void SendspinWsServer::stop() {
     if (this->server_ != nullptr) {
         SS_LOGD(TAG, "Stopping server");
         httpd_handle_t stopped = this->server_;
-        httpd_stop(stopped);
+        const esp_err_t stop_err = httpd_stop(stopped);
         this->server_ = nullptr;
-        // None of THIS server's queued workers can run once httpd_stop returns; break the
-        // keep-alive cycles of the binary send work it discarded so restarts cannot accumulate
-        // stranded blocks. Scoped by handle: another live server's queued work is untouched.
-        reclaim_orphaned_binary_send_work(stopped);
+        if (stop_err == ESP_OK) {
+            // Only on a clean stop can no worker of THIS server run again: break the keep-alive
+            // cycles of the binary send work it discarded so restarts cannot accumulate
+            // stranded blocks (scoped by handle; another live server's work is untouched). On a
+            // failed stop the httpd task may still run queued workers, so reclaim()'s "no worker
+            // can run" precondition would be violated -- leave the blocks (a bounded leak) so a
+            // late worker never collides with a reclaimed lookup.
+            reclaim_orphaned_binary_send_work(stopped);
+        } else {
+            SS_LOGW(TAG, "httpd_stop failed (%s); leaving queued binary send work intact",
+                    esp_err_to_name(stop_err));
+        }
     }
 
     // httpd_stop tore down every session (each close_callback dropped its pending entry), so

--- a/src/host/client_connection.cpp
+++ b/src/host/client_connection.cpp
@@ -120,6 +120,31 @@ SsErr SendspinClientConnection::send_text_message(const std::string& message,
     return SsErr::OK;
 }
 
+SsErr SendspinClientConnection::send_binary_message(const uint8_t* data, size_t len,
+                                                    SendCompleteCallback cb) {
+    if (!this->is_connected()) {
+        if (cb) {
+            cb(false);
+        }
+        return SsErr::INVALID_STATE;
+    }
+
+    // IXWebSocket's API forces a std::string copy of the payload; acceptable on host.
+    auto info = this->ws_->sendBinary(std::string(reinterpret_cast<const char*>(data), len));
+    bool success = info.success;
+
+    if (cb) {
+        cb(success);
+    }
+
+    if (!success) {
+        SS_LOGE(TAG, "Failed to send binary message");
+        return SsErr::FAIL;
+    }
+
+    return SsErr::OK;
+}
+
 bool SendspinClientConnection::send_time_message() {
     if (!this->is_connected()) {
         return false;

--- a/src/host/client_connection.h
+++ b/src/host/client_connection.h
@@ -76,6 +76,13 @@ public:
     SsErr send_text_message(const std::string& message, SendCompleteCallback cb,
                             bool allow_before_hello) override;
 
+    /// @brief Sends a binary message to the server, synchronously like the text path
+    /// @param data Pointer to the message bytes.
+    /// @param len Length of the message in bytes.
+    /// @param cb Callback invoked inline in the calling thread with the send result.
+    /// @return SsErr::OK if sent successfully, error code otherwise.
+    SsErr send_binary_message(const uint8_t* data, size_t len, SendCompleteCallback cb) override;
+
     /// @brief Sends a client/time message, capturing the timestamp synchronously before send
     /// @return true if the message was sent successfully, false otherwise.
     bool send_time_message() override;

--- a/src/host/server_connection.cpp
+++ b/src/host/server_connection.cpp
@@ -83,6 +83,26 @@ SsErr SendspinServerConnection::send_text_message(const std::string& message,
     return success ? SsErr::OK : SsErr::FAIL;
 }
 
+SsErr SendspinServerConnection::send_binary_message(const uint8_t* data, size_t len,
+                                                    SendCompleteCallback on_complete) {
+    if (!this->is_connected()) {
+        if (on_complete) {
+            on_complete(false);
+        }
+        return SsErr::INVALID_STATE;
+    }
+
+    // IXWebSocket's API forces a std::string copy of the payload; acceptable on host.
+    auto info = this->ws_->sendBinary(std::string(reinterpret_cast<const char*>(data), len));
+    bool success = info.success;
+
+    if (on_complete) {
+        on_complete(success);
+    }
+
+    return success ? SsErr::OK : SsErr::FAIL;
+}
+
 bool SendspinServerConnection::send_time_message() {
     if (!this->is_connected()) {
         return false;

--- a/src/host/server_connection.h
+++ b/src/host/server_connection.h
@@ -77,6 +77,14 @@ public:
     SsErr send_text_message(const std::string& message, SendCompleteCallback on_complete,
                             bool allow_before_hello) override;
 
+    /// @brief Sends a binary message to the connected client, synchronously like the text path
+    /// @param data Pointer to the message bytes.
+    /// @param len Length of the message in bytes.
+    /// @param on_complete Callback invoked inline in the calling thread with the send result.
+    /// @return SsErr::OK if sent successfully, error code otherwise.
+    SsErr send_binary_message(const uint8_t* data, size_t len,
+                              SendCompleteCallback on_complete) override;
+
     /// @brief Sends a client/time message, capturing the timestamp synchronously before send
     /// @return true if the message was sent successfully, false otherwise.
     bool send_time_message() override;

--- a/src/platform/types.h
+++ b/src/platform/types.h
@@ -38,6 +38,7 @@ enum class SsErr : int16_t {
     NOT_FOUND = 0x105,      // Resource not found
     NOT_SUPPORTED = 0x106,  // Operation not supported
     TIMEOUT = 0x107,        // Operation timed out
+    NOT_FINISHED = 0x10C,   // Previous operation has not fully completed
 
     // Errors (< 0)
     FAIL = -1,  // Generic failure

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(sendspin_tests
     test_inbox.cpp
     test_visualizer_role.cpp
     test_artwork_role.cpp
+    test_binary_send_registry.cpp
 )
 
 # Reach the library's private headers (protocol_messages.h, time_filter.h, ...).

--- a/tests/test_binary_send_registry.cpp
+++ b/tests/test_binary_send_registry.cpp
@@ -1,0 +1,107 @@
+// Copyright 2026 Sendspin Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @file test_binary_send_registry.cpp
+/// @brief Ownership transitions of the queued-work keep-alive registry backing the ESP server's
+/// binary send slot (engage/claim/reclaim, owner scoping, keep-alive lifetime)
+
+#include "binary_send_registry.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+namespace sendspin {
+namespace {
+
+struct FakeBlock {
+    std::shared_ptr<FakeBlock> self;
+    int tag{0};
+};
+
+int owner_a;
+int owner_b;
+
+// Defends BinarySendRegistry::engage()/claim(): a queued block stays alive through its parked
+// self-reference even when every external reference is dropped, and the worker's claim hands
+// that reference back exactly once.
+TEST(BinarySendRegistry, EngageKeepsBlockAliveUntilClaimed) {
+    BinarySendRegistry<FakeBlock> registry;
+    std::weak_ptr<FakeBlock> observer;
+    FakeBlock* raw = nullptr;
+    {
+        auto block = std::make_shared<FakeBlock>();
+        block->tag = 7;
+        observer = block;
+        raw = block.get();
+        registry.engage(block, &owner_a);
+    }
+    // External reference gone; the parked self-reference must keep it alive.
+    ASSERT_FALSE(observer.expired());
+
+    auto keep = registry.claim(raw);
+    ASSERT_NE(keep, nullptr);
+    EXPECT_EQ(keep->tag, 7);
+
+    // Claim is exactly-once: a second claim (a double-run) gets nothing.
+    EXPECT_EQ(registry.claim(raw), nullptr);
+
+    keep.reset();
+    EXPECT_TRUE(observer.expired());
+}
+
+// Defends reclaim()'s owner scoping: stopping one server must break only that server's queued
+// work; another live server's engaged block stays claimable. This is the cross-server
+// use-after-free shape the scoping exists to prevent.
+TEST(BinarySendRegistry, ReclaimTouchesOnlyTheStoppedOwner) {
+    BinarySendRegistry<FakeBlock> registry;
+    auto block_a = std::make_shared<FakeBlock>();
+    auto block_b = std::make_shared<FakeBlock>();
+    registry.engage(block_a, &owner_a);
+    registry.engage(block_b, &owner_b);
+
+    EXPECT_EQ(registry.reclaim(&owner_a), 1U);
+    EXPECT_EQ(block_a->self, nullptr);
+
+    // Owner B's block is untouched and still claimable by its worker.
+    ASSERT_NE(block_b->self, nullptr);
+    auto keep_b = registry.claim(block_b.get());
+    ASSERT_NE(keep_b, nullptr);
+
+    // A's block is no longer engaged: a late claim gets nothing rather than a stale reference.
+    EXPECT_EQ(registry.claim(block_a.get()), nullptr);
+}
+
+// Defends reclaim()'s exactly-once accounting: a claimed block is no longer the registry's to
+// reclaim, and a reclaimed owner has nothing left on a second reclaim.
+TEST(BinarySendRegistry, ReclaimCountsOnlyStillEngagedBlocks) {
+    BinarySendRegistry<FakeBlock> registry;
+    auto first = std::make_shared<FakeBlock>();
+    auto second = std::make_shared<FakeBlock>();
+    registry.engage(first, &owner_a);
+    registry.engage(second, &owner_a);
+
+    auto keep = registry.claim(first.get());
+    ASSERT_NE(keep, nullptr);
+
+    EXPECT_EQ(registry.reclaim(&owner_a), 1U);
+    EXPECT_EQ(registry.reclaim(&owner_a), 0U);
+
+    // Re-engaging after a reclaim works: the registry holds no stale state for the owner.
+    registry.engage(second, &owner_a);
+    EXPECT_NE(registry.claim(second.get()), nullptr);
+}
+
+}  // namespace
+}  // namespace sendspin

--- a/tests/test_connection_lifecycle.cpp
+++ b/tests/test_connection_lifecycle.cpp
@@ -20,6 +20,9 @@
 // WebSocket upgrade; raw-TCP junk is closed inside the transport layer and never occupies a slot).
 
 #include "connection_manager.h"  // fnv1_hash for the last-played preference
+#include "host/client_connection.h"
+#include "host/server_connection.h"
+#include "protocol_messages.h"
 #include "sendspin/client.h"
 #include "sendspin/config.h"
 #include <gtest/gtest.h>
@@ -36,7 +39,9 @@
 #include <cerrno>
 #include <chrono>
 #include <cstdint>
+#include <cstring>
 #include <functional>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <utility>
@@ -56,6 +61,8 @@ constexpr uint16_t EVICT_TEST_PORT = 18972;
 constexpr uint16_t REJECT_TEST_PORT = 18973;
 constexpr uint16_t STALL_LISTEN_PORT = 18981;
 constexpr uint16_t ADMIT_TEST_PORT = 18982;
+constexpr uint16_t BINARY_TEST_PORT = 18992;
+constexpr uint16_t SERVER_BINARY_TEST_PORT = 18993;
 
 std::string server_url(uint16_t port) {
     return "ws://127.0.0.1:" + std::to_string(port) + "/sendspin";
@@ -597,4 +604,174 @@ TEST(ConnectionLifecycle, FullNurseryOfLivePeersRejectsNewcomer) {
     EXPECT_FALSE(client.is_connected());
     EXPECT_FALSE(mute_a.closed());
     EXPECT_FALSE(mute_b.closed());
+}
+
+// send_binary_message on the host client transport must deliver exactly one binary WebSocket
+// frame carrying the exact payload bytes, reporting success through both the return code and the
+// inline completion callback.
+TEST(ConnectionLifecycle, ClientBinarySendDeliversExactBytes) {
+    std::atomic<int> binary_frames{0};
+    std::string received;
+    std::mutex received_mutex;
+
+    ix::WebSocketServer backend(BINARY_TEST_PORT, "127.0.0.1");
+    backend.setOnConnectionCallback([&](const std::weak_ptr<ix::WebSocket>& weak_ws,
+                                        const std::shared_ptr<ix::ConnectionState>& /*state*/) {
+        auto ws = weak_ws.lock();
+        if (!ws) {
+            return;
+        }
+        ws->setOnMessageCallback([&](const ix::WebSocketMessagePtr& msg) {
+            if (msg->type == ix::WebSocketMessageType::Message && msg->binary) {
+                std::lock_guard<std::mutex> lock(received_mutex);
+                received = msg->str;
+                binary_frames.fetch_add(1);
+            }
+        });
+    });
+    ASSERT_TRUE(backend.listen().first);
+    backend.start();
+
+    SendspinClientConnection conn(server_url(BINARY_TEST_PORT));
+    std::atomic<bool> connected{false};
+    conn.on_connected_cb = [&](SendspinConnection*) { connected.store(true); };
+    conn.start();
+    {
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        while (!connected.load() && std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+    }
+    ASSERT_TRUE(connected.load());
+
+    // Payload shaped like a source audio chunk (type byte, BE64 capture timestamp, frame data),
+    // with bytes chosen to catch truncation and sign mangling.
+    uint8_t payload[1 + BINARY_TIMESTAMP_SIZE + 4];
+    payload[0] = SENDSPIN_BINARY_SOURCE_AUDIO;
+    host_to_be64(-123456789, payload + 1);
+    payload[1 + BINARY_TIMESTAMP_SIZE + 0] = 0x00;
+    payload[1 + BINARY_TIMESTAMP_SIZE + 1] = 0xFF;
+    payload[1 + BINARY_TIMESTAMP_SIZE + 2] = 0x7F;
+    payload[1 + BINARY_TIMESTAMP_SIZE + 3] = 0x80;
+
+    bool cb_fired = false;
+    bool cb_success = false;
+    EXPECT_EQ(conn.send_binary_message(payload, sizeof(payload),
+                                       [&](bool ok) {
+                                           cb_fired = true;
+                                           cb_success = ok;
+                                       }),
+              SsErr::OK);
+    // Synchronous transport: the completion fires inline in the calling thread.
+    EXPECT_TRUE(cb_fired);
+    EXPECT_TRUE(cb_success);
+
+    {
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        while (binary_frames.load() == 0 && std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+    }
+    ASSERT_EQ(binary_frames.load(), 1);
+    {
+        std::lock_guard<std::mutex> lock(received_mutex);
+        ASSERT_EQ(received.size(), sizeof(payload));
+        EXPECT_EQ(0, std::memcmp(received.data(), payload, sizeof(payload)));
+    }
+
+    backend.stop();
+}
+
+// Mirror of ClientBinarySendDeliversExactBytes for the host server transport — the transport a
+// source device uses when the Sendspin server connects inbound, so its parallel but independent
+// send implementation gets its own exact-bytes pin. The library-side connection is constructed
+// directly around the accepted IXWebSocket, the way the host ws_server builds it.
+TEST(ConnectionLifecycle, ServerBinarySendDeliversExactBytes) {
+    std::mutex conn_mutex;
+    std::shared_ptr<SendspinServerConnection> server_conn;
+
+    ix::WebSocketServer listener(SERVER_BINARY_TEST_PORT, "127.0.0.1");
+    listener.setOnConnectionCallback([&](const std::weak_ptr<ix::WebSocket>& weak_ws,
+                                         const std::shared_ptr<ix::ConnectionState>& /*state*/) {
+        auto ws = weak_ws.lock();
+        if (!ws) {
+            return;
+        }
+        // IXWebSocket requires a message callback on every accepted socket; inbound frames are
+        // irrelevant here, only the outbound send path is under test.
+        ws->setOnMessageCallback([](const ix::WebSocketMessagePtr& /*msg*/) {});
+        std::lock_guard<std::mutex> lock(conn_mutex);
+        server_conn = std::make_shared<SendspinServerConnection>(ws, -1);
+    });
+    ASSERT_TRUE(listener.listen().first);
+    listener.start();
+
+    // The peer that receives the frame: an IXWebSocket client capturing binary messages.
+    std::atomic<int> binary_frames{0};
+    std::string received;
+    std::mutex received_mutex;
+    ix::WebSocket peer;
+    peer.setUrl(server_url(SERVER_BINARY_TEST_PORT));
+    peer.disableAutomaticReconnection();
+    peer.setOnMessageCallback([&](const ix::WebSocketMessagePtr& msg) {
+        if (msg->type == ix::WebSocketMessageType::Message && msg->binary) {
+            std::lock_guard<std::mutex> lock(received_mutex);
+            received = msg->str;
+            binary_frames.fetch_add(1);
+        }
+    });
+    peer.start();
+
+    auto conn_ready = [&] {
+        std::lock_guard<std::mutex> lock(conn_mutex);
+        return server_conn != nullptr && server_conn->is_connected();
+    };
+    {
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        while (!conn_ready() && std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+    }
+    ASSERT_TRUE(conn_ready());
+    std::shared_ptr<SendspinServerConnection> conn;
+    {
+        std::lock_guard<std::mutex> lock(conn_mutex);
+        conn = server_conn;
+    }
+
+    uint8_t payload[1 + BINARY_TIMESTAMP_SIZE + 4];
+    payload[0] = SENDSPIN_BINARY_SOURCE_AUDIO;
+    host_to_be64(-123456789, payload + 1);
+    payload[1 + BINARY_TIMESTAMP_SIZE + 0] = 0x00;
+    payload[1 + BINARY_TIMESTAMP_SIZE + 1] = 0xFF;
+    payload[1 + BINARY_TIMESTAMP_SIZE + 2] = 0x7F;
+    payload[1 + BINARY_TIMESTAMP_SIZE + 3] = 0x80;
+
+    bool cb_fired = false;
+    bool cb_success = false;
+    EXPECT_EQ(conn->send_binary_message(payload, sizeof(payload),
+                                        [&](bool ok) {
+                                            cb_fired = true;
+                                            cb_success = ok;
+                                        }),
+              SsErr::OK);
+    // Synchronous transport: the completion fires inline in the calling thread.
+    EXPECT_TRUE(cb_fired);
+    EXPECT_TRUE(cb_success);
+
+    {
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        while (binary_frames.load() == 0 && std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+    }
+    ASSERT_EQ(binary_frames.load(), 1);
+    {
+        std::lock_guard<std::mutex> lock(received_mutex);
+        ASSERT_EQ(received.size(), sizeof(payload));
+        EXPECT_EQ(0, std::memcmp(received.data(), payload, sizeof(payload)));
+    }
+
+    peer.stop();
+    listener.stop();
 }

--- a/tests/test_connection_lifecycle.cpp
+++ b/tests/test_connection_lifecycle.cpp
@@ -611,6 +611,7 @@ TEST(ConnectionLifecycle, FullNurseryOfLivePeersRejectsNewcomer) {
 // inline completion callback.
 TEST(ConnectionLifecycle, ClientBinarySendDeliversExactBytes) {
     std::atomic<int> binary_frames{0};
+    std::atomic<bool> peer_closed{false};
     std::string received;
     std::mutex received_mutex;
 
@@ -626,6 +627,8 @@ TEST(ConnectionLifecycle, ClientBinarySendDeliversExactBytes) {
                 std::lock_guard<std::mutex> lock(received_mutex);
                 received = msg->str;
                 binary_frames.fetch_add(1);
+            } else if (msg->type == ix::WebSocketMessageType::Close) {
+                peer_closed.store(true);
             }
         });
     });
@@ -673,6 +676,17 @@ TEST(ConnectionLifecycle, ClientBinarySendDeliversExactBytes) {
         }
     }
     ASSERT_EQ(binary_frames.load(), 1);
+    // Exactly-once means no LATER duplicate either: close the sender and drain until the peer
+    // observes the close (everything in flight has been delivered), then re-assert the count.
+    conn.disconnect(SendspinGoodbyeReason::SHUTDOWN, nullptr);
+    {
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        while (!peer_closed.load() && std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+    }
+    ASSERT_TRUE(peer_closed.load());
+    ASSERT_EQ(binary_frames.load(), 1);
     {
         std::lock_guard<std::mutex> lock(received_mutex);
         ASSERT_EQ(received.size(), sizeof(payload));
@@ -708,6 +722,7 @@ TEST(ConnectionLifecycle, ServerBinarySendDeliversExactBytes) {
 
     // The peer that receives the frame: an IXWebSocket client capturing binary messages.
     std::atomic<int> binary_frames{0};
+    std::atomic<bool> peer_closed{false};
     std::string received;
     std::mutex received_mutex;
     ix::WebSocket peer;
@@ -718,6 +733,8 @@ TEST(ConnectionLifecycle, ServerBinarySendDeliversExactBytes) {
             std::lock_guard<std::mutex> lock(received_mutex);
             received = msg->str;
             binary_frames.fetch_add(1);
+        } else if (msg->type == ix::WebSocketMessageType::Close) {
+            peer_closed.store(true);
         }
     });
     peer.start();
@@ -765,6 +782,17 @@ TEST(ConnectionLifecycle, ServerBinarySendDeliversExactBytes) {
             std::this_thread::sleep_for(std::chrono::milliseconds(5));
         }
     }
+    ASSERT_EQ(binary_frames.load(), 1);
+    // Exactly-once means no LATER duplicate either: close the sender and drain until the peer
+    // observes the close (everything in flight has been delivered), then re-assert the count.
+    conn->disconnect(SendspinGoodbyeReason::SHUTDOWN, nullptr);
+    {
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        while (!peer_closed.load() && std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+    }
+    ASSERT_TRUE(peer_closed.load());
     ASSERT_EQ(binary_frames.load(), 1);
     {
         std::lock_guard<std::mutex> lock(received_mutex);


### PR DESCRIPTION
Part 2/6 of the source@v1 stack (tracker: #95).

**What it adds:** `send_binary_message()` on the connection interface and all four transports (ESP client/server, host client/server). The ESP server transport gets a single-in-flight send slot that is allocation-free in steady state; the completion callback fires exactly once per call.

**How it's used:** part 3's source task calls it once per audio chunk. No callers yet in this part, so no behavior changes.
