### PR TITLE
Remove wall-clock assertions from the test suite and add a hang watchdog

### DIFF
--- a/.claude/skills/test-standards/SKILL.md
+++ b/.claude/skills/test-standards/SKILL.md
@@ -140,11 +140,11 @@ and are in scope regardless of who wrote them.
   extracting a pure predicate (see "Honest gaps"), not by timing the test.
 - If the property is latency itself, it is a benchmark, not a unit test.
   Name it under "Honest gaps" rather than approximating it with a bound.
-- The CTest `TIMEOUT` in `tests/CMakeLists.txt` is a hang guard, not an
-  assertion. It sits far above any real run time so a regression reports
-  instead of hanging forever. It only fires under `ctest`; a hung wait in a
-  direct or debugger run hangs, and a timeout gives no diagnostic beyond
-  the test name. That is the accepted price of removing the bound.
+- Hangs are guarded, not asserted, at a magnitude that is never a judgment
+  about test speed: the watchdog listener in `tests/main.cpp` aborts a test
+  still running after its budget and prints the main thread's stack, so a
+  direct or debugger run fails loudly and names the wait; the CTest
+  `TIMEOUT` in `tests/CMakeLists.txt` sits just above it as the backstop.
 - A fixed sleep may order events between threads only when a delayed thread
   yields a false pass, never a false failure: sleep so a consumer is likely
   parked before the wake, and if it was not yet parked the wake is held and

--- a/.claude/skills/test-standards/SKILL.md
+++ b/.claude/skills/test-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-standards
-description: Review the tests in a branch or PR against sendspin-cpp's test-quality standards - extract-for-testability, mutation-survivable assertions, control cases, no filler tests, no test seams in production code, and scaffolding that satisfies production invariants. Use when reviewing new or changed tests, or when asked whether a change is adequately tested.
+description: Review the tests in a branch or PR against sendspin-cpp's test-quality standards - extract-for-testability, mutation-survivable assertions, control cases, no filler tests, no wall-clock assertions, no test seams in production code, and scaffolding that satisfies production invariants. Use when reviewing new or changed tests, or when asked whether a change is adequately tested.
 user-invocable: true
 allowed-tools: Read, Grep, Glob, Bash
 ---
@@ -19,54 +19,73 @@ Determine the diff: if `$ARGUMENTS` contains a PR number, use
 `git diff HEAD`. If the review environment already supplies the diff (for
 example an automated PR review), review that diff directly instead of
 computing one. Consider both directions: new tests that are weak, and new
-logic that ships without a test that could catch its breakage. "Pre-existing"
-means present on `main`; new files and new hunks in the diff are the PR's code
-and are in scope regardless of who wrote them.
+logic that ships without a test that could catch its breakage. New files and
+new hunks are in scope regardless of who wrote them; a test already weak on
+`main` is out of scope unless the diff touches it or relies on it for
+coverage.
+
+Back every claim with a command: a "checked and clean" statement, a mutation
+result, or "the suite passes" rests on a build, run, grep, or read performed
+during this review. The suite must pass under ASan/UBSan
+(`-DENABLE_SANITIZERS=ON`, the CI configuration); a stale build directory
+has passed mutations here before, so check that the objects rebuilt.
 
 ## Extract for testability
 
-- Nontrivial pure logic buried inside a threaded or I/O-coupled path should
-  be extracted into a static member or free function with no thread, socket,
-  or callback dependencies, then unit-tested directly. This is the
-  established pattern: `decode_visualizer_message()`
-  (`src/visualizer_role.cpp`) and the static display-timing helpers in
-  `src/artwork_role.cpp` exist for exactly this reason.
-- Extraction purely for testability is encouraged; it needs no other
-  justification. Flag new decision-heavy logic that is only reachable through
-  a thread or a full client as a testability finding.
+- Nontrivial pure logic buried inside a threaded or I/O-coupled path is
+  extracted into a static member or free function with no thread, socket, or
+  callback dependencies, then unit-tested directly. `decode_visualizer_message()`
+  (`src/visualizer_role.cpp`) is the established pattern. Extraction purely
+  for testability needs no other justification; flag new decision-heavy
+  logic that is only reachable through a thread or a full client.
+- A timing decision is extracted into a pure predicate that takes `now` as an
+  ordinary argument; the production call site still reads the real clock and
+  nothing becomes swappable. `display_overdue_us` in `src/artwork_role.cpp`
+  is the shape. This project has no clock injection seam by decision, and a
+  review must not propose one. A predicate covers a decision, not a sequence
+  over time; sequencing that needs direct coverage is a gap to name.
+
+## No test seams in production
+
+- Production code in `src/` and `include/` must not acquire friends,
+  test-only hooks, widened visibility, extra template parameters, injectable
+  clocks or transports, or fixture-aware naming in order to be testable. The
+  fix is extraction (above), a test-side technique, or a named gap.
+- Allowed test-side techniques: tests are white-box and include private
+  headers from `src/`; a fixture may construct and drive a role's `Impl`
+  directly (`tests/test_artwork_role.cpp`); connection tests use real
+  loopback sockets (`tests/test_connection_lifecycle.cpp`); a single
+  white-box translation unit may be compiled with `-fno-access-control`
+  (set per file in `tests/CMakeLists.txt`, never suite-wide), with every
+  private touch routed through a documented fixture helper so the
+  depended-on surface stays auditable in one place.
 
 ## Mutation survival
 
 - For every new test, identify the production line or branch its name or
-  comment claims to defend, and check: if that line were deleted or its
+  comment claims to defend and ask: if that line were deleted or its
   condition inverted, would this test fail? A test that would still pass is
-  filler. Mutations are scoped to that line, not to every line reachable from
-  the test; prefer edits a person would plausibly make (dropping a reset,
-  inverting a comparison, removing a guard) over line-by-line deletion. A
-  surviving mutation is a defect of the test only when it breaks a contract
-  the test claims to cover; otherwise it belongs under "Honest gaps".
+  filler. Scope mutations to that line, preferring edits a person would
+  plausibly make (dropping a reset, inverting a comparison, removing a guard)
+  over line-by-line deletion.
+- Reasoning is enough to pass a test. Before reporting a survival finding or
+  certifying a subtle test as adequate, build and run the mutant after the
+  unmutated build passes, and state the command and result.
+- A surviving mutation is a defect of the test only when it breaks a contract
+  the test claims to cover; otherwise it is a gap. A surviving mutation and
+  an overclaiming comment on the same test are one finding.
 - An assertion that claims to cover several failure modes must fail for each
-  one on its own; a single aggregate check detects only the mode that
-  dominates it. Regress each path alone to confirm the others.
-- A mutation claim is verified by building and running the mutant after the
-  unmutated build passes, and the finding states the command and result; a
-  stale build directory has passed mutations here before, so check that the
-  objects rebuilt. This is the same overclaim that "Granularity and
-  independence" catches by reading; report it once.
+  one on its own; break each path alone to confirm.
 - Watch for self-referential tests: asserting on state the test itself set,
-  exercising only the mock, or re-deriving the expected value with the same
+  exercising only the fake, or re-deriving the expected value with the same
   code path the production code uses.
-- When a test's protective value is non-obvious, a comment or the PR
-  description saying which mutation it catches ("deleting X makes tests Y and
-  Z fail") helps; its absence on a subtle test is worth a note, not a
-  blocker.
 
 ## Validation-test template
 
 - Tests for parsing/validation pair every malformed-input case with an
   explicit control case (comment prefix `Control:`) proving the same parser
-  accepts valid input. A rejection suite with no control case cannot
-  distinguish "rejects bad input" from "rejects everything".
+  accepts valid input; without one, "rejects bad input" is indistinguishable
+  from "rejects everything".
 - Cover the reject-the-whole-object rule: one bad sibling field must reject
   the enclosing object, and the test must show neighboring valid fields did
   not survive into the output.
@@ -78,107 +97,70 @@ and are in scope regardless of who wrote them.
   Recommending deletion of a weak test is a valid review outcome.
 - Test names and comments describe the behavior under test, not the defect
   history ("rejects spectrum config missing n_disp_bins", not "regression
-  test for the config bug").
+  test for the config bug"), closely enough that a red CI run identifies the
+  break without opening the file.
 
 ## Granularity and independence
 
 - One behavior per test: not one assertion per test, and not one test per
-  bug. Several assertions about the same behavior belong together and
-  splitting them is filler; a long test spanning several behaviors is the
-  opposite failure and gets split along the behaviors it conflates.
+  bug. Several assertions about the same behavior belong together; a test
+  spanning several behaviors is split along the behaviors it conflates.
   `MetadataNullClearsAndAbsentPreserves` (`tests/test_protocol.cpp`) asserts
   three things about the single delta-merge rule it covers.
-- A test name describes the behavior closely enough that a red CI run
-  identifies the break without opening the file (see the naming bullet under
-  "No filler").
 - A test's assertions establish what its name and comment claim, no more and
-  no less. A comment that promises a property the assertions do not check is
-  an overclaim; add the assertion or narrow the comment.
-- `ASSERT_*` aborts the test function while `EXPECT_*` continues, so an
-  over-merged test masks later failures behind the first one. Reserve
+  no less; a comment that promises an unchecked property is an overclaim.
+- `ASSERT_*` aborts the test function while `EXPECT_*` continues; reserve
   `ASSERT_*` for the point where continuing would be meaningless, such as a
   parse that must succeed before its result is read.
 - No test depends on execution order, on another test having run first, or on
-  shared mutable global state; each test sets up the world it needs.
+  shared mutable global state. A test that fails without a code change is a
+  defect in the test: fix it or delete it, never retry it into passing.
 
-## No test seams in production
-
-- Production code in `src/` and `include/` must not acquire friends,
-  test-only hooks, widened visibility, extra template parameters, or
-  fixture-aware naming in order to be testable. The fix for hard-to-reach
-  code is extraction (above) or test-side techniques, never a seam in the
-  shipped code.
-
-## Scaffolding parity
+## Scaffolding and test doubles
 
 - Test harnesses satisfy production invariants instead of stubbing around
-  them: if production code asserts a bound `Inbox`, the test fixture binds
-  one. A harness that suppresses an invariant hides every bug that invariant
-  guards.
-- Concurrency tests observe real effects rather than self-referential timing:
-  never assert on a counter that the thread under test would have been the
-  one to advance; use the code's own observable outputs or event flags. A
-  fixed sleep is not a synchronization tool; the narrow ordering use it is
-  allowed is in "No wall-clock assertions".
+  them: if production code asserts a bound `Inbox`, the fixture binds one. A
+  harness that suppresses an invariant hides every bug it guards.
+- Doubles are hand-written fakes that record outcomes; the tree uses no
+  gmock. A test that asserts on which calls were made rather than on what
+  resulted is exercising the double, not the code.
+- Concurrency tests observe real effects: never assert on a counter the
+  thread under test would have been the one to advance; use the code's own
+  observable outputs or event flags.
 
 ## No wall-clock assertions
 
 - A unit test never makes elapsed time the pass/fail condition
-  (`EXPECT_LT(elapsed, x)`, `EXPECT_GE(elapsed, y)`). A stopwatch measures
-  the runner and the scheduler, not the code, and the bound it needs is a
-  guess about machine speed that is eventually wrong. A bounded wait that
-  only decides when to sample an observation is scheduling, not an
-  assertion; the last bullet says when that is allowed.
-- An elapsed-time assertion is a symptom: the call under test has a second
-  way to return (a timeout) and the clock exists only to tell the two apart.
-  Remove the second exit instead. Wait with no timeout so the event under
-  test is the only way out and completion is the proof; assert on a value
-  that only a correctly blocked call could produce ("the consumer received
-  the item sent after it parked"); or rely on a structural failure
-  (`std::thread` terminates on a joinable thread, the sanitizers catch a
-  use-after-free). Timing decisions inside production code are covered by
-  extracting a pure predicate (see "Honest gaps"), not by timing the test.
-- If the property is latency itself, it is a benchmark, not a unit test.
-  Name it under "Honest gaps" rather than approximating it with a bound.
-- Hangs are guarded, not asserted, at a magnitude that is never a judgment
-  about test speed: the watchdog listener in `tests/main.cpp` aborts a test
-  still running after its budget and prints the main thread's stack, so a
-  direct or debugger run fails loudly and names the wait; the CTest
-  `TIMEOUT` in `tests/CMakeLists.txt` sits just above it as the backstop.
-- A fixed sleep may order events between threads only when a delayed thread
-  yields a false pass, never a false failure: sleep so a consumer is likely
-  parked before the wake, and if it was not yet parked the wake is held and
-  the test still passes. It is never itself an assertion. A bounded window
-  is likewise acceptable only for a "must not happen" check on a monotonic
-  observation (a flag or counter that cannot un-set within the test), where
-  a short window can only miss a regression. A watchdog is tested the same
-  way: wait with no timeout for "it fires", a bounded window for "not yet".
-
-## Sanitizers
-
-- The suite must pass under ASan/UBSan (`-DENABLE_SANITIZERS=ON`, the CI
-  configuration).
+  (`EXPECT_LT(elapsed, x)`, `EXPECT_GE(elapsed, y)`); the bound is a guess
+  about machine speed that is eventually wrong. If the property is latency
+  itself, it is a benchmark: name it as a gap.
+- An elapsed-time assertion means the call under test has a second exit (a
+  timeout) and the clock exists to tell the two apart. Remove the second
+  exit: wait with no timeout so completion is the proof; assert on a value
+  only a correctly blocked call could produce ("the consumer received the
+  item sent after it parked"); or rely on a structural failure (`std::thread`
+  terminates on a joinable thread, the sanitizers catch a use-after-free).
+  Hangs are guarded by the watchdog in `tests/main.cpp` and the CTest
+  `TIMEOUT` in `tests/CMakeLists.txt`, both far above any test's real
+  duration.
+- Allowed: a bounded wait that only decides when to sample; a fixed sleep
+  that orders threads only when a late thread yields a false pass, never a
+  false failure (sleep so the consumer is likely parked, and if it was not,
+  the wake is held and the test still passes); a bounded window for a "must
+  not happen" check on a monotonic observation, where a short window can
+  only miss a regression. A watchdog is tested with these: no timeout for
+  "it fires", a bounded window for "not yet".
 
 ## Honest gaps
 
 - A coverage gap that cannot be closed cheaply is named explicitly in the PR
   rather than papered over with a test that appears to cover it. Flag
-  apparent coverage that does not actually exercise the gap.
-- Naming the gap is the finding. Do not recommend a production seam to close
-  it: an injectable clock, a virtual hook, or a swappable transport added to
-  `src/` or `include/` for a test's benefit is the seam violation above, not
-  the remedy for it. This project has no clock injection seam and a review
-  must not propose introducing one; where a timing decision needs direct
-  coverage, extract it into a pure predicate the test calls with supplied
-  values. Unlike a seam, the predicate takes `now` as an ordinary argument
-  and the production call site still reads the real clock; nothing becomes
-  swappable. `display_overdue_us` in `src/artwork_role.cpp` is the shape.
+  apparent coverage that does not exercise the gap. Naming the gap is the
+  finding; never recommend a production seam to close it.
 - The host suite compiles only the host arm of `#ifdef ESP_PLATFORM`. A
   finding that touches platform-guarded code states which arm the test
   exercises; a change to the ESP arm is a gap to name, and a host mutation
   result says nothing about it.
-- A test that fails without a code change is a defect in the test. Fix it or
-  delete it; never retry it into passing.
 
 ## Report format
 

--- a/.claude/skills/test-standards/SKILL.md
+++ b/.claude/skills/test-standards/SKILL.md
@@ -46,11 +46,13 @@ and are in scope regardless of who wrote them.
   surviving mutation is a defect of the test only when it breaks a contract
   the test claims to cover; otherwise it belongs under "Honest gaps".
 - An assertion that claims to cover several failure modes must fail for each
-  one on its own. A single bound against a sum of timeouts detects only the
-  largest term; regress each path alone to check the small ones.
-- A mutation claim in a finding is verified by running it, with evidence the
-  binary actually rebuilt; a stale build directory has passed mutations here
-  before.
+  one on its own; a single aggregate check detects only the mode that
+  dominates it. Regress each path alone to confirm the others.
+- A mutation claim is verified by building and running the mutant after the
+  unmutated build passes, and the finding states the command and result; a
+  stale build directory has passed mutations here before, so check that the
+  objects rebuilt. This is the same overclaim that "Granularity and
+  independence" catches by reading; report it once.
 - Watch for self-referential tests: asserting on state the test itself set,
   exercising only the mock, or re-deriving the expected value with the same
   code path the production code uses.
@@ -115,14 +117,18 @@ and are in scope regardless of who wrote them.
   guards.
 - Concurrency tests observe real effects rather than self-referential timing:
   never assert on a counter that the thread under test would have been the
-  one to advance; use the code's own observable outputs or event flags. Time
-  itself is covered under "No wall-clock assertions".
+  one to advance; use the code's own observable outputs or event flags. A
+  fixed sleep is not a synchronization tool; the narrow ordering use it is
+  allowed is in "No wall-clock assertions".
 
 ## No wall-clock assertions
 
-- A unit test does not assert on elapsed time. A stopwatch measures the
-  runner and the scheduler, not the code, and the bound it needs is a guess
-  about how slow a machine might be; every such guess is eventually wrong.
+- A unit test never makes elapsed time the pass/fail condition
+  (`EXPECT_LT(elapsed, x)`, `EXPECT_GE(elapsed, y)`). A stopwatch measures
+  the runner and the scheduler, not the code, and the bound it needs is a
+  guess about machine speed that is eventually wrong. A bounded wait that
+  only decides when to sample an observation is scheduling, not an
+  assertion; the last bullet says when that is allowed.
 - An elapsed-time assertion is a symptom: the call under test has a second
   way to return (a timeout) and the clock exists only to tell the two apart.
   Remove the second exit instead. Wait with no timeout so the event under
@@ -136,19 +142,17 @@ and are in scope regardless of who wrote them.
   Name it under "Honest gaps" rather than approximating it with a bound.
 - The CTest `TIMEOUT` in `tests/CMakeLists.txt` is a hang guard, not an
   assertion. It sits far above any real run time so a regression reports
-  instead of hanging forever.
+  instead of hanging forever. It only fires under `ctest`; a hung wait in a
+  direct or debugger run hangs, and a timeout gives no diagnostic beyond
+  the test name. That is the accepted price of removing the bound.
 - A fixed sleep may order events between threads only when a delayed thread
-  yields a false pass, never a false failure. It is never itself an
-  assertion, and the test must still be correct if the sleep is too short. A
-  bounded window is likewise acceptable only for a "must not happen" check
-  on a monotonic observation, where a short window can only miss a
-  regression.
-
-## Platform branches
-
-- State which `#ifdef ESP_PLATFORM` arm a test exercises. The host suite
-  compiles only the host arm; a change to the ESP arm is an honest gap, not
-  covered, and a host mutation result says nothing about device behavior.
+  yields a false pass, never a false failure: sleep so a consumer is likely
+  parked before the wake, and if it was not yet parked the wake is held and
+  the test still passes. It is never itself an assertion. A bounded window
+  is likewise acceptable only for a "must not happen" check on a monotonic
+  observation (a flag or counter that cannot un-set within the test), where
+  a short window can only miss a regression. A watchdog is tested the same
+  way: wait with no timeout for "it fires", a bounded window for "not yet".
 
 ## Sanitizers
 
@@ -166,10 +170,19 @@ and are in scope regardless of who wrote them.
   the remedy for it. This project has no clock injection seam and a review
   must not propose introducing one; where a timing decision needs direct
   coverage, extract it into a pure predicate the test calls with supplied
-  values.
+  values. Unlike a seam, the predicate takes `now` as an ordinary argument
+  and the production call site still reads the real clock; nothing becomes
+  swappable. `display_overdue_us` in `src/artwork_role.cpp` is the shape.
+- The host suite compiles only the host arm of `#ifdef ESP_PLATFORM`. A
+  finding that touches platform-guarded code states which arm the test
+  exercises; a change to the ESP arm is a gap to name, and a host mutation
+  result says nothing about it.
+- A test that fails without a code change is a defect in the test. Fix it or
+  delete it; never retry it into passing.
 
 ## Report format
 
 For each finding: location (file:line), the standard it misses, and the
-concrete improvement (including "delete this test" where warranted). Separate
+concrete improvement (including "delete this test" where warranted); a
+mutation finding also states the command run and the observed result. Separate
 sections for weak tests, missing tests, and production-testability issues.

--- a/.claude/skills/test-standards/SKILL.md
+++ b/.claude/skills/test-standards/SKILL.md
@@ -2,7 +2,7 @@
 name: test-standards
 description: Review the tests in a branch or PR against sendspin-cpp's test-quality standards - extract-for-testability, mutation-survivable assertions, control cases, no filler tests, no wall-clock assertions, no test seams in production code, and scaffolding that satisfies production invariants. Use when reviewing new or changed tests, or when asked whether a change is adequately tested.
 user-invocable: true
-allowed-tools: Read, Grep, Glob, Bash
+allowed-tools: Read, Grep, Glob, Bash, Edit
 ---
 
 # Test Standards Review
@@ -10,7 +10,11 @@ allowed-tools: Read, Grep, Glob, Bash
 Review the tests a change adds or modifies, and whether the change's logic is
 testable at all. A test's job is to fail when the production code is broken;
 a test that cannot fail that way is filler, and filler has negative value.
-Report findings only; do not edit files.
+Report findings only. The normative rules live in `docs/conventions.md`
+("Testing"); this checklist applies them to a diff. The only edits this
+review makes are temporary mutations of production code for the checks
+under "Mutation survival", and every one of them is reverted before the
+report is written.
 
 ## Scope
 
@@ -20,15 +24,13 @@ Determine the diff: if `$ARGUMENTS` contains a PR number, use
 example an automated PR review), review that diff directly instead of
 computing one. Consider both directions: new tests that are weak, and new
 logic that ships without a test that could catch its breakage. New files and
-new hunks are in scope regardless of who wrote them; a test already weak on
-`main` is out of scope unless the diff touches it or relies on it for
-coverage.
+new hunks are in scope whether a person or a coding agent wrote them; a test
+already weak on `main` is out of scope unless the diff touches it or relies
+on it for coverage.
 
 Back every claim with a command: a "checked and clean" statement, a mutation
 result, or "the suite passes" rests on a build, run, grep, or read performed
-during this review. The suite must pass under ASan/UBSan
-(`-DENABLE_SANITIZERS=ON`, the CI configuration); a stale build directory
-has passed mutations here before, so check that the objects rebuilt.
+during this review.
 
 ## Extract for testability
 
@@ -54,11 +56,7 @@ has passed mutations here before, so check that the objects rebuilt.
 - Allowed test-side techniques: tests are white-box and include private
   headers from `src/`; a fixture may construct and drive a role's `Impl`
   directly (`tests/test_artwork_role.cpp`); connection tests use real
-  loopback sockets (`tests/test_connection_lifecycle.cpp`); a single
-  white-box translation unit may be compiled with `-fno-access-control`
-  (set per file in `tests/CMakeLists.txt`, never suite-wide), with every
-  private touch routed through a documented fixture helper so the
-  depended-on surface stays auditable in one place.
+  loopback sockets (`tests/test_connection_lifecycle.cpp`).
 
 ## Mutation survival
 
@@ -68,9 +66,16 @@ has passed mutations here before, so check that the objects rebuilt.
   filler. Scope mutations to that line, preferring edits a person would
   plausibly make (dropping a reset, inverting a comparison, removing a guard)
   over line-by-line deletion.
-- Reasoning is enough to pass a test. Before reporting a survival finding or
-  certifying a subtle test as adequate, build and run the mutant after the
-  unmutated build passes, and state the command and result.
+- Reasoning alone may clear a test whose assertion obviously pins the line
+  it claims. A survival finding, or a certification that a subtle test is
+  adequate, requires building and running the mutant after the unmutated
+  build passes, and the report states the command and the result.
+- Running a mutant: apply the edit, rebuild, run, then revert with
+  `git checkout -- <file>` and confirm `git status` shows the tree as it was
+  before the review. Build under ASan/UBSan (`-DENABLE_SANITIZERS=ON`, the
+  CI configuration). A stale build directory has passed mutations here
+  before, so check that the build output shows the mutated object
+  recompiling.
 - A surviving mutation is a defect of the test only when it breaks a contract
   the test claims to cover; otherwise it is a gap. A surviving mutation and
   an overclaiming comment on the same test are one finding.
@@ -80,7 +85,7 @@ has passed mutations here before, so check that the objects rebuilt.
   exercising only the fake, or re-deriving the expected value with the same
   code path the production code uses.
 
-## Validation-test template
+## Validation tests
 
 - Tests for parsing/validation pair every malformed-input case with an
   explicit control case (comment prefix `Control:`) proving the same parser
@@ -112,6 +117,10 @@ has passed mutations here before, so check that the objects rebuilt.
 - `ASSERT_*` aborts the test function while `EXPECT_*` continues; reserve
   `ASSERT_*` for the point where continuing would be meaningless, such as a
   parse that must succeed before its result is read.
+- An assertion whose failure would not explain itself carries a `<<` message
+  with the observed value: a "must not happen" window reports the count it
+  saw, a multi-step sequence reports which step it reached. A red run should
+  be diagnosable from the log alone.
 - No test depends on execution order, on another test having run first, or on
   shared mutable global state. A test that fails without a code change is a
   defect in the test: fix it or delete it, never retry it into passing.
@@ -121,12 +130,17 @@ has passed mutations here before, so check that the objects rebuilt.
 - Test harnesses satisfy production invariants instead of stubbing around
   them: if production code asserts a bound `Inbox`, the fixture binds one. A
   harness that suppresses an invariant hides every bug it guards.
+- Production `assert()` calls are contracts for callers, not behavior under
+  test; the suite has no death tests and a review does not ask for one.
 - Doubles are hand-written fakes that record outcomes; the tree uses no
   gmock. A test that asserts on which calls were made rather than on what
   resulted is exercising the double, not the code.
 - Concurrency tests observe real effects: never assert on a counter the
   thread under test would have been the one to advance; use the code's own
   observable outputs or event flags.
+- CI runs the suite under ASan/UBSan only. A concurrency finding backed by a
+  local ThreadSanitizer run says so and states the command; the absence of a
+  TSan run is not itself a finding.
 
 ## No wall-clock assertions
 
@@ -150,6 +164,10 @@ has passed mutations here before, so check that the objects rebuilt.
   not happen" check on a monotonic observation, where a short window can
   only miss a regression. A watchdog is tested with these: no timeout for
   "it fires", a bounded window for "not yet".
+- Sleeps and windows are the minimum that reliably orders the threads, on
+  the order of milliseconds. A test that takes longer than a few hundred
+  milliseconds carries a comment saying why; the watchdog budget is shared
+  by the whole suite and slow tests hide hangs behind it.
 
 ## Honest gaps
 
@@ -166,5 +184,8 @@ has passed mutations here before, so check that the objects rebuilt.
 
 For each finding: location (file:line), the standard it misses, and the
 concrete improvement (including "delete this test" where warranted); a
-mutation finding also states the command run and the observed result. Separate
-sections for weak tests, missing tests, and production-testability issues.
+mutation finding also states the command run and the observed result.
+Separate sections for weak tests, missing tests, production-testability
+issues, and named gaps (coverage that is missing by acknowledged decision,
+listed so the PR can state them; no action requested). Close with the
+`git status` output showing every mutation was reverted.

--- a/.claude/skills/test-standards/SKILL.md
+++ b/.claude/skills/test-standards/SKILL.md
@@ -19,7 +19,9 @@ Determine the diff: if `$ARGUMENTS` contains a PR number, use
 `git diff HEAD`. If the review environment already supplies the diff (for
 example an automated PR review), review that diff directly instead of
 computing one. Consider both directions: new tests that are weak, and new
-logic that ships without a test that could catch its breakage.
+logic that ships without a test that could catch its breakage. "Pre-existing"
+means present on `main`; new files and new hunks in the diff are the PR's code
+and are in scope regardless of who wrote them.
 
 ## Extract for testability
 
@@ -35,9 +37,20 @@ logic that ships without a test that could catch its breakage.
 
 ## Mutation survival
 
-- For every new test, identify the production line or branch it defends, and
-  check: if that line were deleted or its condition inverted, would this test
-  fail? A test that would still pass is filler.
+- For every new test, identify the production line or branch its name or
+  comment claims to defend, and check: if that line were deleted or its
+  condition inverted, would this test fail? A test that would still pass is
+  filler. Mutations are scoped to that line, not to every line reachable from
+  the test; prefer edits a person would plausibly make (dropping a reset,
+  inverting a comparison, removing a guard) over line-by-line deletion. A
+  surviving mutation is a defect of the test only when it breaks a contract
+  the test claims to cover; otherwise it belongs under "Honest gaps".
+- An assertion that claims to cover several failure modes must fail for each
+  one on its own. A single bound against a sum of timeouts detects only the
+  largest term; regress each path alone to check the small ones.
+- A mutation claim in a finding is verified by running it, with evidence the
+  binary actually rebuilt; a stale build directory has passed mutations here
+  before.
 - Watch for self-referential tests: asserting on state the test itself set,
   exercising only the mock, or re-deriving the expected value with the same
   code path the production code uses.
@@ -76,6 +89,9 @@ logic that ships without a test that could catch its breakage.
 - A test name describes the behavior closely enough that a red CI run
   identifies the break without opening the file (see the naming bullet under
   "No filler").
+- A test's assertions establish what its name and comment claim, no more and
+  no less. A comment that promises a property the assertions do not check is
+  an overclaim; add the assertion or narrow the comment.
 - `ASSERT_*` aborts the test function while `EXPECT_*` continues, so an
   over-merged test masks later failures behind the first one. Reserve
   `ASSERT_*` for the point where continuing would be meaningless, such as a
@@ -99,11 +115,40 @@ logic that ships without a test that could catch its breakage.
   guards.
 - Concurrency tests observe real effects rather than self-referential timing:
   never assert on a counter that the thread under test would have been the
-  one to advance, and never use fixed sleeps as synchronization; use the
-  code's own observable outputs or event flags.
-- A sleep that advances wall-clock time toward a real deadline is not
-  synchronization; before calling such a test fragile, compute the margin
-  between its nominal elapsed time and that deadline and state the margin.
+  one to advance; use the code's own observable outputs or event flags. Time
+  itself is covered under "No wall-clock assertions".
+
+## No wall-clock assertions
+
+- A unit test does not assert on elapsed time. A stopwatch measures the
+  runner and the scheduler, not the code, and the bound it needs is a guess
+  about how slow a machine might be; every such guess is eventually wrong.
+- An elapsed-time assertion is a symptom: the call under test has a second
+  way to return (a timeout) and the clock exists only to tell the two apart.
+  Remove the second exit instead. Wait with no timeout so the event under
+  test is the only way out and completion is the proof; assert on a value
+  that only a correctly blocked call could produce ("the consumer received
+  the item sent after it parked"); or rely on a structural failure
+  (`std::thread` terminates on a joinable thread, the sanitizers catch a
+  use-after-free). Timing decisions inside production code are covered by
+  extracting a pure predicate (see "Honest gaps"), not by timing the test.
+- If the property is latency itself, it is a benchmark, not a unit test.
+  Name it under "Honest gaps" rather than approximating it with a bound.
+- The CTest `TIMEOUT` in `tests/CMakeLists.txt` is a hang guard, not an
+  assertion. It sits far above any real run time so a regression reports
+  instead of hanging forever.
+- A fixed sleep may order events between threads only when a delayed thread
+  yields a false pass, never a false failure. It is never itself an
+  assertion, and the test must still be correct if the sleep is too short. A
+  bounded window is likewise acceptable only for a "must not happen" check
+  on a monotonic observation, where a short window can only miss a
+  regression.
+
+## Platform branches
+
+- State which `#ifdef ESP_PLATFORM` arm a test exercises. The host suite
+  compiles only the host arm; a change to the ESP arm is an honest gap, not
+  covered, and a host mutation result says nothing about device behavior.
 
 ## Sanitizers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ Core source files in `src/` have no `#ifdef ESP_PLATFORM` guards; all platform d
 
 ## Coding conventions
 
-- Design standards: `docs/conventions.md` is the normative reference (threading/Inbox rules, validation posture, platform abstraction, embedded resource discipline, public API shape, documentation sync); the bullets below are a summary
+- Design standards: `docs/conventions.md` is the normative reference (threading/Inbox rules, validation posture, platform abstraction, embedded resource discipline, public API shape, testing, documentation sync); the bullets below are a summary
 - C++20 (`gnu++20` on ESP, `cxx_std_20` on host)
 - Namespace: `sendspin`
 - Logging: Platform macros `SS_LOGE`, `SS_LOGW`, `SS_LOGI`, `SS_LOGD`, `SS_LOGV` (not raw `ESP_LOG*`)

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -118,6 +118,32 @@ checklists in `.claude/skills/` apply these standards to a diff.
   of a paired flag and value, a derived constant) so the invariant holds by
   construction.
 
+## Testing
+
+- Tests are host-only, white-box, and live in `tests/`; they include private
+  headers from `src/` and run under ASan/UBSan in CI.
+- Production code in `src/` and `include/` acquires nothing for the sake of
+  tests: no friends, test-only hooks, widened visibility, extra template
+  parameters, injectable clocks or transports, or fixture-aware naming.
+  Logic that is hard to reach is extracted into a pure static member or
+  free function and tested directly; a timing decision becomes a predicate
+  that takes `now` as an argument while the call site keeps reading the real
+  clock.
+- A test defends a specific production line or branch and fails when that
+  line is deleted or its condition inverted. A test that cannot fail that
+  way is filler and is deleted. Every malformed-input case in a validation
+  test is paired with a `Control:` case showing the same parser accepts
+  valid input.
+- Elapsed time is never a pass/fail condition. A blocked call is proven by
+  waiting with no timeout, by a value only the correct path can produce, or
+  by a structural failure; hangs are caught by the suite watchdog and the
+  CTest timeout, not by per-test bounds.
+- Fixtures satisfy production invariants rather than stubbing around them.
+  Test doubles are hand-written fakes that record outcomes; the tree uses no
+  gmock.
+- Coverage that cannot be obtained without a production seam is named as a
+  gap in the PR rather than approximated by a test that appears to cover it.
+
 ## Documentation
 
 - Comments and docs describe the current state of the code. No history

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,4 +50,4 @@ if(ENABLE_SANITIZERS)
 endif()
 
 include(GoogleTest)
-gtest_discover_tests(sendspin_tests)
+gtest_discover_tests(sendspin_tests PROPERTIES TIMEOUT 60)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,9 +17,11 @@ set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
 set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)  # only gtest_main is used; skip building gmock
 FetchContent_MakeAvailable(googletest)
 
-# One executable aggregating every test_*.cpp file. gtest_discover_tests still
-# registers the individual TEST() cases with CTest so failures are reported per case.
+# One executable aggregating every test_*.cpp file behind the main.cpp watchdog entry point.
+# gtest_discover_tests still registers the individual TEST() cases with CTest so failures are
+# reported per case.
 add_executable(sendspin_tests
+    main.cpp
     test_audio_stream_info.cpp
     test_connection_lifecycle.cpp
     test_time_filter.cpp
@@ -37,7 +39,12 @@ add_executable(sendspin_tests
 # if sendspin is ever added as a subdirectory of a larger superproject.
 target_include_directories(sendspin_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 
-target_link_libraries(sendspin_tests PRIVATE sendspin GTest::gtest_main)
+target_link_libraries(sendspin_tests PRIVATE sendspin GTest::gtest)
+# The watchdog in main.cpp prints a backtrace on a hang; glibc needs exported symbols to name
+# the frames.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_options(sendspin_tests PRIVATE -rdynamic)
+endif()
 
 target_compile_features(sendspin_tests PRIVATE cxx_std_20)
 target_compile_options(sendspin_tests PRIVATE -Wall -Wextra)
@@ -50,4 +57,6 @@ if(ENABLE_SANITIZERS)
 endif()
 
 include(GoogleTest)
+# Backstop above the 55 s watchdog in main.cpp, which fires first and prints the hung test's
+# stack.
 gtest_discover_tests(sendspin_tests PROPERTIES TIMEOUT 60)

--- a/tests/README.md
+++ b/tests/README.md
@@ -59,6 +59,6 @@ Each `test_*.cpp` file covers one unit of cross-platform logic:
 
 These are white-box tests: they include private headers from `src/`, so the test target adds
 `src/` to its include path. To add a new test file, create `test_<unit>.cpp` here and add it to
-the `add_executable(sendspin_tests ...)` list in `tests/CMakeLists.txt`. The standards new tests
-are held to are in `docs/conventions.md` ("Testing"); the `test-standards` skill in
+the `add_executable(sendspin_tests ...)` list in `tests/CMakeLists.txt`. New tests are held to
+the standards in `docs/conventions.md` ("Testing"); the `test-standards` skill in
 `.claude/skills/` applies them to a diff.

--- a/tests/README.md
+++ b/tests/README.md
@@ -34,15 +34,31 @@ ctest --test-dir build-tests-asan --output-on-failure
 
 ## Layout
 
+`main.cpp` is the entry point. It registers a hang watchdog that aborts the binary with the
+name and stack of any test still running after 55 s; the CTest `TIMEOUT` of 60 s is the backstop
+behind it. Tests wait on events with no per-test timeout, so a regression that hangs shows up as
+a watchdog report rather than a flaky elapsed-time assertion.
+
 Each `test_*.cpp` file covers one unit of cross-platform logic:
 
-- `test_protocol.cpp` — wire-protocol parsing/formatting: enum round-trips, message dispatch, the
+- `test_protocol.cpp`: wire-protocol parsing/formatting: enum round-trips, message dispatch, the
   tri-state metadata/color deltas, and the hand-rolled `client/time` formatter checked against
   `snprintf`.
-- `test_time_filter.cpp` — `SendspinTimeFilter` invariants (monotonic-timestamp rejection, reset,
+- `test_time_filter.cpp`: `SendspinTimeFilter` invariants (monotonic-timestamp rejection, reset,
   offset round-trip, convergence).
-- `test_audio_stream_info.cpp` — byte/frame/sample/duration conversions.
+- `test_audio_stream_info.cpp`: byte/frame/sample/duration conversions.
+- `test_network_info.cpp`: local interface MAC lookup is well-formed or absent.
+- `test_spsc_ring_buffer.cpp`: ring buffer storage sizing and alignment.
+- `test_inbox.cpp`: `Inbox`/`InboxSlot` topic bits, event ring ordering, and slot binding.
+- `test_visualizer_role.cpp`: `decode_visualizer_message()` and the visualizer role's
+  negotiation and dispatch.
+- `test_artwork_role.cpp`: the artwork role's `Impl` driven directly: decode thread, slot
+  gating, `frame_done()` acks, and stream restart/clear.
+- `test_connection_lifecycle.cpp`: the connection nursery (prove-then-admit) over real loopback
+  sockets: junk probes, slow peers, early server hello, and capacity.
 
 These are white-box tests: they include private headers from `src/`, so the test target adds
 `src/` to its include path. To add a new test file, create `test_<unit>.cpp` here and add it to
-the `add_executable(sendspin_tests ...)` list in `tests/CMakeLists.txt`.
+the `add_executable(sendspin_tests ...)` list in `tests/CMakeLists.txt`. The standards new tests
+are held to are in `docs/conventions.md` ("Testing"); the `test-standards` skill in
+`.claude/skills/` applies them to a diff.

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,0 +1,129 @@
+// Copyright 2026 Sendspin Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @file main.cpp
+/// @brief Test entry point with an in-process hang watchdog. Tests wait on events with no
+/// timeout, so a regression hangs; this aborts the run with the hung test's name and the main
+/// thread's stack, which the CTest TIMEOUT alone cannot provide and a direct run has no other
+/// guard for.
+
+#include <execinfo.h>
+#include <gtest/gtest.h>
+#include <pthread.h>
+#include <signal.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <cstdlib>
+#include <mutex>
+#include <thread>
+
+namespace {
+
+// Below the CTest TIMEOUT in tests/CMakeLists.txt so this fires first and CTest records the
+// diagnostic; CTest remains the backstop if this thread cannot run.
+constexpr auto WATCHDOG_BUDGET = std::chrono::seconds(55);
+
+pthread_t main_thread;
+
+// Signal handler run on the main thread, where every blocking test helper waits.
+// backtrace_symbols_fd writes straight to the fd, so nothing here allocates.
+void dump_stack(int /*signum*/) {
+    void* frames[64];
+    int count = backtrace(frames, 64);
+    backtrace_symbols_fd(frames, count, STDERR_FILENO);
+}
+
+class HangWatchdog : public testing::EmptyTestEventListener {
+public:
+    HangWatchdog() : thread_([this] { this->run(); }) {}
+
+    ~HangWatchdog() override {
+        {
+            std::lock_guard<std::mutex> lock(this->mutex_);
+            this->stopping_ = true;
+        }
+        this->cv_.notify_all();
+        this->thread_.join();
+    }
+
+    void OnTestStart(const testing::TestInfo& info) override {
+        {
+            std::lock_guard<std::mutex> lock(this->mutex_);
+            this->current_ = &info;
+            this->deadline_ = std::chrono::steady_clock::now() + WATCHDOG_BUDGET;
+        }
+        this->cv_.notify_all();
+    }
+
+    void OnTestEnd(const testing::TestInfo& /*info*/) override {
+        {
+            std::lock_guard<std::mutex> lock(this->mutex_);
+            this->current_ = nullptr;
+        }
+        this->cv_.notify_all();
+    }
+
+private:
+    void run() {
+        std::unique_lock<std::mutex> lock(this->mutex_);
+        while (!this->stopping_) {
+            if (this->current_ == nullptr) {
+                this->cv_.wait(lock);
+                continue;
+            }
+            if (this->cv_.wait_until(lock, this->deadline_) == std::cv_status::timeout &&
+                this->current_ != nullptr) {
+                this->fire(*this->current_);
+            }
+        }
+    }
+
+    static void fire(const testing::TestInfo& info) {
+        std::fprintf(stderr, "\nHang watchdog: %s.%s (%s:%d) still running after %lld s\n",
+                     info.test_suite_name(), info.name(), info.file() ? info.file() : "?",
+                     info.line(), static_cast<long long>(WATCHDOG_BUDGET.count()));
+        std::fflush(stderr);
+        pthread_kill(main_thread, SIGUSR1);
+        // Give the handler time to write the stack before the process goes down.
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        std::abort();
+    }
+
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    const testing::TestInfo* current_{nullptr};
+    std::chrono::steady_clock::time_point deadline_;
+    bool stopping_{false};
+    std::thread thread_;
+};
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    main_thread = pthread_self();
+    struct sigaction action {};
+    action.sa_handler = dump_stack;
+    sigemptyset(&action.sa_mask);
+    sigaction(SIGUSR1, &action, nullptr);
+    // backtrace() may allocate on first use; take that hit here rather than in the handler.
+    void* prime[1];
+    backtrace(prime, 1);
+
+    testing::InitGoogleTest(&argc, argv);
+    testing::UnitTest::GetInstance()->listeners().Append(new HangWatchdog);  // gtest owns it
+    return RUN_ALL_TESTS();
+}

--- a/tests/test_artwork_role.cpp
+++ b/tests/test_artwork_role.cpp
@@ -41,11 +41,10 @@ void put_be64(std::vector<uint8_t>& out, int64_t val) {
     }
 }
 
-// Negative-wait window: long enough to be safely past the decode thread's 100ms parked-slot
-// sweep fallback (see DRAIN_RECEIVE_TIMEOUT_MS in artwork_role.cpp), short enough to keep the
-// suite fast.
+// Window for "must NOT fire" checks: past the decode thread's 100ms parked-slot sweep fallback
+// (see DRAIN_RECEIVE_TIMEOUT_MS in artwork_role.cpp). Every counter it watches is monotonic, so
+// a window that is too short can only miss a regression, never fail a correct run.
 constexpr auto NEGATIVE_WINDOW = std::chrono::milliseconds(300);
-constexpr auto POSITIVE_TIMEOUT = std::chrono::milliseconds(1500);
 
 // Records every callback fired by an ArtworkRole::Impl under test, guarded by its own mutex so
 // the test thread can safely poll state produced on the decode thread and the main thread. If
@@ -90,12 +89,13 @@ public:
         this->cv.notify_all();
     }
 
-    // Waits (up to timeout) for pred() to become true, evaluated under this->mutex so it can
-    // safely read decodes/displays/clears.
+    // Waits for pred() to become true, evaluated under this->mutex so it can safely read
+    // decodes/displays/clears. No timeout: a regression hangs here and the CTest TIMEOUT
+    // reports it.
     template <typename Pred>
-    bool wait_for(Pred pred, std::chrono::milliseconds timeout) {
+    void wait_until(Pred pred) {
         std::unique_lock<std::mutex> lock(this->mutex);
-        return this->cv.wait_for(lock, timeout, pred);
+        this->cv.wait(lock, pred);
     }
 
     // Asserts pred() stays false for the whole window; used for "must NOT fire" checks. Returns
@@ -221,20 +221,19 @@ void send_clear(ArtworkRole::Impl& impl, uint8_t slot, int64_t timestamp = 1) {
     impl.handle_binary(slot, data.data(), data.size());
 }
 
-// Polls drain_events() until `pred` is true or the timeout elapses. drain_events() must run on
-// the "main loop" thread (here, the test thread), so it cannot be driven from inside the
-// listener's condition variable wait -- it has to be called from an ordinary polling loop.
+// Polls drain_events() until `pred` is true. drain_events() must run on the "main loop" thread
+// (here, the test thread), so it cannot be driven from inside the listener's condition variable
+// wait -- it has to be called from an ordinary polling loop. No timeout: a regression hangs
+// here and the CTest TIMEOUT reports it.
 template <typename Pred>
-bool poll_drain_until(ArtworkRole::Impl& impl, Pred pred, std::chrono::milliseconds timeout) {
-    const auto deadline = std::chrono::steady_clock::now() + timeout;
-    do {
+void poll_drain_until(ArtworkRole::Impl& impl, Pred pred) {
+    for (;;) {
         impl.drain_events();
         if (pred()) {
-            return true;
+            return;
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    } while (std::chrono::steady_clock::now() < deadline);
-    return pred();
+    }
 }
 
 // Asserts pred() stays false for the whole window while the main loop keeps draining: the
@@ -247,29 +246,34 @@ bool poll_drain_until(ArtworkRole::Impl& impl, Pred pred, std::chrono::milliseco
 // true (the expected outcome).
 template <typename Pred>
 bool poll_drain_never(ArtworkRole::Impl& impl, Pred pred, std::chrono::milliseconds window) {
-    return !poll_drain_until(impl, pred, window);
+    const auto deadline = std::chrono::steady_clock::now() + window;
+    do {
+        impl.drain_events();
+        if (pred()) {
+            return false;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    } while (std::chrono::steady_clock::now() < deadline);
+    return !pred();
 }
 
-// Polls until `pred` (evaluated under impl.drain_task->slot_mutex) is true or the timeout
-// elapses. SlotBuffer::has_parked/ack_state are decode-thread-owned state with no listener
+// Polls until `pred` (evaluated under impl.drain_task->slot_mutex) is true. No timeout: a
+// regression hangs here and the CTest TIMEOUT reports it. SlotBuffer::has_parked/ack_state are decode-thread-owned state with no listener
 // callback to hang a condition variable off of, so tests that need to synchronize with "the
 // decode thread has parked this notification" (rather than "the decode thread has decoded
 // something") poll the (public, per artwork_role_impl.h) SlotBuffer fields directly under the
 // same mutex the production code uses.
 template <typename Pred>
-bool wait_slot_state(ArtworkRole::Impl& impl, Pred pred, std::chrono::milliseconds timeout) {
-    const auto deadline = std::chrono::steady_clock::now() + timeout;
-    do {
+void wait_slot_state(ArtworkRole::Impl& impl, Pred pred) {
+    for (;;) {
         {
             std::lock_guard<std::mutex> lock(impl.drain_task->slot_mutex);
             if (pred()) {
-                return true;
+                return;
             }
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
-    } while (std::chrono::steady_clock::now() < deadline);
-    std::lock_guard<std::mutex> lock(impl.drain_task->slot_mutex);
-    return pred();
+    }
 }
 
 }  // namespace
@@ -286,11 +290,11 @@ TEST(ArtworkFrameDoneGate, DefaultUngatedUnchanged) {
     impl->handle_stream_start(ServerArtworkStreamObject{});
 
     send_frame(*impl, 0, 'A');
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 1; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 1; });
     EXPECT_EQ(listener.decode_marker_at(0), 'A');
 
     send_frame(*impl, 0, 'B');
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 2; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 2; });
     EXPECT_EQ(listener.decode_marker_at(1), 'B');
 }
 
@@ -306,7 +310,7 @@ TEST(ArtworkFrameDoneGate, GateHoldsSecondFrame) {
     impl->handle_stream_start(ServerArtworkStreamObject{});
 
     send_frame(*impl, 0, 'A');
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 1; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 1; });
     EXPECT_EQ(listener.decode_marker_at(0), 'A');
 
     send_frame(*impl, 0, 'B');
@@ -314,7 +318,7 @@ TEST(ArtworkFrameDoneGate, GateHoldsSecondFrame) {
         listener.never_within([&] { return listener.decodes.size() >= 2; }, NEGATIVE_WINDOW));
 
     impl->frame_done(0);
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 2; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 2; });
     EXPECT_EQ(listener.decode_marker_at(1), 'B');
 }
 
@@ -326,10 +330,9 @@ TEST(ArtworkFrameDoneGate, GateHoldsThroughDisplay) {
     impl->handle_stream_start(ServerArtworkStreamObject{});
 
     send_frame(*impl, 0, 'A');
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 1; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 1; });
 
-    ASSERT_TRUE(
-        poll_drain_until(*impl, [&] { return listener.display_count() >= 1; }, POSITIVE_TIMEOUT));
+    poll_drain_until(*impl, [&] { return listener.display_count() >= 1; });
 
     // The gate must still be held after the display fires -- only frame_done() releases it.
     send_frame(*impl, 0, 'B');
@@ -337,7 +340,7 @@ TEST(ArtworkFrameDoneGate, GateHoldsThroughDisplay) {
         listener.never_within([&] { return listener.decodes.size() >= 2; }, NEGATIVE_WINDOW));
 
     impl->frame_done(0);
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 2; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 2; });
     EXPECT_EQ(listener.decode_marker_at(1), 'B');
 }
 
@@ -349,18 +352,18 @@ TEST(ArtworkFrameDoneGate, SupersedeKeepsNewestParked) {
     impl->handle_stream_start(ServerArtworkStreamObject{});
 
     send_frame(*impl, 0, 'A');
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 1; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 1; });
 
     send_frame(*impl, 0, 'B');
     // Wait for B to actually be parked before sending C, so C deterministically observes an
     // already-parked notification to supersede (see the wait_slot_state comment on its first use
     // in ClearIsADeliveryAndDropsParked for why this matters instead of a fixed sleep).
-    ASSERT_TRUE(wait_slot_state(
-        *impl, [&] { return impl->drain_task->slot_buffers[0].has_parked; }, POSITIVE_TIMEOUT));
+    wait_slot_state(
+        *impl, [&] { return impl->drain_task->slot_buffers[0].has_parked; });
     send_frame(*impl, 0, 'C');
 
     impl->frame_done(0);
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 2; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 2; });
 
     // Only one more decode fires, and it is the newest (C); B was superseded while parked.
     EXPECT_TRUE(
@@ -381,7 +384,7 @@ TEST(ArtworkFrameDoneGate, ClearIsADeliveryAndDropsParked) {
     impl->handle_stream_start(ServerArtworkStreamObject{});
 
     send_frame(*impl, 0, 'A');
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 1; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 1; });
 
     send_frame(*impl, 0, 'B');  // parks: A's delivery is still un-acked
     // Wait for the decode thread to actually park B (has_parked observed under slot_mutex)
@@ -389,11 +392,11 @@ TEST(ArtworkFrameDoneGate, ClearIsADeliveryAndDropsParked) {
     // notification and land before B is parked, in which case B would park *behind* the clear's
     // own owed ack instead of being dropped by it, which is a different (also-tested, see
     // ClearGateHoldsNextStreamFirstFrame) scenario.
-    ASSERT_TRUE(wait_slot_state(
-        *impl, [&] { return impl->drain_task->slot_buffers[0].has_parked; }, POSITIVE_TIMEOUT));
+    wait_slot_state(
+        *impl, [&] { return impl->drain_task->slot_buffers[0].has_parked; });
 
     impl->handle_stream_ring_event(ArtworkEventType::STREAM_CLEAR);
-    ASSERT_TRUE(listener.wait_for([&] { return listener.clears.size() >= 1; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.clears.size() >= 1; });
 
     // The clear itself owes an ack; acking it must NOT resurrect the dropped, parked B.
     impl->frame_done(0);
@@ -403,7 +406,7 @@ TEST(ArtworkFrameDoneGate, ClearIsADeliveryAndDropsParked) {
     // A fresh stream's frame decodes normally: the gate is IDLE again.
     impl->handle_stream_start(ServerArtworkStreamObject{});
     send_frame(*impl, 0, 'C');
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 2; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 2; });
     EXPECT_EQ(listener.decode_marker_at(1), 'C');
 }
 
@@ -415,13 +418,12 @@ TEST(ArtworkFrameDoneGate, ClearGateHoldsNextStreamFirstFrame) {
     impl->handle_stream_start(ServerArtworkStreamObject{});
 
     send_frame(*impl, 0, 'A');
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 1; }, POSITIVE_TIMEOUT));
-    ASSERT_TRUE(
-        poll_drain_until(*impl, [&] { return listener.display_count() >= 1; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 1; });
+    poll_drain_until(*impl, [&] { return listener.display_count() >= 1; });
 
     // stream/end fires the clear callback but the clear's own ack is still outstanding.
     impl->handle_stream_ring_event(ArtworkEventType::STREAM_END);
-    ASSERT_TRUE(listener.wait_for([&] { return listener.clears.size() >= 1; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.clears.size() >= 1; });
 
     impl->handle_stream_start(ServerArtworkStreamObject{});
     send_frame(*impl, 0, 'B');
@@ -429,7 +431,7 @@ TEST(ArtworkFrameDoneGate, ClearGateHoldsNextStreamFirstFrame) {
         listener.never_within([&] { return listener.decodes.size() >= 2; }, NEGATIVE_WINDOW));
 
     impl->frame_done(0);
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 2; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 2; });
     EXPECT_EQ(listener.decode_marker_at(1), 'B');
 }
 
@@ -447,8 +449,7 @@ TEST(ArtworkChannelClear, EmptyPayloadFiresClearWithoutDecoding) {
 
     send_clear(*impl, 0);
 
-    ASSERT_TRUE(
-        poll_drain_until(*impl, [&] { return listener.clear_count() >= 1; }, POSITIVE_TIMEOUT));
+    poll_drain_until(*impl, [&] { return listener.clear_count() >= 1; });
     EXPECT_EQ(listener.clear_at(0), 0);
     EXPECT_TRUE(
         poll_drain_never(*impl, [&] { return listener.clear_count() >= 2; }, NEGATIVE_WINDOW));
@@ -467,16 +468,14 @@ TEST(ArtworkChannelClear, ClearAfterDisplayedFrameFiresAgain) {
 
     // The album's first track: artwork arrives and is displayed.
     send_frame(*impl, 0, 'A');
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 1; }, POSITIVE_TIMEOUT));
-    ASSERT_TRUE(
-        poll_drain_until(*impl, [&] { return listener.display_count() >= 1; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 1; });
+    poll_drain_until(*impl, [&] { return listener.display_count() >= 1; });
 
     // A later track with no artwork of its own: the clear must reach the listener while the
     // stream is still running, so a consumer can tell "no artwork for this item" apart from
     // "artwork unchanged, nothing sent".
     send_clear(*impl, 0);
-    ASSERT_TRUE(
-        poll_drain_until(*impl, [&] { return listener.clear_count() >= 1; }, POSITIVE_TIMEOUT));
+    poll_drain_until(*impl, [&] { return listener.clear_count() >= 1; });
     EXPECT_TRUE(
         poll_drain_never(*impl, [&] { return listener.clear_count() >= 2; }, NEGATIVE_WINDOW));
     EXPECT_EQ(listener.display_count(), 1U);
@@ -493,15 +492,14 @@ TEST(ArtworkChannelClear, ClearOnlyAffectsItsOwnSlot) {
     // Slot 1 (ungated) is cleared; slot 0 (gated) must be left alone entirely -- a stream-level
     // clear fires for every configured slot, a per-channel clear for exactly one.
     send_clear(*impl, 1);
-    ASSERT_TRUE(
-        poll_drain_until(*impl, [&] { return listener.clear_count() >= 1; }, POSITIVE_TIMEOUT));
+    poll_drain_until(*impl, [&] { return listener.clear_count() >= 1; });
     EXPECT_EQ(listener.clear_at(0), 1);
     EXPECT_TRUE(
         poll_drain_never(*impl, [&] { return listener.clear_count() >= 2; }, NEGATIVE_WINDOW));
 
     // Slot 0's gate was never armed by slot 1's clear, so its frame decodes without any ack.
     send_frame(*impl, 0, 'A');
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 1; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 1; });
     EXPECT_EQ(listener.decode_marker_at(0), 'A');
 }
 
@@ -513,22 +511,20 @@ TEST(ArtworkChannelClear, GatedClearParksBehindUnackedFrame) {
     impl->handle_stream_start(ServerArtworkStreamObject{});
 
     send_frame(*impl, 0, 'A');
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 1; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 1; });
 
     // A's delivery is un-acked, so the clear parks rather than overtaking it: the consumer is
     // mid-presentation of A and its buffers must not be disturbed.
     send_clear(*impl, 0);
-    ASSERT_TRUE(wait_slot_state(
-        *impl, [&] { return impl->drain_task->slot_buffers[0].has_parked; }, POSITIVE_TIMEOUT));
+    wait_slot_state(
+        *impl, [&] { return impl->drain_task->slot_buffers[0].has_parked; });
     EXPECT_TRUE(
         poll_drain_never(*impl, [&] { return listener.clear_count() >= 1; }, NEGATIVE_WINDOW));
 
     // A's own display still fires; only then does acking it release the parked clear.
-    ASSERT_TRUE(
-        poll_drain_until(*impl, [&] { return listener.display_count() >= 1; }, POSITIVE_TIMEOUT));
+    poll_drain_until(*impl, [&] { return listener.display_count() >= 1; });
     impl->frame_done(0);
-    ASSERT_TRUE(
-        poll_drain_until(*impl, [&] { return listener.clear_count() >= 1; }, POSITIVE_TIMEOUT));
+    poll_drain_until(*impl, [&] { return listener.clear_count() >= 1; });
     EXPECT_EQ(listener.clear_at(0), 0);
     EXPECT_TRUE(
         poll_drain_never(*impl, [&] { return listener.clear_count() >= 2; }, NEGATIVE_WINDOW));
@@ -542,8 +538,7 @@ TEST(ArtworkChannelClear, GatedClearOwesExactlyOneAck) {
     impl->handle_stream_start(ServerArtworkStreamObject{});
 
     send_clear(*impl, 0);
-    ASSERT_TRUE(
-        poll_drain_until(*impl, [&] { return listener.clear_count() >= 1; }, POSITIVE_TIMEOUT));
+    poll_drain_until(*impl, [&] { return listener.clear_count() >= 1; });
     EXPECT_TRUE(
         poll_drain_never(*impl, [&] { return listener.clear_count() >= 2; }, NEGATIVE_WINDOW));
 
@@ -553,7 +548,7 @@ TEST(ArtworkChannelClear, GatedClearOwesExactlyOneAck) {
         listener.never_within([&] { return !listener.decodes.empty(); }, NEGATIVE_WINDOW));
 
     impl->frame_done(0);
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 1; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 1; });
     EXPECT_EQ(listener.decode_marker_at(0), 'A');
 }
 
@@ -565,7 +560,7 @@ TEST(ArtworkChannelClear, GatedClearSupersedesParkedClear) {
     impl->handle_stream_start(ServerArtworkStreamObject{});
 
     send_frame(*impl, 0, 'A');
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 1; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 1; });
 
     // Two clears arrive back to back while A is un-acked. Both park, and the second must overwrite
     // the first (latest-wins) rather than queue behind it, so the consumer is asked to clear once
@@ -573,18 +568,15 @@ TEST(ArtworkChannelClear, GatedClearSupersedesParkedClear) {
     // notification to carry the second clear's timestamp is what keeps this deterministic, since
     // has_parked is already true from the first.
     send_clear(*impl, 0, /*timestamp=*/1);
-    ASSERT_TRUE(wait_slot_state(
-        *impl, [&] { return impl->drain_task->slot_buffers[0].has_parked; }, POSITIVE_TIMEOUT));
+    wait_slot_state(
+        *impl, [&] { return impl->drain_task->slot_buffers[0].has_parked; });
     send_clear(*impl, 0, /*timestamp=*/2);
-    ASSERT_TRUE(wait_slot_state(
-        *impl, [&] { return impl->drain_task->slot_buffers[0].parked.timestamp == 2; },
-        POSITIVE_TIMEOUT));
+    wait_slot_state(
+        *impl, [&] { return impl->drain_task->slot_buffers[0].parked.timestamp == 2; });
 
-    ASSERT_TRUE(
-        poll_drain_until(*impl, [&] { return listener.display_count() >= 1; }, POSITIVE_TIMEOUT));
+    poll_drain_until(*impl, [&] { return listener.display_count() >= 1; });
     impl->frame_done(0);
-    ASSERT_TRUE(
-        poll_drain_until(*impl, [&] { return listener.clear_count() >= 1; }, POSITIVE_TIMEOUT));
+    poll_drain_until(*impl, [&] { return listener.clear_count() >= 1; });
     EXPECT_TRUE(
         poll_drain_never(*impl, [&] { return listener.clear_count() >= 2; }, NEGATIVE_WINDOW));
 }
@@ -598,14 +590,13 @@ TEST(ArtworkChannelClear, StreamEndOnTopOfUnackedChannelClearFiresAgain) {
 
     // A per-channel clear is delivered and left un-acked, e.g. the consumer is running a fade-out.
     send_clear(*impl, 0);
-    ASSERT_TRUE(
-        poll_drain_until(*impl, [&] { return listener.clear_count() >= 1; }, POSITIVE_TIMEOUT));
+    poll_drain_until(*impl, [&] { return listener.clear_count() >= 1; });
 
     // The queue then ends. stream/end is a distinct lifecycle event, so it fires on_image_clear()
     // again rather than being swallowed because a clear is already outstanding -- it supersedes
     // that clear the same way it supersedes an un-acked frame.
     impl->handle_stream_ring_event(ArtworkEventType::STREAM_END);
-    ASSERT_TRUE(listener.wait_for([&] { return listener.clears.size() >= 2; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.clears.size() >= 2; });
 
     // Superseded, not stacked: exactly one ack is owed for the two clears, so a single frame_done()
     // releases the gate for the next stream's first frame.
@@ -614,7 +605,7 @@ TEST(ArtworkChannelClear, StreamEndOnTopOfUnackedChannelClearFiresAgain) {
     EXPECT_TRUE(listener.never_within([&] { return !listener.decodes.empty(); }, NEGATIVE_WINDOW));
 
     impl->frame_done(0);
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 1; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 1; });
     EXPECT_EQ(listener.decode_marker_at(0), 'A');
 }
 
@@ -650,7 +641,7 @@ TEST(ArtworkFrameDoneGate, FrameDoneNoOpWhenIdle) {
     impl->frame_done(99);
 
     send_frame(*impl, 0, 'A');
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 1; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 1; });
     EXPECT_EQ(listener.decode_marker_at(0), 'A');
 }
 
@@ -666,7 +657,7 @@ TEST(ArtworkFrameDoneGate, RestartReleasesUndisplayedDecode) {
     impl->handle_stream_start(ServerArtworkStreamObject{});
 
     send_frame(*impl, 0, 'A');
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 1; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 1; });
     // Deliberately never call drain_events() here: A's display must never fire.
 
     impl->handle_stream_start(ServerArtworkStreamObject{});  // restart
@@ -680,7 +671,7 @@ TEST(ArtworkFrameDoneGate, RestartReleasesUndisplayedDecode) {
 
     // The DECODE_DELIVERED gate was auto-released by the restart: B decodes without any ack.
     send_frame(*impl, 0, 'B');
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 2; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 2; });
     EXPECT_EQ(listener.decode_marker_at(1), 'B');
 }
 
@@ -692,9 +683,8 @@ TEST(ArtworkFrameDoneGate, RestartKeepsPresentedGate) {
     impl->handle_stream_start(ServerArtworkStreamObject{});
 
     send_frame(*impl, 0, 'A');
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 1; }, POSITIVE_TIMEOUT));
-    ASSERT_TRUE(
-        poll_drain_until(*impl, [&] { return listener.display_count() >= 1; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 1; });
+    poll_drain_until(*impl, [&] { return listener.display_count() >= 1; });
 
     impl->handle_stream_start(ServerArtworkStreamObject{});  // restart; PRESENTED stays armed
 
@@ -703,7 +693,7 @@ TEST(ArtworkFrameDoneGate, RestartKeepsPresentedGate) {
         listener.never_within([&] { return listener.decodes.size() >= 2; }, NEGATIVE_WINDOW));
 
     impl->frame_done(0);
-    ASSERT_TRUE(listener.wait_for([&] { return listener.decodes.size() >= 2; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return listener.decodes.size() >= 2; });
     EXPECT_EQ(listener.decode_marker_at(1), 'B');
 }
 
@@ -726,9 +716,8 @@ TEST(ArtworkFrameDoneGate, FrameDoneReentrantFromDisplay) {
     // display without any external frame_done() call and without deadlock.
     send_frame(*impl, 0, 'B');
 
-    ASSERT_TRUE(poll_drain_until(
-        *impl, [&] { return listener.decode_count() >= 2 && listener.display_count() >= 2; },
-        POSITIVE_TIMEOUT));
+    poll_drain_until(
+        *impl, [&] { return listener.decode_count() >= 2 && listener.display_count() >= 2; });
 
     EXPECT_TRUE(listener.has_decoded_marker(0, 'A'));
     EXPECT_TRUE(listener.has_decoded_marker(0, 'B'));
@@ -746,7 +735,7 @@ TEST(ArtworkFrameDoneGate, UngatedSlotUnaffectedBesideGatedSlot) {
     ASSERT_TRUE(impl->start());
     impl->handle_stream_start(ServerArtworkStreamObject{});
 
-    // wait_for()'s predicate runs under RecordingListener::mutex (via condition_variable's
+    // wait_until()'s predicate runs under RecordingListener::mutex (via condition_variable's
     // predicate overload), so it must touch listener.decodes directly rather than going through
     // a helper like decode_count_for_slot() that re-locks the same non-recursive mutex.
     auto count_for_slot = [&](uint8_t slot) {
@@ -761,7 +750,7 @@ TEST(ArtworkFrameDoneGate, UngatedSlotUnaffectedBesideGatedSlot) {
 
     // Gate slot 0 with an un-acked delivery.
     send_frame(*impl, 0, 'A');
-    ASSERT_TRUE(listener.wait_for([&] { return count_for_slot(0) >= 1; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return count_for_slot(0) >= 1; });
 
     // Slot 1 keeps decoding every frame freely, ungated by slot 0's outstanding delivery. Each
     // send waits for its own decode before the next is sent: slot 1 is double-buffered like any
@@ -770,11 +759,11 @@ TEST(ArtworkFrameDoneGate, UngatedSlotUnaffectedBesideGatedSlot) {
     // real (and separately-covered) property of the double-buffering scheme, not of the ack
     // gate this test is about, so it must not be exercised here.
     send_frame(*impl, 1, 'X');
-    ASSERT_TRUE(listener.wait_for([&] { return count_for_slot(1) >= 1; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return count_for_slot(1) >= 1; });
     send_frame(*impl, 1, 'Y');
-    ASSERT_TRUE(listener.wait_for([&] { return count_for_slot(1) >= 2; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return count_for_slot(1) >= 2; });
     send_frame(*impl, 1, 'Z');
-    ASSERT_TRUE(listener.wait_for([&] { return count_for_slot(1) >= 3; }, POSITIVE_TIMEOUT));
+    listener.wait_until([&] { return count_for_slot(1) >= 3; });
 
     EXPECT_EQ(listener.decode_count_for_slot(0), 1U);
 }

--- a/tests/test_connection_lifecycle.cpp
+++ b/tests/test_connection_lifecycle.cpp
@@ -94,23 +94,27 @@ private:
     uint32_t hash_;
 };
 
-/// Pumps client.loop() (like a platform main loop would) until the predicate returns true or the
-/// timeout elapses. Returns true if the predicate was satisfied.
-bool pump_until(SendspinClient& client, const std::function<bool()>& pred, int timeout_ms) {
-    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
-    while (std::chrono::steady_clock::now() < deadline) {
+
+// Pumps client.loop() until pred() is true. No timeout: a regression hangs here and the CTest
+// TIMEOUT reports it.
+void pump_until(SendspinClient& client, const std::function<bool()>& pred) {
+    for (;;) {
         client.loop();
         if (pred()) {
-            return true;
+            return;
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(2));
     }
-    return false;
 }
 
+// Pumps client.loop() for a fixed window. Only for spacing events or "must not happen" checks:
+// a window that is too short can miss a regression, never fail a correct run.
 void pump_for(SendspinClient& client, int duration_ms) {
-    pump_until(
-        client, [] { return false; }, duration_ms);
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(duration_ms);
+    while (std::chrono::steady_clock::now() < deadline) {
+        client.loop();
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
 }
 
 int connect_loopback(uint16_t port) {
@@ -347,8 +351,7 @@ TEST(ConnectionLifecycle, JunkProbeDoesNotBlockRealServer) {
     SendspinClient client(make_config(PROBE_TEST_PORT));
     client.set_network_provider(&network);
     ASSERT_TRUE(client.start_server());
-    // The WS server starts synchronously on the first loop() once the network reports ready.
-    pump_for(client, 50);
+    client.loop();  // First tick binds the WS server
 
     // Hold a raw TCP connection open without ever speaking WebSocket.
     int probe_fd = connect_loopback(PROBE_TEST_PORT);
@@ -360,8 +363,7 @@ TEST(ConnectionLifecycle, JunkProbeDoesNotBlockRealServer) {
     // A real server connects while the probe is held: it must establish promptly, not after the
     // probe's deadline.
     FakeServer real_server(server_url(PROBE_TEST_PORT), "server-a");
-    EXPECT_TRUE(pump_until(
-        client, [&] { return client.is_connected(); }, 4000));
+    pump_until(client, [&] { return client.is_connected(); });
     auto info = client.get_server_information();
     ASSERT_TRUE(info.has_value());
     EXPECT_EQ(info->server_id, "server-a");
@@ -369,8 +371,7 @@ TEST(ConnectionLifecycle, JunkProbeDoesNotBlockRealServer) {
     // The probe never completes a WebSocket handshake, so the transport layer closes it without
     // it ever reaching the manager (host: IXWebSocket's 3 s server-side handshake timeout; on
     // ESP the ws_server tick would reap it at 5 s). Budget covers either bound plus margin.
-    EXPECT_TRUE(pump_until(
-        client, [&] { return socket_closed(probe_fd); }, 6500));
+    pump_until(client, [&] { return socket_closed(probe_fd); });
     ::close(probe_fd);
 
     // The established connection must have been untouched by the probe reap.
@@ -410,17 +411,13 @@ TEST(ConnectionLifecycle, SlowOutboundSurvivesUpgradeTier) {
     SendspinClient client(make_config(OUTBOUND_TEST_PORT));
     client.set_network_provider(&network);
     ASSERT_TRUE(client.start_server());
-    pump_for(client, 50);
+    client.loop();  // First tick binds the WS server
 
     client.connect_to(server_url(PROXY_LISTEN_PORT));
 
-    // Nothing can establish before the proxy forwards the upgrade at ~8 s; the connection must
-    // still be alive past the 5 s mark, well beyond any inbound-side upgrade deadline.
-    EXPECT_FALSE(pump_until(
-        client, [&] { return client.is_connected(); }, 6500));
-
-    EXPECT_TRUE(pump_until(
-        client, [&] { return client.is_connected(); }, 7500));
+    // The proxy holds the upgrade for 8 s, past any inbound-side upgrade deadline; the outbound
+    // tier must ride that out and still establish.
+    pump_until(client, [&] { return client.is_connected(); });
     auto info = client.get_server_information();
     ASSERT_TRUE(info.has_value());
     EXPECT_EQ(info->server_id, "server-slow");
@@ -453,19 +450,17 @@ TEST(ConnectionLifecycle, InFlightOutboundDoesNotBlockInboundAdmission) {
     SendspinClient client(make_config(ADMIT_TEST_PORT));
     client.set_network_provider(&network);
     ASSERT_TRUE(client.start_server());
-    pump_for(client, 50);
+    client.loop();  // First tick binds the WS server
 
     client.connect_to(server_url(STALL_LISTEN_PORT));
 
     // A mute inbound peer occupies one inbound slot past TCP_OPEN.
     FakeServer mute(server_url(ADMIT_TEST_PORT), "mute", {.answer_hello = false});
-    ASSERT_TRUE(pump_until(
-        client, [&] { return mute.got_client_hello(); }, 3000));
+    pump_until(client, [&] { return mute.got_client_hello(); });
 
     // The real server takes the second inbound slot; the stalled outbound must not consume it.
     FakeServer real_server(server_url(ADMIT_TEST_PORT), "server-real");
-    EXPECT_TRUE(pump_until(
-        client, [&] { return client.is_connected(); }, 4000));
+    pump_until(client, [&] { return client.is_connected(); });
     auto info = client.get_server_information();
     ASSERT_TRUE(info.has_value());
     EXPECT_EQ(info->server_id, "server-real");
@@ -485,11 +480,10 @@ TEST(ConnectionLifecycle, EarlyServerHelloDoesNotWedge) {
     SendspinClient client(make_config(EARLY_HELLO_TEST_PORT));
     client.set_network_provider(&network);
     ASSERT_TRUE(client.start_server());
-    pump_for(client, 50);
+    client.loop();  // First tick binds the WS server
 
     FakeServer eager(server_url(EARLY_HELLO_TEST_PORT), "server-eager", {.hello_on_open = true});
-    EXPECT_TRUE(pump_until(
-        client, [&] { return client.is_connected(); }, 4000));
+    pump_until(client, [&] { return client.is_connected(); });
     auto info = client.get_server_information();
     ASSERT_TRUE(info.has_value());
     EXPECT_EQ(info->server_id, "server-eager");
@@ -507,33 +501,26 @@ TEST(ConnectionLifecycle, TwoServerRaceResolvedByPreference) {
     client.set_network_provider(&network);
     client.set_persistence_provider(&persistence);
     ASSERT_TRUE(client.start_server());
-    pump_for(client, 50);
+    client.loop();  // First tick binds the WS server
 
     // server-a establishes and is promoted into the empty slot first...
     FakeServer server_a(server_url(RACE_TEST_PORT), "server-a");
-    ASSERT_TRUE(pump_until(
-        client,
-        [&] {
-            auto info = client.get_server_information();
-            return info.has_value() && info->server_id == "server-a";
-        },
-        3000));
+    pump_until(client, [&] {
+        auto info = client.get_server_information();
+        return info.has_value() && info->server_id == "server-a";
+    });
 
     // ...then server-b establishes against the incumbent. Both sides of the comparison are
     // established; the last-played preference (server-b) must win the handoff, and the later
     // arrival must not be evicted for finishing second.
     FakeServer server_b(server_url(RACE_TEST_PORT), "server-b");
-    EXPECT_TRUE(pump_until(
-        client,
-        [&] {
-            auto info = client.get_server_information();
-            return info.has_value() && info->server_id == "server-b";
-        },
-        3000));
+    pump_until(client, [&] {
+        auto info = client.get_server_information();
+        return info.has_value() && info->server_id == "server-b";
+    });
 
     // The displaced incumbent is released with a goodbye, not left dangling.
-    EXPECT_TRUE(pump_until(
-        client, [&] { return server_a.closed(); }, 3000));
+    pump_until(client, [&] { return server_a.closed(); });
     EXPECT_FALSE(server_b.closed());
     EXPECT_TRUE(client.is_connected());
 }
@@ -545,7 +532,7 @@ TEST(ConnectionLifecycle, HeldProbesNeverOccupyNursery) {
     SendspinClient client(make_config(EVICT_TEST_PORT));
     client.set_network_provider(&network);
     ASSERT_TRUE(client.start_server());
-    pump_for(client, 50);
+    client.loop();  // First tick binds the WS server
 
     // Two held raw probes, enough to fill every nursery slot if they were admitted at accept.
     int probe1 = connect_loopback(EVICT_TEST_PORT);
@@ -558,15 +545,13 @@ TEST(ConnectionLifecycle, HeldProbesNeverOccupyNursery) {
     // The real server must establish promptly: the probes hold no nursery slots, so nothing
     // needs evicting and nothing is rejected.
     FakeServer real_server(server_url(EVICT_TEST_PORT), "server-real");
-    EXPECT_TRUE(pump_until(
-        client, [&] { return client.is_connected(); }, 4000));
+    pump_until(client, [&] { return client.is_connected(); });
     auto info = client.get_server_information();
     ASSERT_TRUE(info.has_value());
     EXPECT_EQ(info->server_id, "server-real");
 
     // The transport layer closes the probes on its own (host: IX 3 s handshake timeout).
-    EXPECT_TRUE(pump_until(
-        client, [&] { return socket_closed(probe1) && socket_closed(probe2); }, 6500));
+    pump_until(client, [&] { return socket_closed(probe1) && socket_closed(probe2); });
     EXPECT_TRUE(client.is_connected());
 
     ::close(probe1);
@@ -581,18 +566,16 @@ TEST(ConnectionLifecycle, FullNurseryOfLivePeersRejectsNewcomer) {
     SendspinClient client(make_config(REJECT_TEST_PORT));
     client.set_network_provider(&network);
     ASSERT_TRUE(client.start_server());
-    pump_for(client, 50);
+    client.loop();  // First tick binds the WS server
 
     // Two mute peers: they upgrade and receive client/hello but never answer it, occupying both
     // nursery slots past TCP_OPEN until the establish deadline.
     FakeServer mute_a(server_url(REJECT_TEST_PORT), "mute-a", {.answer_hello = false});
     FakeServer mute_b(server_url(REJECT_TEST_PORT), "mute-b", {.answer_hello = false});
-    ASSERT_TRUE(pump_until(
-        client, [&] { return mute_a.got_client_hello() && mute_b.got_client_hello(); }, 3000));
+    pump_until(client, [&] { return mute_a.got_client_hello() && mute_b.got_client_hello(); });
 
     FakeServer late(server_url(REJECT_TEST_PORT), "server-late");
-    EXPECT_TRUE(pump_until(
-        client, [&] { return late.closed(); }, 3000));
+    pump_until(client, [&] { return late.closed(); });
     EXPECT_TRUE(late.got_goodbye());
     EXPECT_FALSE(client.is_connected());
     EXPECT_FALSE(mute_a.closed());


### PR DESCRIPTION
## What changed

- **Tests no longer make elapsed time a pass/fail condition.** The artwork-role and connection-lifecycle tests that asserted `elapsed < x` or `elapsed >= y` now prove a blocked call by waiting with no timeout, by asserting on a value only the correct path can produce, or by relying on a structural failure. Fixed sleeps remain only where a late thread yields a false pass, never a false failure.
- **In-process hang watchdog** in `tests/main.cpp`: any test still running after 55 s aborts the binary with the test name and a stack, ahead of the 60 s CTest `TIMEOUT` backstop. The test target now builds behind this entry point instead of `gtest_main`, with `-rdynamic` on Linux so the backtrace names frames.
- **`test-standards` skill** gains the no-wall-clock rule and is restructured and trimmed. Its internal contradictions are resolved: mutation runs are explicitly temporary edits reverted via git and the report ends with the `git status` proving it; the reasoning-versus-running rule is reworded; new rules cover assertion messages, test cost, the ASan/UBSan-only CI bar, and production asserts; the report format gains a named-gaps section.
- **`docs/conventions.md` gets a Testing section** so the skill cites a normative source the way the sibling skills do, and `tests/README.md` is brought up to date with the watchdog entry point and all nine test files.

## Why

Elapsed-time bounds are guesses about machine speed and were the only flaky-by-design assertions left in the suite. Removing them requires a different hang guard, hence the watchdog. The skill changes came out of a holistic review of the checklist against the tree.

## Reviewer notes

- Suite passes under `-DENABLE_SANITIZERS=ON`.
- Test-file docs in `tests/README.md` were checked against each file's test names.