### PR TITLE
Add a ThreadSanitizer build configuration and CI job

### DIFF
--- a/.claude/skills/test-standards/SKILL.md
+++ b/.claude/skills/test-standards/SKILL.md
@@ -72,9 +72,11 @@ during this review.
   build passes, and the report states the command and the result.
 - Running a mutant: apply the edit, rebuild, run, then revert with
   `git checkout -- <file>` and confirm `git status` shows the tree as it was
-  before the review. Build under ASan/UBSan (`-DENABLE_SANITIZERS=ON`, the
-  CI configuration). A stale build directory has passed mutations here
-  before, so check that the build output shows the mutated object
+  before the review. Build under ASan/UBSan (`-DENABLE_SANITIZERS=ON`); a
+  mutant that changes thread interaction (a dropped lock, a reordered store,
+  a removed join) is built under ThreadSanitizer (`-DENABLE_TSAN=ON`) instead,
+  since ASan does not see it. A stale build directory has passed mutations
+  here before, so check that the build output shows the mutated object
   recompiling.
 - A surviving mutation is a defect of the test only when it breaks a contract
   the test claims to cover; otherwise it is a gap. A surviving mutation and
@@ -138,9 +140,11 @@ during this review.
 - Concurrency tests observe real effects: never assert on a counter the
   thread under test would have been the one to advance; use the code's own
   observable outputs or event flags.
-- CI runs the suite under ASan/UBSan only. A concurrency finding backed by a
-  local ThreadSanitizer run says so and states the command; the absence of a
-  TSan run is not itself a finding.
+- CI runs the suite under ASan/UBSan and, in a separate job, ThreadSanitizer
+  (`-DENABLE_TSAN=ON`; the two cannot be combined). A concurrency finding, or
+  a certification that a threaded test is adequate, is backed by a TSan run
+  and states the command. A race TSan reports is real until shown otherwise;
+  the review never proposes a suppressions file.
 
 ## No wall-clock assertions
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,39 @@ jobs:
       - name: Run tests
         run: ctest --test-dir build-tests --output-on-failure
 
+  test-tsan:
+    name: Unit tests (ThreadSanitizer)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libavahi-compat-libdnssd-dev
+
+      - name: Configure CMake
+        # ENABLE_TSAN instead of ENABLE_SANITIZERS: the two sanitizers cannot be combined.
+        run: cmake -B build-tsan -DSENDSPIN_BUILD_TESTS=ON -DENABLE_TSAN=ON -DBUILD_EXAMPLES=OFF .
+
+      - name: Build tests
+        run: cmake --build build-tsan --target sendspin_tests
+
+      - name: Reduce mmap randomization
+        # TSan aborts at startup with "unexpected memory mapping" under the 32-bit mmap
+        # randomization the runner kernel defaults to.
+        run: sudo sysctl vm.mmap_rnd_bits=28
+
+      - name: Run tests
+        # halt_on_error makes a detected race fail the job deterministically rather than relying
+        # on the process happening to abort afterwards.
+        env:
+          TSAN_OPTIONS: halt_on_error=1
+        run: ctest --test-dir build-tsan --output-on-failure
+
   ci:
     name: CI
-    needs: [pre-commit, lint, build, test]
+    needs: [pre-commit, lint, build, test, test-tsan]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ Core source files in `src/` have no `#ifdef ESP_PLATFORM` guards; all platform d
 - **ESP-IDF**: Used as an IDF component via `idf_component.yml`. Sources defined in `cmake/sources.cmake`.
 - **Host (CMake)**: `cmake -B build && cmake --build build`. Fetches dependencies (ArduinoJson, micro-flac, micro-opus, IXWebSocket) via FetchContent.
 - **Tests**: `cmake -B build-tests -DSENDSPIN_BUILD_TESTS=ON -DENABLE_SANITIZERS=ON -DBUILD_EXAMPLES=OFF .`, then `cmake --build build-tests --target sendspin_tests` and `ctest --test-dir build-tests --output-on-failure`.
+- **ThreadSanitizer tests**: `cmake -B build-tsan -DSENDSPIN_BUILD_TESTS=ON -DENABLE_TSAN=ON -DBUILD_EXAMPLES=OFF .`, then `cmake --build build-tsan --target sendspin_tests` and `TSAN_OPTIONS=halt_on_error=1 ctest --test-dir build-tsan --output-on-failure`. `ENABLE_TSAN` applies the thread sanitizer to every target, including the fetched dependencies, and cannot be combined with `ENABLE_SANITIZERS`.
 - **ESP dependencies**: ArduinoJson, esp_websocket_client, micro-flac, micro-opus, esp_http_server, mbedtls, pthread, esp_ringbuf
 - **Host dependencies**: ArduinoJson, micro-flac, micro-opus, IXWebSocket, pthreads
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,22 @@ else()
     # Host build options
     option(ENABLE_WERROR "Treat warnings as errors" OFF)
     option(ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
+    option(ENABLE_TSAN "Enable ThreadSanitizer (mutually exclusive with ENABLE_SANITIZERS)" OFF)
+    if(ENABLE_TSAN AND ENABLE_SANITIZERS)
+        message(FATAL_ERROR "ENABLE_TSAN and ENABLE_SANITIZERS are mutually exclusive")
+    endif()
+
+    # ThreadSanitizer is applied globally rather than per target, and before the FetchContent
+    # dependencies are declared, so IXWebSocket, GoogleTest and the codecs are instrumented too.
+    # TSan intercepts pthread calls in uninstrumented code but cannot see its std::atomic
+    # accesses, which reports the lock-free stop flags in IXWebSocket as false races.
+    if(ENABLE_TSAN)
+        string(APPEND CMAKE_C_FLAGS " -fsanitize=thread -fno-omit-frame-pointer -g")
+        string(APPEND CMAKE_CXX_FLAGS " -fsanitize=thread -fno-omit-frame-pointer -g")
+        string(APPEND CMAKE_EXE_LINKER_FLAGS " -fsanitize=thread")
+        string(APPEND CMAKE_SHARED_LINKER_FLAGS " -fsanitize=thread")
+        string(APPEND CMAKE_MODULE_LINKER_FLAGS " -fsanitize=thread")
+    endif()
 
     # Examples build by default for standalone development, but not when sendspin is pulled into
     # a larger project via add_subdirectory (where the consumer doesn't want the example deps,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,15 @@ cmake --build build-tests --target sendspin_tests
 ctest --test-dir build-tests --output-on-failure
 ```
 
+CI also runs the suite under ThreadSanitizer in a separate job. TSan cannot be
+combined with ASan/UBSan, so it is a second build directory:
+
+```bash
+cmake -B build-tsan -DSENDSPIN_BUILD_TESTS=ON -DENABLE_TSAN=ON -DBUILD_EXAMPLES=OFF .
+cmake --build build-tsan --target sendspin_tests
+TSAN_OPTIONS=halt_on_error=1 ctest --test-dir build-tsan --output-on-failure
+```
+
 On ESP-IDF the library is consumed as a component via `idf_component.yml`; the
 source lists live in `cmake/sources.cmake`.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,7 +9,7 @@ static library and run on macOS/Linux with [GoogleTest](https://github.com/googl
 From the repository root:
 
 ```bash
-cmake -B build-tests -DSENDSPIN_BUILD_TESTS=ON .
+cmake -B build-tests -DSENDSPIN_BUILD_TESTS=ON -DBUILD_EXAMPLES=OFF .
 cmake --build build-tests --target sendspin_tests
 ctest --test-dir build-tests --output-on-failure
 ```
@@ -27,7 +27,7 @@ is what CI runs, and it is the recommended way to exercise the pointer-heavy cod
 formatter, JSON parsing):
 
 ```bash
-cmake -B build-tests-asan -DSENDSPIN_BUILD_TESTS=ON -DENABLE_SANITIZERS=ON .
+cmake -B build-tests-asan -DSENDSPIN_BUILD_TESTS=ON -DENABLE_SANITIZERS=ON -DBUILD_EXAMPLES=OFF .
 cmake --build build-tests-asan --target sendspin_tests
 ctest --test-dir build-tests-asan --output-on-failure
 ```
@@ -39,7 +39,7 @@ flag applies to every target, including the fetched dependencies, because TSan c
 in uninstrumented code and reports IXWebSocket's stop flags as false races otherwise:
 
 ```bash
-cmake -B build-tsan -DSENDSPIN_BUILD_TESTS=ON -DENABLE_TSAN=ON .
+cmake -B build-tsan -DSENDSPIN_BUILD_TESTS=ON -DENABLE_TSAN=ON -DBUILD_EXAMPLES=OFF .
 cmake --build build-tsan --target sendspin_tests
 TSAN_OPTIONS=halt_on_error=1 ctest --test-dir build-tsan --output-on-failure
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -32,6 +32,18 @@ cmake --build build-tests-asan --target sendspin_tests
 ctest --test-dir build-tests-asan --output-on-failure
 ```
 
+`-DENABLE_TSAN=ON` builds with ThreadSanitizer instead. CI runs this as a separate job because
+TSan cannot be combined with ASan/UBSan. It is the configuration to reach for on the threaded code
+(the sync task, the connection threads, the inbox handoffs) the way ASan is for the parsers. The
+flag applies to every target, including the fetched dependencies, because TSan cannot see atomics
+in uninstrumented code and reports IXWebSocket's stop flags as false races otherwise:
+
+```bash
+cmake -B build-tsan -DSENDSPIN_BUILD_TESTS=ON -DENABLE_TSAN=ON .
+cmake --build build-tsan --target sendspin_tests
+TSAN_OPTIONS=halt_on_error=1 ctest --test-dir build-tsan --output-on-failure
+```
+
 ## Layout
 
 `main.cpp` is the entry point. It registers a hang watchdog that aborts the binary with the

--- a/tests/test_artwork_role.cpp
+++ b/tests/test_artwork_role.cpp
@@ -47,7 +47,8 @@ void put_be64(std::vector<uint8_t>& out, int64_t val) {
 constexpr auto NEGATIVE_WINDOW = std::chrono::milliseconds(300);
 
 // Records every callback fired by an ArtworkRole::Impl under test, guarded by its own mutex so
-// the test thread can safely poll state produced on the decode thread and the main thread. If
+// the test thread can safely poll state produced on the decode thread and the main thread.
+// Every test declares it before the Impl so it outlives the drain thread, which ~Impl joins. If
 // frame_done_on_display is set, on_image_display() immediately (and reentrantly) calls
 // frame_done() on the Impl this listener was bound to, exercising the reentrant-ack path.
 class RecordingListener : public ArtworkRoleListener {
@@ -283,8 +284,8 @@ void wait_slot_state(ArtworkRole::Impl& impl, Pred pred) {
 // ============================================================================
 
 TEST(ArtworkFrameDoneGate, DefaultUngatedUnchanged) {
-    auto impl = make_impl(make_single_slot_config(false));
     RecordingListener listener;
+    auto impl = make_impl(make_single_slot_config(false));
     impl->listener = &listener;
     ASSERT_TRUE(impl->start());
     impl->handle_stream_start(ServerArtworkStreamObject{});
@@ -303,8 +304,8 @@ TEST(ArtworkFrameDoneGate, DefaultUngatedUnchanged) {
 // ============================================================================
 
 TEST(ArtworkFrameDoneGate, GateHoldsSecondFrame) {
-    auto impl = make_impl(make_single_slot_config(true));
     RecordingListener listener;
+    auto impl = make_impl(make_single_slot_config(true));
     impl->listener = &listener;
     ASSERT_TRUE(impl->start());
     impl->handle_stream_start(ServerArtworkStreamObject{});
@@ -323,8 +324,8 @@ TEST(ArtworkFrameDoneGate, GateHoldsSecondFrame) {
 }
 
 TEST(ArtworkFrameDoneGate, GateHoldsThroughDisplay) {
-    auto impl = make_impl(make_single_slot_config(true));
     RecordingListener listener;
+    auto impl = make_impl(make_single_slot_config(true));
     impl->listener = &listener;
     ASSERT_TRUE(impl->start());
     impl->handle_stream_start(ServerArtworkStreamObject{});
@@ -345,8 +346,8 @@ TEST(ArtworkFrameDoneGate, GateHoldsThroughDisplay) {
 }
 
 TEST(ArtworkFrameDoneGate, SupersedeKeepsNewestParked) {
-    auto impl = make_impl(make_single_slot_config(true));
     RecordingListener listener;
+    auto impl = make_impl(make_single_slot_config(true));
     impl->listener = &listener;
     ASSERT_TRUE(impl->start());
     impl->handle_stream_start(ServerArtworkStreamObject{});
@@ -377,8 +378,8 @@ TEST(ArtworkFrameDoneGate, SupersedeKeepsNewestParked) {
 // ============================================================================
 
 TEST(ArtworkFrameDoneGate, ClearIsADeliveryAndDropsParked) {
-    auto impl = make_impl(make_single_slot_config(true));
     RecordingListener listener;
+    auto impl = make_impl(make_single_slot_config(true));
     impl->listener = &listener;
     ASSERT_TRUE(impl->start());
     impl->handle_stream_start(ServerArtworkStreamObject{});
@@ -411,8 +412,8 @@ TEST(ArtworkFrameDoneGate, ClearIsADeliveryAndDropsParked) {
 }
 
 TEST(ArtworkFrameDoneGate, ClearGateHoldsNextStreamFirstFrame) {
-    auto impl = make_impl(make_single_slot_config(true));
     RecordingListener listener;
+    auto impl = make_impl(make_single_slot_config(true));
     impl->listener = &listener;
     ASSERT_TRUE(impl->start());
     impl->handle_stream_start(ServerArtworkStreamObject{});
@@ -441,8 +442,8 @@ TEST(ArtworkFrameDoneGate, ClearGateHoldsNextStreamFirstFrame) {
 // ============================================================================
 
 TEST(ArtworkChannelClear, EmptyPayloadFiresClearWithoutDecoding) {
-    auto impl = make_impl(make_single_slot_config(false));
     RecordingListener listener;
+    auto impl = make_impl(make_single_slot_config(false));
     impl->listener = &listener;
     ASSERT_TRUE(impl->start());
     impl->handle_stream_start(ServerArtworkStreamObject{});
@@ -460,8 +461,8 @@ TEST(ArtworkChannelClear, EmptyPayloadFiresClearWithoutDecoding) {
 }
 
 TEST(ArtworkChannelClear, ClearAfterDisplayedFrameFiresAgain) {
-    auto impl = make_impl(make_single_slot_config(false));
     RecordingListener listener;
+    auto impl = make_impl(make_single_slot_config(false));
     impl->listener = &listener;
     ASSERT_TRUE(impl->start());
     impl->handle_stream_start(ServerArtworkStreamObject{});
@@ -483,8 +484,8 @@ TEST(ArtworkChannelClear, ClearAfterDisplayedFrameFiresAgain) {
 }
 
 TEST(ArtworkChannelClear, ClearOnlyAffectsItsOwnSlot) {
-    auto impl = make_impl(make_two_slot_config());
     RecordingListener listener;
+    auto impl = make_impl(make_two_slot_config());
     impl->listener = &listener;
     ASSERT_TRUE(impl->start());
     impl->handle_stream_start(ServerArtworkStreamObject{});
@@ -504,8 +505,8 @@ TEST(ArtworkChannelClear, ClearOnlyAffectsItsOwnSlot) {
 }
 
 TEST(ArtworkChannelClear, GatedClearParksBehindUnackedFrame) {
-    auto impl = make_impl(make_single_slot_config(true));
     RecordingListener listener;
+    auto impl = make_impl(make_single_slot_config(true));
     impl->listener = &listener;
     ASSERT_TRUE(impl->start());
     impl->handle_stream_start(ServerArtworkStreamObject{});
@@ -531,8 +532,8 @@ TEST(ArtworkChannelClear, GatedClearParksBehindUnackedFrame) {
 }
 
 TEST(ArtworkChannelClear, GatedClearOwesExactlyOneAck) {
-    auto impl = make_impl(make_single_slot_config(true));
     RecordingListener listener;
+    auto impl = make_impl(make_single_slot_config(true));
     impl->listener = &listener;
     ASSERT_TRUE(impl->start());
     impl->handle_stream_start(ServerArtworkStreamObject{});
@@ -553,8 +554,8 @@ TEST(ArtworkChannelClear, GatedClearOwesExactlyOneAck) {
 }
 
 TEST(ArtworkChannelClear, GatedClearSupersedesParkedClear) {
-    auto impl = make_impl(make_single_slot_config(true));
     RecordingListener listener;
+    auto impl = make_impl(make_single_slot_config(true));
     impl->listener = &listener;
     ASSERT_TRUE(impl->start());
     impl->handle_stream_start(ServerArtworkStreamObject{});
@@ -582,8 +583,8 @@ TEST(ArtworkChannelClear, GatedClearSupersedesParkedClear) {
 }
 
 TEST(ArtworkChannelClear, StreamEndOnTopOfUnackedChannelClearFiresAgain) {
-    auto impl = make_impl(make_single_slot_config(true));
     RecordingListener listener;
+    auto impl = make_impl(make_single_slot_config(true));
     impl->listener = &listener;
     ASSERT_TRUE(impl->start());
     impl->handle_stream_start(ServerArtworkStreamObject{});
@@ -610,8 +611,8 @@ TEST(ArtworkChannelClear, StreamEndOnTopOfUnackedChannelClearFiresAgain) {
 }
 
 TEST(ArtworkChannelClear, ClearIgnoredWithoutActiveStream) {
-    auto impl = make_impl(make_single_slot_config(false));
     RecordingListener listener;
+    auto impl = make_impl(make_single_slot_config(false));
     impl->listener = &listener;
     ASSERT_TRUE(impl->start());
 
@@ -630,8 +631,8 @@ TEST(ArtworkChannelClear, ClearIgnoredWithoutActiveStream) {
 // ============================================================================
 
 TEST(ArtworkFrameDoneGate, FrameDoneNoOpWhenIdle) {
-    auto impl = make_impl(make_single_slot_config(true));
     RecordingListener listener;
+    auto impl = make_impl(make_single_slot_config(true));
     impl->listener = &listener;
     ASSERT_TRUE(impl->start());
     impl->handle_stream_start(ServerArtworkStreamObject{});
@@ -650,8 +651,8 @@ TEST(ArtworkFrameDoneGate, FrameDoneNoOpWhenIdle) {
 // ============================================================================
 
 TEST(ArtworkFrameDoneGate, RestartReleasesUndisplayedDecode) {
-    auto impl = make_impl(make_single_slot_config(true));
     RecordingListener listener;
+    auto impl = make_impl(make_single_slot_config(true));
     impl->listener = &listener;
     ASSERT_TRUE(impl->start());
     impl->handle_stream_start(ServerArtworkStreamObject{});
@@ -676,8 +677,8 @@ TEST(ArtworkFrameDoneGate, RestartReleasesUndisplayedDecode) {
 }
 
 TEST(ArtworkFrameDoneGate, RestartKeepsPresentedGate) {
-    auto impl = make_impl(make_single_slot_config(true));
     RecordingListener listener;
+    auto impl = make_impl(make_single_slot_config(true));
     impl->listener = &listener;
     ASSERT_TRUE(impl->start());
     impl->handle_stream_start(ServerArtworkStreamObject{});
@@ -702,8 +703,8 @@ TEST(ArtworkFrameDoneGate, RestartKeepsPresentedGate) {
 // ============================================================================
 
 TEST(ArtworkFrameDoneGate, FrameDoneReentrantFromDisplay) {
-    auto impl = make_impl(make_single_slot_config(true));
     RecordingListener listener;
+    auto impl = make_impl(make_single_slot_config(true));
     listener.frame_done_on_display = true;
     listener.impl = impl.get();
     impl->listener = &listener;
@@ -729,8 +730,8 @@ TEST(ArtworkFrameDoneGate, FrameDoneReentrantFromDisplay) {
 // ============================================================================
 
 TEST(ArtworkFrameDoneGate, UngatedSlotUnaffectedBesideGatedSlot) {
-    auto impl = make_impl(make_two_slot_config());
     RecordingListener listener;
+    auto impl = make_impl(make_two_slot_config());
     impl->listener = &listener;
     ASSERT_TRUE(impl->start());
     impl->handle_stream_start(ServerArtworkStreamObject{});


### PR DESCRIPTION
The host suite has only ever run under ASan/UBSan, which cannot be combined with ThreadSanitizer, so no data race in the sync task, connection threads, or inbox handoffs could show up in CI. This adds an `ENABLE_TSAN` option and a `test-tsan` job.

- `ENABLE_TSAN` CMake option, default OFF; configuring it together with `ENABLE_SANITIZERS` is a `FATAL_ERROR`.
- The flags are applied globally (`CMAKE_C_FLAGS`, `CMAKE_CXX_FLAGS`, linker flags) before the FetchContent dependencies are declared, not per target. TSan intercepts pthread calls in uninstrumented code but cannot see its atomics, and IXWebSocket signals its worker threads with `std::atomic` stop flags; a per-target build reports those as false races. This is the one deliberate departure from the shape on the `encryption-support` branch (bf0da76).
- `test-tsan` job mirrors `test` and runs with `TSAN_OPTIONS=halt_on_error=1`. It sets `vm.mmap_rnd_bits=28` first: recent runner kernels default 32-bit mmap randomization high enough that TSan aborts at startup with "unexpected memory mapping".
- The test-standards skill, CONTRIBUTING.md, tests/README.md and CLAUDE.md are updated. The skill previously said CI runs ASan/UBSan only and a missing TSan run is not a finding; that rule inverts now that the job exists.

No production code changes. `tests/CMakeLists.txt` is untouched.

## Test changes

The first CI run of `test-tsan` failed 13 of 19 artwork tests with the same report: a data race in `~RecordingListener` (`tests/test_artwork_role.cpp`), `pthread_cond_destroy` on the main thread against `pthread_cond_broadcast` from the still-running artwork drain thread.

Every artwork test declared its `RecordingListener` after the `Impl`, so the listener was destroyed first while `~Impl` was still stopping the drain thread; the drain thread could call `notify_all()` on a condition variable being destroyed. Commit 85f6bc0 declares the listener before the `Impl` in all 19 tests so it outlives the thread `~Impl` joins. This is a test-scaffolding defect, not a library one; `ArtworkRole::Impl` itself already stops and joins in its destructor.
